### PR TITLE
DEVDOCS-1239 adds graph ql to store info API plus other missing schema

### DIFF
--- a/reference/json/BigCommerce_Store_Information_API.oas2.json
+++ b/reference/json/BigCommerce_Store_Information_API.oas2.json
@@ -265,6 +265,14 @@
                       "type": "string",
                       "example": "optimized",
                       "description": "What type of checkout is enabled on the store. Possible values returned are optimized, single (one page), single_customizable (one page for developers), klarna."
+                    },
+                    "wishlists_enabled": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "graphql_storefront_api_enabled": {
+                      "type": "boolean",
+                      "example": true
                     }
                   }
                 }


### PR DESCRIPTION
# [DEVDOCS-1239](https://jira.bigcommerce.com/browse/DEVDOCS-1239)

Adds graphql_storefront_api_enabled and wishlists_enabled to Store Information API features object 
