### PR TITLE
Devdocs 1274 paymentsapi vaulted paypal

### DIFF
--- a/reference/json/BigCommerce_Payments_API.oas2.json
+++ b/reference/json/BigCommerce_Payments_API.oas2.json
@@ -1375,7 +1375,50 @@
           }
         }
       }
+    },
+    "StoredPaypalInstrument": {
+      "title": "StoredPaypalInstrument",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type to classify this stored account"
+        },
+        "is_default": {
+          "type": "boolean",
+          "description": "Whether this instrument is a default instrument",
+          "default": "false"
+        },
+        "token": {
+          "type": "string",
+          "description": "Identifier representing this stored account",
+          "minLength": 64,
+          "maxLength": 64
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Email address of this stored account"
+        }
+      },
+      "required": [
+        "email",
+        "token",
+        "is_default",
+        "type"
+      ]
+    },
+    "SupportedPaypalAccountInstrument": {
+    "title": "SupportedPaypalAccountInstrument",
+    "type": "object",
+    "properties": {
+      "instrument_type": {
+        "type": "string",
+        "description": "Type of this instrument",
+        "required": ["instrument_type"]
+      }
     }
+  }
   },
   "tags": [
     {

--- a/reference/json/BigCommerce_Process_Payment_API.oas2.json
+++ b/reference/json/BigCommerce_Process_Payment_API.oas2.json
@@ -652,8 +652,27 @@
         "title",
         "type"
       ]
-    }
-  },
+    },
+  "StoredPayPalAccount": {
+    "title": "Stored Paypal Account",
+    "type": "object",
+    "properties": {
+      "type": {
+        "description": "Type to classify this payment instrument"
+      },
+      "token": {
+      "description": "Identifier representing this stored paypal account",
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 64
+        }
+      },
+    "required": [
+    "type",
+    "token"
+    ]
+  }
+},
   "tags": [
     {
       "name": "Payment",


### PR DESCRIPTION
# [DEVDOCS-1274](https://jira.bigcommerce.com/browse/DEVDOCS-1274)

## What changed?
Adds paypal instrument and supported instrument to Payments API GET, and POST to /payments accepts stored paypal account