### PR TITLE
DEVDOCS 1102 add information about Wishlists API scope

### DIFF
--- a/markdown/api-docs/getting-started/authentication.md
+++ b/markdown/api-docs/getting-started/authentication.md
@@ -279,6 +279,7 @@ Scope limits ability to read or write to data. Set the scope to the minimum leve
 All OAuth scopes except `default` have `read_only` scopes that allow only `GET` and `HEAD` requests.
 
 - Webhooks are accessible from the default scope that is available when API Credentials are created.
+- Wishlists API is accessible with Customers scope.
 
 | Scope GUI Name | Resources  | Description |
 |---|---|---|

--- a/spec/json/BigCommerce_Wishlist_API.oas2.json
+++ b/spec/json/BigCommerce_Wishlist_API.oas2.json
@@ -4,7 +4,7 @@
     "version": "",
     "title": "Wishlist API",
     "contact": {},
-    "description": "## Wishlist API\n  \nThe Wishlist API allows a developer to create and manage customer [Wishlists](https://support.bigcommerce.com/s/article/Wishlists). A Wishlist allows you to see what your customers are interested in and saving on the store. With this information you’ll be able to create targeted campaigns to help merchants grow their business.  "
+    "description": "## Wishlist API\n  \nThe Wishlist API allows a developer to create and manage customer [Wishlists](https://support.bigcommerce.com/s/article/Wishlists). A Wishlist allows you to see what your customers are interested in and saving on the store. With this information you’ll be able to create targeted campaigns to help merchants grow their business.\n  Customer API OAuth scopes give you access to Wishlists API. See[OAuth Scopes](https://developer.bigcommerce.com/api-docs/getting-started/authentication#authentication_oauth-scopes) "
   },
   "host": "api.bigcommerce.com",
   "basePath": "/stores/{store_hash}/v3",


### PR DESCRIPTION
# [DEVDOCS-1102](https://jira.bigcommerce.com/browse/DEVDOCS-1102)

## What changed?

Add Oauth scope needed to access Wishlists API in spec and in APi docs under authentication