### PR TITLE
DEVDOCS-1214 Update URL param of payment methods GET request

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -137,7 +137,7 @@ lineNumbers: true
 -->
 
 **Example Response Get Payment Methods**  
-`/GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?{{order_id}}`
+`/GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?order_id={{order_id}}`
 
 ```json
 {


### PR DESCRIPTION
# [DEVDOCS-1214](https://jira.bigcommerce.com/browse/DEVDOCS-1214)

## What changed?
Added `order_id=` to example payment methods URL
