### PR TITLE
Login object is not global, and came_from_checkout is not available a…

### DIFF
--- a/markdown/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/markdown/api-docs/getting-started/webhooks/about-webhooks.md
@@ -384,7 +384,7 @@ The webhook dispatcher will then attempt several retries (at increasing interval
 <!-- theme: warning -->
 
 ### Retries Based on Subscriber Domain, Not by Specific Hooks
-> The webhook dispatcher determines whether retries are needed based on responses from the subscribed domain as a whole,not by specific hooks. For example, `domain.com/webhook-1` and `domain.com/webhook-2` will affect each other for failures and retries.
+> The webhook dispatcher determines whether retries are needed based on responses from the subscribed domain as a whole, not by specific hooks. For example, `domain.com/webhook-1` and `domain.com/webhook-2` will affect each other for failures and retries.
 
 </div>
 </div>

--- a/markdown/stencil-docs/reference-docs/global-objects-and-properties.md
+++ b/markdown/stencil-docs/reference-docs/global-objects-and-properties.md
@@ -521,33 +521,6 @@ No properties available for this object.
 
 ---
 
-<a href='#global-objects_login' aria-hidden='true' class='block-anchor'  id='global-objects_login'><i aria-hidden='true' class='linkify icon'></i></a>
-
-## Login
-
-<b>Description: </b>Object to handle customer login details<br>
-
-<b>Handlebars Expression:</b> `{{forms.login}}`
-
-<b>Object Properties:</b>
-
-<table>
-  <tr>
-    <th>Property</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>came_from_checkout</td>
-    <td>Boolean indicating whether the customer submitted login information at checkout</td>
-  </tr>
-  <tr>
-    <td>error</td>
-    <td>BC-defined message to display when customer’s login fails</td>
-  </tr>
-</table>
-
----
-
 <a href='#global-objects_new-products' aria-hidden='true' class='block-anchor'  id='global-objects_new-products'><i aria-hidden='true' class='linkify icon'></i></a>
 
 ## New Products

--- a/markdown/stencil-docs/reference-docs/other-objects-and-properties-overview.md
+++ b/markdown/stencil-docs/reference-docs/other-objects-and-properties-overview.md
@@ -2821,7 +2821,7 @@ https://github.com/bigcommerce/cornerstone/tree/master/templates/components/comm
   </tr>
   <tr>
   <td>error</td>
-  <td>BC-defined message to display when customer’s login fails</td>
+  <td>BigCommerce defined message to display when customer’s login fails</td>
   </tr>
 </table>
 

--- a/markdown/stencil-docs/reference-docs/other-objects-and-properties-overview.md
+++ b/markdown/stencil-docs/reference-docs/other-objects-and-properties-overview.md
@@ -2819,6 +2819,10 @@ https://github.com/bigcommerce/cornerstone/tree/master/templates/components/comm
     <td>recaptcha.markup</td>
     <td>Adds reCaptcha V2</td>
   </tr>
+  <tr>
+  <td>error</td>
+  <td>BC-defined message to display when customer’s login fails</td>
+  </tr>
 </table>
 
 <div class="HubBlock--callout">


### PR DESCRIPTION
…s a property at all, so made changes to docs that relfect this and moved login.form.error to Other Objects

# [DEVDOCS-959](https://jira.bigcommerce.com/browse/DEVDOCS-959)

## What changed?
In audit of login, found that form.login is not global, and even when adding form to other template with front matter, this property cannot be pulled. Edited GLobal Objects to reflect this finding. The property came_from_checkout does not appear to be an available property at all in Stencil based on what I saw in the code. Moved form.login.error to Other Objects section
