### PR TITLE
DEVDOCS-1059 Refunds API

### DIFF
--- a/beta-documentation/refunds-api-PROJECT-2776/refunds.json
+++ b/beta-documentation/refunds-api-PROJECT-2776/refunds.json
@@ -1,0 +1,3 @@
+{
+    "description": "This is a placeholder for the swagger file. Feel free to rename and replace this with the api"
+}

--- a/beta-documentation/refunds-api-PROJECT-2776/refunds.yaml
+++ b/beta-documentation/refunds-api-PROJECT-2776/refunds.yaml
@@ -1,1 +1,0 @@
-This is a placeholder for the swagger file. Feel free to rename and replace this with the api

--- a/beta-documentation/refunds-api-PROJECT-2776/refunds.yaml
+++ b/beta-documentation/refunds-api-PROJECT-2776/refunds.yaml
@@ -1,0 +1,1 @@
+This is a placeholder for the swagger file. Feel free to rename and replace this with the api

--- a/beta-documentation/refunds-api-PROJECT-2776/refunds_documentation.md
+++ b/beta-documentation/refunds-api-PROJECT-2776/refunds_documentation.md
@@ -1,0 +1,1 @@
+# This is the placeholder for the article if needed.


### PR DESCRIPTION
# [DEVDOCS-1059](https://jira.bigcommerce.com/browse/DEVDOCS-1059)

## What changed?
- added a beta folder. Thought it might be easier to keep any beta projects in one place instead of trying to hunt for them in the production documentation. Also makes sure we know this is a beta doc.
- added placeholder for swagger and markdown file

