### PR TITLE
Fix Categories Object and Add Example

### DIFF
--- a/markdown/stencil-docs/reference-docs/global-objects-and-properties.md
+++ b/markdown/stencil-docs/reference-docs/global-objects-and-properties.md
@@ -263,13 +263,25 @@ example: `{{{banner}}}`. (Double braces would escape the HTML.)
 
  ## Categories
 
- <b>Description:</b> A list of all product categories shown in the current page context; default sorting is by category id, from lowest to highest
+ <b>Description:</b> A array of category objects filled with all categories shown in the current page context; default sorting is by category ID, from lowest to highest
 
 <b>Handlebars Expression:</b> `{{categories}}`
 
-<b>Object Properties:</b>
+**Usage Example:**
 
-<b>Object Properties:</b>
+```html
+<!-- renders a UL of categories for the current page context -->
+<ul class="people_list">
+  {{#each categories}}
+    <li>{{this.name}}</li>
+  {{/each}}
+</ul>
+```
+
+**Object Properties:**
+
+The table below displays properties for the individual category objects within the array.
+
 <table>  
   <tr>   
     <th>Property</th>    


### PR DESCRIPTION
# [DEVDOCS-1167](https://jira.bigcommerce.com/browse/DEVDOCS-1167)

## What changed?
* Made it clear that the Object Properties in the Categories section are for the individual categories in the array
* Added usage example that shows how the name property can be used to render a list of category names for the given page context

