### PR TITLE
Fix Broken HTML in Embedded CO Content

### DIFF
--- a/markdown/api-docs/cart-and-checkout/embedded-checkout-overview.md
+++ b/markdown/api-docs/cart-and-checkout/embedded-checkout-overview.md
@@ -1,15 +1,19 @@
-<h1>Embedded Checkout Overview</h1>
+# Embedded Checkout Overview 
+
 <div class="otp" id="no-index">
+
 ### On This Page
 
-* [How it Works](#how-it-works)
-* [Channels, Sites and Routes](#channels-sites-routes)
-* [BigCommerce Checkout SDK](#cart-checkout_embed-checkout-sdk)
-* [Logged-In Customers](#cart-checkout_logged-in-customers)
+- [How it Works](#how-it-works)
+- [Channels, Sites and Routes APIs](#channels-sites-and-routes-apis)
+- [BigCommerce Checkout SDK](#bigcommerce-checkout-sdk)
+- [Logged-In Customers](#logged-in-customers)
 
 </div>
 
 Embedded Checkout lets you place BigCommerce’s checkout onto any website. Customers can check out on an external storefront while their order information syncs simultaneously to the BigCommerce Control Panel. You can see this in action within the BigCommerce for WordPress plugin, which uses the same process described here as a checkout option for merchants. View more information about the plugin in the article [BigCommerce for Wordpress](https://developer.bigcommerce.com/bigcommerce-for-wordpress/getting-started/introduction).
+
+---
 
 <a id="how-it-works"></a>
 
@@ -20,6 +24,8 @@ Embedded Checkout uses an HTML `<iframe>` to display a BigCommerce's PCI complia
 
 If your channel site doesn't match the URL from which you're making a request to a BigCommerce, you will get a security error and the checkout will not load. Additionally, if requests to your BigCommerce store aren't served over HTTPS, you will also see an error.
 
+---
+
 <a id="channels-sites-routes"></a>
 
 
@@ -27,11 +33,15 @@ If your channel site doesn't match the URL from which you're making a request to
 
 You will need to use the [Channels, Sites and Routes](#) APIs to embed checkout on an external site. The Channels API allows you to create and manage sales channel listings across a merchant's product catalog. A channel can be a marketplace, like Amazon, or an external storefront, like a WordPress site. The Sites and Routes APIs let you set an external storefront domain and define the paths for important pages, like the home page, cart page, or checkout page. The site and routes are used to link back to the proper URL from invoice emails and storefront links.
 
+---
+
 <a id="cart-checkout_embed-checkout-sdk"></a>
 
 ## BigCommerce Checkout SDK
 
 Embedded Checkout requires the BigCommerce Checkout SDK to invoke a method that can render the checkout in your app. Learn more about the [Checkout SDK](https://developer.bigcommerce.com/api-docs/cart-and-checkout/checkout-sdk).
+
+---
 
 <a id="#cart-checkout_logged-in-customers"></a>
 

--- a/markdown/api-docs/cart-and-checkout/embedded-checkout-tutorial.md
+++ b/markdown/api-docs/cart-and-checkout/embedded-checkout-tutorial.md
@@ -4,10 +4,13 @@
 
 ### On This Page
 
-* [Step 1: Create a Channel](#step-1-create-channel)
-* [Step 2: Create a Site](#step-2-create-site)
-* [Step 3: Create a Cart](#step-3-create-cart)
-* [Step 4: Embed Checkout](#step-4-embed-checkout)
+- [Step 1: Create a Channel](#step-1-create-a-channel)
+- [2: Create a Site](#2-create-a-site)
+- [Step 3: Create a Cart](#step-3-create-a-cart)
+- [Step 4: Embed Checkout](#step-4-embed-checkout)
+- [FAQ](#faq)
+
+</div>
 
 Embedded Checkout lets you place BigCommerce’s Optimized One-Page checkout onto an external site. This tutorial will walk you through the sequence of API calls your application should make to create a working Embedded Checkout. 
 
@@ -158,7 +161,6 @@ Next, generate a cart URL and set this cart as the active cart by posting to  to
 Use the `embedded_checkout_url` that is returned and assemble a JSON object that will be used by the Checkout JS SDK to determine how to render the checkout. Pass the object to the `embedCheckout` method of the Checkout SDK. This will render the checkout to an HTML element with the `id` you chose.
 
 Read more about the [JSON object](https://github.com/bigcommerce/checkout-sdk-js/blob/master/docs/README.md#embedcheckout) and its possible corresponding [rendering options](https://github.com/bigcommerce/checkout-sdk-js/blob/master/docs/interfaces/embeddedcheckoutoptions.md).
-
 
 
 ```html


### PR DESCRIPTION
## What changed?
* Fixed some broken HTML in the embedded checkout overview in tutorial that was causing the page to be scrunched to the right. 

