### PR TITLE
Add nvm use command to mac instructions

### DIFF
--- a/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/markdown/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -28,7 +28,7 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | b
 # Install Stencil CLI supported version of Node.js
 nvm install 8.16
 
-# Switch to Stencil CLI support version of Node.js:
+# Switch to Stencil CLI supported version of Node.js:
 nvm use 8.16
 
 # Install Stencil CLI


### PR DESCRIPTION
This is required; installing doesn't automatically switch the version being used.
