### PR TITLE
added callout that explains webhook retries are based on the subscrib…

### DIFF
--- a/markdown/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/markdown/api-docs/getting-started/webhooks/about-webhooks.md
@@ -377,6 +377,19 @@ Webhooks created during that 60-second block will be queued up to send on the ne
 
 The webhook dispatcher will then attempt several retries (at increasing intervals) until the maximum retry limit is reached.
 
+<div class="HubBlock--callout">
+<div class="CalloutBlock--warning">
+<div class="HubBlock-content">
+    
+<!-- theme: warning -->
+
+### Retries Based on Subscriber Domain, Not by Specific Hooks
+> The webhook dispatcher determines whether retries are needed based on responses from the subscribed domain as a whole,not by specific hooks. For example, `domain.com/webhook-1` and `domain.com/webhook-2` will affect each other for failures and retries.
+
+</div>
+</div>
+</div>
+
 ### Retry Intervals
 
 * 60 seconds after the most recent failure  


### PR DESCRIPTION
…ing domain's response

# [DEVDOCS-1088](https://jira.bigcommerce.com/browse/DEVDOCS-1088)

## What changed?
added callout that explains webhook retries are based on the subscribing domains responses and not by individual hook
