### PR TITLE
Fix Broken Link to Previewing Themes

### DIFF
--- a/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -164,7 +164,7 @@ npm install -g @bigcommerce/stencil-cli
 
 ## Live Previewing a Theme
 
-Once Stencil CLI is installed, the next step on the road to theme development is downloading a theme to edit and previewing live changes using Stencil CLI's powerful Browsersync functionality. For detailed instructions on doing so, see: [Live Previewing a Theme](https://developer.bigcommerce.com/stencil-docs/live-previewing-a-theme). Here's the gist:
+Once Stencil CLI is installed, the next step on the road to theme development is downloading a theme to edit and previewing live changes using Stencil CLI's powerful Browsersync functionality. For detailed instructions on doing so, see: [Live Previewing a Theme](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/live-previewing-a-theme). Here's the gist:
 
 ```shell
 # move into theme dir


### PR DESCRIPTION
## What changed?

Fixed a broken link to https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/live-previewing-a-theme

