### PR TITLE
Devdocs 1121 fix stencil windows instructions

### DIFF
--- a/markdown/legacy/stencil-themes/installing-legacy-theme-modules.md
+++ b/markdown/legacy/stencil-themes/installing-legacy-theme-modules.md
@@ -1,0 +1,95 @@
+<h1>Installing Legacy Theme Modules</h1>
+
+<div class="otp" id="no-index">
+
+### On This Page
+
+* [Step 1: Install `jspm`](#install-jspm)
+* [Step 2: Register `jspm` Instance](#register-jspm-instance)
+* [Step 3: Install `jspm-git`](#install-jspm-git)
+* [Step 4: Add BitBucket as a `jspm Registry`](#add-bitbucket-as-a-jspm-registry)
+* [Step 5: Install the Modules](#install-the-modules) 
+
+</div>
+
+If a theme’s version number is lower than `1.10.0`, the theme uses `jspm` as its JavaScript build system. Follow the steps outlined on this article to install theme modules via `jspm`.
+
+--- 
+
+<a href='#install-jspm' aria-hidden='true' class='block-anchor'  id='install-jspm'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 1: Install `jspm`
+
+```shell
+npm install -g jspm@0.16.30
+```
+
+Or, for Windows:
+
+```shell
+npm install -g jspm@0.16.31
+```
+
+---
+
+<a href='#register-jspm-instance' aria-hidden='true' class='block-anchor'  id='register-jspm-instance'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 2: Register `jspm` Instance
+
+Next, register your jspm instance with GitHub. To do so:
+* Navigate to your [GitHub Personal Access Tokens page](https://github.com/settings/tokens).
+* Generate a new personal access token with the name `Stencil` and scope `repo` (GitHub provides specific instructions).
+* Verify the token includes the following scopes: `repo:status`, `repo_deployment`, and `public_repo`.
+* Run the following command in a terminal to associate the `jspm` module and GitHub account: `jspm registry config github`
+* When prompted with `Set up GitHub credentials?`, copy and paste the access token created above.
+
+---
+
+<a href='#install-jspm-git' aria-hidden='true' class='block-anchor'  id='install-jspm-git'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 3: Install `jspm-git`
+
+For the next step, you will need the [jspm-git registry plug-in](https://www.npmjs.com/package/jspm-git).
+
+To install it, enter the following in a terminal: 
+
+```shell
+# Install jspm-git registry plug-in
+npm install -g jspm-git
+```
+
+If you already have an earlier version of `jspm-git` installed, you might need to update it to handle git projects with two-digit version numbers: 
+
+```shell
+npm upgrade jspm-git@latest
+```
+
+---
+
+<a href='#add-bitbucket-as-a-jspm-registry' aria-hidden='true' class='block-anchor'  id='add-bitbucket-as-a-jspm-registry'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 4: Add BitBucket as a `jspm` Registry
+
+Working with downloaded Marketplace themes requires adding a BitBucket registry for `jspm`. To do so, you'll need a [BitBucket account](https://bitbucket.org/product). Once you have an account, enter the following in a terminal to add BitBucket as a `jspm` registry:
+
+```shell
+jspm registry create bitbucket jspm-git
+
+# When prompted for a base URL, Enter: ssh://git@bitbucket.org
+```
+
+---
+
+<a href='#install-the-modules' aria-hidden='true' class='block-anchor'  id='install-the-modules'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 5: Install the Modules
+
+Finally, install the `npm` and `jspm` modules required to access Stencil JavaScript events:
+
+```shell
+# move into the theme's directory
+cd ~/path/to/theme
+
+# install the modules with jspm
+jspm install
+```

--- a/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -5,15 +5,13 @@
     <li><a href="#authorizing_prerequisites">Installing on Mac</a></li>
     <li><a href="#authorizing_prerequisites2">Installing on Windows</a></li>
     <li><a href="#authorizing_prerequisites3">Installing on Linux</a></li>
-    <li><a href="#authorizing_download">Downloading Cornerstone</a></li>
-    <li><a href="#authorizing_download2">Downloading Marketplace Themes</a></li>
-    <li><a href="#authorizing_initialize">Live Previewing a Theme</a></li>
+    <li><a href="#live-previewing-a-theme">Live Previewing a Theme</a></li>
 	</ul>
 </div>
 
-Stencil CLI allows developers to locally edit themes with no impact to a merchant’s live storefront. Additionally, developers have access to a real-time Browsersync preview and testing across desktop, mobile, and tablet devices. Once work is complete, a theme can be pushed to the storefront and set live using Stencil CLI's simple commands. 
+Stencil CLI gives developers the power to locally edit and preview themes with no impact to a merchant’s live storefront, and its built-in [Browsersync](https://github.com/bigcommerce/browser-sync) capabilities make simultaneous testing across desktop, mobile, and tablet devices a breeze. Once work is complete, developers can push themes to BigCommerce storefronts (and set them live) using Stencil CLI's simple, yet powerful commands. 
 
-This article contains detailed instructions on installing, configuring, and using Stencil CLI for theme development.
+This article contains the detailed instructions needed to install and configure Stencil CLI -- the first step to developing themes on the BigCommerce platform.
 
 ---
 
@@ -21,49 +19,42 @@ This article contains detailed instructions on installing, configuring, and usin
 
 ## Installing on Mac
 
-**Required Dependencies**:
-1. [Xcode](https://developer.apple.com/xcode/)
-2. [Node.js 8.16](https://nodejs.org/en/download/releases/)
-3. [nvm 0.31.0](https://github.com/creationix/nvm/tree/v0.31.0)
-
-To install Stencil CLI and it's dependencies, run the following commands: 
+To install Stencil CLI and it's dependencies on Mac, open a terminal and run the following commands: 
 
 ```shell
+# Install Node Version Manager (nvm)
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
 
+# Switch to a Stencil CLI supported version of Node.js
 nvm install 8.16
 
+# Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli
 ```
 
-These instructions have been tested on Mac OS X Yosemite.
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+
+<!-- theme: info -->
+
+> These instructions have been tested on **Mac OS X Yosemite**.
+
+</div>
+</div>
+</div>
 
 ---
 
 <a href='#authorizing_prerequisites2' aria-hidden='true' class='block-anchor'  id='authorizing_prerequisites2'><i aria-hidden='true' class='linkify icon'></i></a>
 
 ## Installing on Windows
+There's two methods for installing Stencil CLI and its dependencies on Windows.
 
-**Required Dependencies:**
-* [git](https://git-scm.com/downloads)
-* [python2.7.x](https://www.python.org/downloads/) - required to build some dependencies
-* [node.js 8.16](https://nodejs.org/en/download/releases/) - later versions not currently supported on Windows
-* [Visual C++ Build Tools](https://www.npmjs.com/package/windows-build-tools) - required to compile some dependencies
-
-**Optional Tools:**
-* [chocolatey](https://chocolatey.org/docs/installation) - package manager for Windows
-* [nvm-windows](https://github.com/coreybutler/nvm-windows) - node.js version manager for windows
-
-**There's two methods for installing stencil's dependencies on Windows:**
-1. Install required dependencies manually (or using your preferred method).
-2. Use chocolatey to install dependencies.
-
-If you're experienced at installing and configuring `python` and `node.js` environments on Windows, feel free to install the required dependencies using your preferred method. If you're unsure, chocolatey is the easier option:
-
+### Method 1: Install Dependencies Using Chocolatey
+If you're not comfortable manually installing and configuring Python and Node.js on windows, or if you prefer an easy installation option, use the [Chocolatey package manager](https://chocolatey.org/) to install Stencil CLI's dependencies. To do so, [open PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/starting-windows-powershell?view=powershell-6) as an administrator, and run the following commands:
 ```shell
-# Open PowerShell as administrator, then run the following commands: 
-
-# Install chocolatey
+ # Install Chocolatey
 iex ((New-Object System.Net.WebClient).DownloadString("https://chocolatey.org/install.ps1"))
 
 # Install git if you don't have it
@@ -93,7 +84,37 @@ npm install -g @bigcommerce/stencil-cli
 <!-- theme: warning -->
 
 ### Execution Policy Errors
-> If you receive an execution policy error while attempting to install chocolatey, refer to [Microsoft's Documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-6) or consult with your organization's system administrator to determine the appropriate course of action.
+> If you receive an execution policy error while attempting to install chocolatey, refer to [Microsoft's Documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-6) and/or consult with your organization's system administrator to determine the appropriate course of action.
+> 
+### Chocolatey Installation Alternatives
+> For additional information on installing Chocolatey and alternative installation options, see [the installation page on chocolatey.org](https://chocolatey.org/install).
+
+</div>
+</div>
+</div>
+
+### Method 2: Install Dependencies Manually
+If you're a pro at installing and configuring Python and Node.js environments on Windows, feel free to install the required dependencies using your preferred method.
+
+**Required Dependencies:**
+* [Git](https://git-scm.com/downloads) - required to run npm install
+* [Python 2.7.x](https://www.python.org/downloads/) - required to build some dependencies
+* [Node.js 8.16 and npm](https://nodejs.org/en/download/releases/) - later versions not currently supported on Windows
+* [Visual C++ Build Tools 2015](https://www.npmjs.com/package/windows-build-tools) - required to compile some dependencies
+
+Once they're installed and configured, use `npm` to install Stencil CLI:
+
+```shell
+npm install -g @bigcommerce/stencil-cli
+```
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+
+<!-- theme: info -->
+
+> These instructions have been tested successfully on **Windows 10**. 
 
 </div>
 </div>
@@ -105,58 +126,33 @@ npm install -g @bigcommerce/stencil-cli
 
 ## Installing on Linux
 
-**Required Dependencies**
-1. [Node.js 8.16](https://nodejs.org/en/download/releases/)
-2. [nvm](https://github.com/nvm-sh/nvm)
+To install Stencil CLI and dependencies on debian-based distros, open a terminal and run the following commands:
 
-**Depending on the distro, you may also need to install:**
-* g++
-* [libsass](https://sass-lang.com/libsass)
-
-To install Stencil CLI and it’s dependencies, open a terminal, and enter:
 ```shell
-## update package list
-sudo apt-get update
+## Update package list, then install node and npm
+sudo apt-get update && sudo apt-get install nodejs npm
 
-## install node and npm
-sudo apt-get install nodejs npm
-
-# download nvm install.sh and run with bash
+# Download nvm install.sh and run with bash
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
 
-# explicitly install supported node version
+# Explicitly install supported node version
 nvm install 8.16
 
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli
 ```
 
-These instructions have been tested on Linux/Ubuntu v.14.04.4.
-
----
-
-<a href='#authorizing_download' aria-hidden='true' class='block-anchor'  id='authorizing_download'><i aria-hidden='true' class='linkify icon'></i></a>
-
-## Downloading Cornerstone
-
-To begin using Stencil CLI for theme development, you'll first need to obtain a theme. To develop against BigCommerce's Cornerstone theme, clone [the repository](https://github.com/bigcommerce/cornerstone) from GitHub:
-
-```shell
-git clone https://github.com/bigcommerce/cornerstone.git
-```
-
-Cornerstone and other themes can also be downloaded from the BigCommerce Control Panel. For instructions on doing so, see [Downloading and Uploading Custom Themes](https://support.bigcommerce.com/s/article/Stencil-Themes#download-upload) (BigCommerce Knowledge Base).
+**Depending on the distro, you may also need to install:**
+* g++
+* [libsass](https://sass-lang.com/libsass)
 
 <div class="HubBlock--callout">
-<div class="CalloutBlock--error">
+<div class="CalloutBlock--info">
 <div class="HubBlock-content">
 
-#### Distribution of Cornerstone-based Themes
-> Distribution of Cornerstone-based themes is subject to BigCommerce's Cornerstone license, including the mandatory incorporation of BigCommerce's copyright statement.
+<!-- theme: info -->
 
-#### Back Up before Reinstalling
-> If you are reinstalling over a base theme on which you have already begun development, first back up your theme’s .stencil file. This contains your store URL, BigCommerce username and access tokens, and other basic settings. Preserving those settings will speed up initializing and launching the new version. If you would like to allow for complete rollback, back up your entire theme’s directory.
-
+> These instructions have been tested on **Ubuntu v.14.04.4**. 
 
 </div>
 </div>
@@ -164,123 +160,29 @@ Cornerstone and other themes can also be downloaded from the BigCommerce Control
 
 ---
 
-<a href='#authorizing_download2' aria-hidden='true' class='block-anchor'  id='authorizing_download2'><i aria-hidden='true' class='linkify icon'></i></a>
-
-## Downloading Marketplace Themes
-
-It is also possible to download and develop against themes in the BigCommerce Themes Marketplace. To download a marketplace theme:
-1. Navigate to **Storefront** > **Themes Marketplace**, and add the desired theme.
-2. Once added, navigate to **Storefront** > **My Themes** > **Theme Thumbnail** > **Theme Options**.
-3. Select the appropriate Download option.
-
-![#### Theme Options](//s3.amazonaws.com/user-content.stoplight.io/6116/1562092313957 "#### Theme Options")
-
-**Download Options**:
-* **Download current theme:** Download the theme version active on the storefront (appears only if you selected the current theme).
-* **Download your latest customizations:** Download the theme's most recently saved version (appears only for themes customized for this store).
-* **Download theme file:** Download the theme as it was originally uploaded to Theme Marketplace.
-
-<div class="HubBlock--callout">
-<div class="CalloutBlock--warning">
-<div class="HubBlock-content">
-
-<!-- theme: warning -->
-
-### Theme Access, Copyright/Ownership, and Distribution
-> Marketplace themes other than Cornerstone must be purchased in order to be downloadable. You are entitled to customize a free or purchased theme for a store you support; however, the original creator retains rights to that theme's design. So, except for Cornerstone-based themes, you may not upload a derived theme to a public theme marketplace (whether BigCommerce's or third-party), nor sell it privately.
-
-</div>
-</div>
-</div>
-
-<div class="HubBlock--callout">
-<div class="CalloutBlock--warning">
-<div class="HubBlock-content">
-
-<!-- theme: warning -->
-
-### Setting Up BitBucket SSH Keys (Pixel Union Themes)
-> To set up Stencil CLI for Pixel Union Themes, you must first authorize communication among your local system, the BitBucket registry, and GitHub. Therefore, steps beyond this point require that you have active accounts on both BitBucket and GitHub.
-
-To authorize ongoing communication, you must first set up a secure shell (SSH) key that is shared between BitBucket and GitHub.
-
-Setting up an SSH key is a multi-step process. We have included resources below to help achieve this step.
-
-* [Setting up SSH for Git on BitBucket](https://confluence.atlassian.com/bitbucket/set-up-ssh-for-git-728138079.html) (Confluence)
-* [Connecting to Github with SSH](https://help.github.com/articles/connecting-to-github-with-ssh/) (Github)
-
-</div>
-</div>
-</div>
-
----
-
-<a href='#authorizing_initialize' aria-hidden='true' class='block-anchor'  id='authorizing_initialize'><i aria-hidden='true' class='linkify icon'></i></a>
+<a href='#live-previewing-a-theme' aria-hidden='true' class='block-anchor'  id='live-previewing-a-theme'><i aria-hidden='true' class='linkify icon'></i></a>
 
 ## Live Previewing a Theme
 
-Stencil CLI's Browsersync makes it possible to serve up a live preview of a theme in development. This is done by using the `stencil start` command. When `stencil start` is executed, Stencil CLI checks for the required `.stencil` configuration file, which contains:
-* the store's URL
-* an API access token
-* a local port number
-
-This configuration file is created by running `stencil init`. Before doing so, be sure to obtain an API access token; for instructions on doing so, see: [Obtaining Store API Credentials](/api-docs/getting-started/authentication#authentication_getting-api-credentials). Once you have an API access token, `cd` into the theme's directory and run `stencil init`:
+Once Stencil CLI is installed, the next step on the road to theme development is downloading a theme to edit and previewing live changes using Stencil CLI's powerful Browsersync functionality. For detailed instructions on doing so, see: [Live Previewing a Theme](https://developer.bigcommerce.com/stencil-docs/live-previewing-a-theme). Here's the gist:
 
 ```shell
 # move into theme dir
-cd ~/path/to/them/dir
+cd ~/path/to/theme/dir
 
-# start .stencil initialization prompt
+# initialize a new .stencil config for the theme
 stencil init
 
-# prompt:
-? What is the URL of your store\'s home page? # Your BigCommerce Storefront URL. Ex: https://yourstore.com/
-? What port would you like to run the server on? (3000) # Enter a port number or press enter to use default
-? What is your Stencil OAuth Access Token? # Enter your OAuth Access Token
+# install theme modules
+npm install
 
-# a .stencil file will be generated
-
-# to serve the theme, run:
+# serve a live, Browsersync enabled preview of the theme
 stencil start
 ```
-
-After entering `stencil start`, Stencil CLI will output several URLs to the console:
-
-```shell
-# ...
-[Browsersync] Proxying: http://localhost:3001
-[Browsersync] Access URLs:
- -----------------------------------
-       Local: http://localhost:3000  # preview real-time changes on your local machine
-    External: http://10.4.10.71:3000 # preview real-time changes across multiple devices
- -----------------------------------
-          UI: http://localhost:3002
- UI External: http://10.4.10.71:3002
- -----------------------------------
-[Browsersync] Watching files...
-```
-
-Browse to the local URL to preview the theme and see changes updated in real-time. To preview the theme on multiple devices simultaneously, browse to the external URL on the desired devices.
-
-For a full list of Stencil CLI commands, see [Stencil CLI Options and Commands](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands). For help troubleshooting errors or installation issues, see: [Troubleshooting Your Setup](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/troubleshooting-your-setup).
-
-<div class="HubBlock--callout">
-<div class="CalloutBlock--warning">
-<div class="HubBlock-content">
-
-<!-- theme: warning -->
-
-### BitBucket Reauthentication
-> If you receive error messages about resolving BitBucket as an SSH host when running `stencil init`, enter the BitBucket password used to setup the BitBucket SSH Keys when prompted.
-
-</div>
-</div>
-</div>
 
 ---
 
 ## Resources
 
 ### Additional Resources
-
 * [Demonstration of Stencil Installation and Launch](https://www.youtube.com/watch/iWBrJalyM0A) (Youtube)

--- a/markdown/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/markdown/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -1,0 +1,194 @@
+<h1>Live Previewing a Theme</h1>
+
+<div class="otp" id="no-index">
+
+### On This Page
+
+* [Step 1: Download a Theme](#step-1-download-a-theme)
+* [Step 2: Install Theme Modules](#step-2-install-theme-modules)
+* [Step 3: Serve Live Preview](#step-3-serve-live-preview)
+</div>
+
+Once Stencil CLI is installed, the next step on the road to theme development is downloading a theme to edit and previewing live changes using Stencil CLI's powerful Browsersync functionality. This article will walk you through the process of downloading a theme for development, installing theme modules, then serving a live preview using Stencil CLI's `stencil start` command. The steps in this article assume Stencil CLI has been installed on your system; if its not installed yet, see [Installing Stencil CLI](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/installing-stencil) for detailed, operating system specific instructions.
+
+---
+
+<a href='#step-1-download-a-theme' aria-hidden='true' class='block-anchor'  id='step-1-download-a-theme'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 1: Download a Theme
+
+To develop against BigCommerce's Cornerstone theme (which is the building block and starting point for rapidly developing themes for BigCommerce) clone [the repository](https://github.com/bigcommerce/cornerstone) from GitHub:
+
+```shell
+git clone https://github.com/bigcommerce/cornerstone.git
+```
+
+Cornerstone and other themes can also be downloaded from the BigCommerce control panel. For instructions on doing so, see [Downloading and Uploading Custom Themes](https://support.bigcommerce.com/s/article/Stencil-Themes#download-upload) (BigCommerce Knowledge Base).
+
+
+It is also possible to download and develop against themes in the BigCommerce Themes Marketplace. To do so:
+1. Navigate to **Storefront** > **Themes Marketplace**, and add the desired theme.
+2. Once added, navigate to **Storefront** > **My Themes** > **Theme Thumbnail** > **Theme Options**.
+3. Select the appropriate Download option.
+
+![#### Theme Options](//s3.amazonaws.com/user-content.stoplight.io/6116/1562092313957 "#### Theme Options")
+
+**Download Options**:
+* **Download current theme** - download the theme active on the storefront (appears when current theme is selected).
+* **Download your latest customizations** - download the theme's most recently saved version (appears only for themes customized for this store).
+* **Download theme file** - download the theme as it was originally uploaded to Theme Marketplace.
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--warning">
+<div class="HubBlock-content">
+
+<!-- theme: warning -->
+
+### Theme Access, Copyright, and Distribution
+> Developers may customize free and purchased marketplace themes; however, the original creator retains rights to the theme's design, which means derived themes may not be uploaded to a public theme marketplace (BigCommerce's or third-party) or sold privately.
+
+</div>
+</div>
+</div>
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--warning">
+<div class="HubBlock-content">
+
+<!-- theme: warning -->
+
+### Setting Up BitBucket SSH Keys (Pixel Union Themes)
+> To set up Stencil CLI for Pixel Union Theme development, you'll first need authorize communication between your local machine, the BitBucket registry, and GitHub.
+
+For instructions on doing so, see the following resources: 
+* [Setting up SSH for Git on BitBucket](https://confluence.atlassian.com/bitbucket/set-up-ssh-for-git-728138079.html) (Confluence)
+* [Connecting to Github with SSH](https://help.github.com/articles/connecting-to-github-with-ssh/) (Github)
+
+</div>
+</div>
+</div>
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--error">
+<div class="HubBlock-content">
+
+### Distribution of Cornerstone-Based Themes
+> Distribution of Cornerstone-based themes is subject to BigCommerce's Cornerstone license, including the mandatory incorporation of BigCommerce's copyright statement.
+
+### Back Up before Reinstalling
+> If you're re-installing an existing theme, be sure to back up the theme’s `.stencil` file -- this contains the store URL, username, access tokens, and other settings. If you would like to allow for complete rollback, back up your entire theme’s directory.
+
+</div>
+</div>
+</div>
+
+---
+
+<a href='#step-2-install-theme-modules' aria-hidden='true' class='block-anchor'  id='step-2-install-theme-modules'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 2: Install Theme Modules
+ 
+For theme versions `1.10.0+`, modules can be installed with `npm`:
+
+```shell
+# move into the theme dir
+cd ~/path/to/theme/dir
+
+# install modules using npm
+npm install
+```
+
+This will install the `npm` modules required to properly leverage the Stencil event framework.
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+
+<!-- theme: info -->
+
+### Themes Prior to 1.10.0
+> For instructions on installing modules via `jspm` on pre 1.10.0 themes, see: [Installing Legacy Theme Modules](https://developer.bigcommerce.com/legacy/stencil-themes/installing-legacy-theme-modules).
+
+</div>
+</div>
+</div>
+
+---
+
+<a href='#step-3-serve-live-preview' aria-hidden='true' class='block-anchor'  id='step-3-serve-live-preview'><i aria-hidden='true' class='linkify icon'></i></a>
+
+## Step 3: Serve Live Preview
+
+Once Stencil CLI is installed and a theme is downloaded, a `.stencil` configuration file can be initialized for the theme and development can begin. 
+
+Stencil CLI uses [Browsersync](https://github.com/bigcommerce/browser-sync) to serve up a live preview of a theme in development. When the preview is opened on multiple devices or browser windows, scroll, click, refresh and form actions are mirrored across the browser instances.
+
+The Browsersync preview is launched by executing the `stencil start` command in a terminal window. When `stencil start` is executed, Stencil CLI checks for the required `.stencil` configuration file, which contains the following information:
+* the store's URL
+* an API access token
+* a local port number
+
+This configuration file is created by running `stencil init`, which begins a prompt requesting the information listed above (before doing so, be sure to obtain an API access token; for instructions on doing so, see: [Obtaining Store API Credentials](/api-docs/getting-started/authentication#authentication_getting-api-credentials)). 
+
+To initialize a new stencil configuration for a theme,`cd` into the theme's directory and run `stencil init`:
+
+```shell
+# move into theme dir
+cd ~/path/to/theme/dir
+
+# install theme modules (if you haven't already)
+npm install
+
+# start .stencil initialization prompt
+stencil init
+
+# prompt:
+? What is the URL of your store\'s home page? # Your BigCommerce Storefront URL. Ex: https://yourstore.com/
+? What port would you like to run the server on? (3000) # Enter a port number or press enter to use default
+? What is your Stencil OAuth Access Token? # Enter your OAuth Access Token
+
+# a .stencil file will be generated
+
+# to serve the theme, run:
+stencil start
+```
+
+`stencil start` will output several URLs:
+
+```shell
+# ...
+[Browsersync] Proxying: http://localhost:3001
+[Browsersync] Access URLs:
+ -----------------------------------
+       Local: http://localhost:3000  # preview real-time changes on your local machine
+    External: http://10.4.10.71:3000 # preview real-time changes across multiple devices
+ -----------------------------------
+          UI: http://localhost:3002
+ UI External: http://10.4.10.71:3002
+ -----------------------------------
+[Browsersync] Watching files...
+```
+
+Browse to the local URL to preview the theme and see changes updated in real-time. To preview the theme on multiple devices simultaneously, browse to the external URL on the desired devices. As you navigate through the site, Stencil CLI will use store API token supplied to make API calls to BigCommerce's API and populate the theme preview with live store data in order to mimic production as closely as possible. 
+
+For a full list of Stencil CLI commands, see [Stencil CLI Options and Commands](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands). For help troubleshooting errors or installation issues, see: [Troubleshooting Your Setup](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/troubleshooting-your-setup).
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--warning">
+<div class="HubBlock-content">
+
+<!-- theme: warning -->
+
+### BitBucket Re-Authentication
+> If you receive error messages about resolving BitBucket as an SSH host when running `stencil init`, enter the BitBucket password used to setup the BitBucket SSH Keys when prompted.
+
+</div>
+</div>
+</div>
+
+---
+
+## Resources
+
+### Additional Resources
+* [Demonstration of Stencil Installation and Launch](https://www.youtube.com/watch/iWBrJalyM0A) (Youtube)


### PR DESCRIPTION
# [DEVDOCS-1121](https://jira.bigcommerce.com/browse/DEVDOCS-1121)

## What changed?
* Created new windows install instructions that use the Chocolatey package manager for windows
* Rewrote the article and simplified instructions

Also split out sections not having to do with strictly installing the CLI into separate articles: 
* **Live Previewing a Theme** - These are the instructions on how to live preview a theme using Stencil CLI. It assumes the CLI has already been installed.
* **Installing Legacy Theme Modules** - This is going in the legacy dir because it deals with installing modules via jspm for really old themes. Having it in with the Stencil CLI install instructions or live previewing a theme article just clutters those articles with instructions that don't apply to most users. 

The result is that the "Installing Stencil CLI" article is very concise and gives only the specific instructions needed to install the CLI. The goal here is to increase the clarity of the install instructions and hopefully reduce the occurrence of issues users face along the way. 