### PR TITLE
DEVDOCS-963

### DIFF
--- a/markdown/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/markdown/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -126,7 +126,7 @@ In this case, this Handlebars statement:
 
 ```html
 {{pluck (limit categories 2) 'name'}}
-<!-- Returns: "Bakeware,Cookware" -->
+<!-- Returns: ["Bakeware","Cookware"] -->
 ```
 
 #### {{pluck}} Example 2


### PR DESCRIPTION
# [DEVDOCS-963](https://jira.bigcommerce.com/browse/DEVDOCS-963)

## What changed?
Fixed pluck example to reflect it returns an array. Had a discussion with @bookernath and confirmed this is correct
