### PR TITLE
remove non-working anchors and add div IDs to fix the scroll issue 

### DIFF
--- a/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -36,9 +36,7 @@ Each OS has different prerequisites that need to be fulfilled before installing 
 * [Linux](#linux)
 * [Windows](#windows)
 
-<a href='#mac' aria-hidden='true' class='block-anchor'  id='#mac'><i aria-hidden='true' class='linkify icon'></i></a>
-
-### Mac OS
+###  <div id="mac">Mac OS</div>
 
 These instructions have been tested on Mac OS X Yosemite. Dependencies for other platforms will be added upon further testing.
 
@@ -57,9 +55,8 @@ Next, explicitly install a supported Node.js version:
 ```
 nvm install 8.1.0
 ```
-<a href='#linux' aria-hidden='true' class='block-anchor'  id='#linux'><i aria-hidden='true' class='linkify icon'></i></a>
 
-### Linux
+### <div id="linux">Linux</div>
 
 These instructions have been tested on Linux/Ubuntu v.14.04.4.
 
@@ -109,9 +106,7 @@ nodejs --version
 	* g++
 	* [libsass](https://sass-lang.com/libsass)
 
-<a href='#windows' aria-hidden='true' class='block-anchor'  id='#windows'><i aria-hidden='true' class='linkify icon'></i></a>
-
-### Windows
+### <div id="windows">Windows<div>
 
 The following instructions have been tested on Windows 10. Dependencies for other platforms will be added upon further testing.
 


### PR DESCRIPTION
# [DEVDOCS-1066](https://jira.bigcommerce.com/browse/DEVDOCS-1066)

## What changed?
The in context anchors (not OTP anchors) were not working on installing stencil for the following anchors: mac, windows, and linux. 

i changed them to match the structure of the in context anchors that exist in the localization article, which is using div ids instead of <a> tags.

