### PR TITLE
Update BigCommerce_Orders_API.oas2.json

### DIFF
--- a/spec/json/BigCommerce_Orders_API.oas2.json
+++ b/spec/json/BigCommerce_Orders_API.oas2.json
@@ -4475,6 +4475,22 @@
           }
         }
       }
+    },
+    "Error": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "Error",
+      "description": "Returns for incorrect requests. "
     }
   },
   "tags": [


### PR DESCRIPTION
add error model back in because i accidentally removed it in a pr
Related PR: https://github.com/bigcommerce/dev-docs/pull/89

# [DEVDOCS-1065](https://jira.bigcommerce.com/browse/DEVDOCS-1065)

## What changed?
- added error model
