### PR TITLE
DEVDOCS-1294 Removes distinction that sf tokens are non-jwt

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.html
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+        <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+        <title>GraphQL Storefront API Overview</title>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/markdown.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/highlight.css">
+        <link href="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.css" rel="stylesheet" type="text/css">
+        <style>
+.task-list-item { list-style-type: none; } .task-list-item-checkbox { margin-left: -20px; vertical-align: middle; }
+</style>
+        <style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', 'Ubuntu', 'Droid Sans', sans-serif;
+                font-size: 14px;
+                line-height: 1.6;
+            }
+        </style>
+        
+        <script src="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.js"></script>
+    </head>
+    <body>
+        <h1 id="graphql-storefront-api-overview">GraphQL Storefront API Overview</h1>
+<div class="otp" id="no-index">
+<h3 id="on-this-page">On this Page</h3>
+<ul>
+<li><a href="#see-it-in-action">See it in Action</a></li>
+<li><a href="#accessing-the-graphql-playground">Accessing the GraphQL Playground</a></li>
+<li><a href="#using-the-graphql-playground">Using the GraphQL Playground</a></li>
+<li><a href="#authentication">Authentication</a></li>
+<li><a href="#querying-within-a-bigcommerce-storefront">Querying Within a BigCommerce Storefront</a></li>
+<li><a href="#resources">Resources</a></li>
+</ul>
+</div>
+<p>BigCommerce's GraphQL Storefront API makes it possible to query storefront data from from within a <a href="https://devcenter-production.docs.stoplight.io/stencil-docs/getting-started/about-stencil">Stencil</a> theme or remote site. This means information previously only available on the back-end via <a href="https://devcenter-production.docs.stoplight.io/stencil-docs/reference-docs/global-objects-and-properties">Stencil's template logic</a> can now be accessed via front-end javascript. For example, with the Storefront API, it is possible to:</p>
+<ul>
+<li>Access product options, variations, and custom fields for any product from any page</li>
+<li>Request any product's images at any resolution</li>
+<li>Ask for customer details such as name, email address, and attributes (if logged in)</li>
+<li>Look up objects (e.g. categories or brands) by URL, and fetch their details</li>
+<li>Build front-end applications on top of a BigCommerce <a href="https://devcenter-production.docs.stoplight.io/stencil-docs/getting-started/about-stencil">Stencil</a> theme or on a remote site</li>
+</ul>
+<p>Additionally, by leveraging the power of <a href="https://graphql.org/">GraphQL</a>, data for multiple resources can be returned from a single API call, which simplifies integration and increases performance so that developers can focus on building delightful shopper experiences.</p>
+<p>This article is a general overview of the capabilities and usage of BigCommerce's GraphQL Storefront API; it includes sections on authentication and how to access a store's GraphQL Playground. To see specific examples of how GraphQL can be used to query storefront data, see <a href="https://developer-beta.bigcommerce.com/api-docs/storefront/graphql/graphql-storefront-api-samples">GraphQL Storefront API Code Samples</a>.</p>
+<div class="HubBlock--callout">
+<div class="CalloutBlock--warning">
+<div class="HubBlock-content">
+<!-- theme: warning -->
+<h3 id="note">Note</h3>
+<blockquote>
+<ul>
+<li>GraphQL Storefront API is in beta</li>
+<li>BigCommerce legacy Blueprint themes currently do not support the GraphQL API and Playground</li>
+</ul>
+</blockquote>
+</div>
+</div>
+</div>
+<p><a id="see-it-in-action" class="devdocsAnchor"></a></p>
+<h2 id="see-it-in-action">See it in Action</h2>
+<p>To see the GraphQL storefront API in action, checkout the <a href="https://bigcommerce.github.io/storefront-api-examples/html-bootstrap-vanillajs/">Bootstrap + Vanilla JS Storefront API Example</a> hosted on GitHub. This example shows how a static HTML site can be used to render dynamic product information via the GraphQL Storefront API.</p>
+<p>Simply open the link and click submit with the sample data in the form. To see the example page with your store's data, <a href="https://developer.bigcommerce.com/api-reference/storefront/storefront-token-api/api-token/createtoken">create a Storefront API Token</a> against your store and paste the token into the example form (be sure to create a token valid for this origin: <code>https://bigcommerce.github.io</code>).</p>
+<p>For a full list of examples, see the <a href="https://github.com/bigcommerce/storefront-api-examples">Storefront API Examples repo</a>.</p>
+<p><a id="accessing-the-graphql-playground" class="devdocsAnchor"></a></p>
+<h2 id="accessing-the-graphql-playground">Accessing the GraphQL Playground</h2>
+<p>To access the GraphQL Storefront API Playground<sup>1</sup> and documentation:</p>
+<ol>
+<li>Login to a BigCommerce store enrolled in the beta</li>
+<li>Navigate to <strong>Advanced Settings</strong> &gt; <strong>Storefront API Playground</strong><sup>2</sup></li>
+</ol>
+<p>The GraphQL Storefront API Playground will be opened:</p>
+<p><img src="https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/graphql-storefront-api-playground.png" alt="GraphQL Storefront API Playground" title="GraphQL Storefront API Playground"></p>
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+<!-- theme: info -->
+<h3 id="note-1">Note</h3>
+<blockquote>
+<ol>
+<li>GraphQL Playground is a GraphQL IDE built on Electron. For more information, see <a href="https://electronjs.org/apps/graphql-playground">GraphQL Playground</a> on <a href="https://electronjs.org">electrongjs.org</a></li>
+</ol>
+</blockquote>
+<blockquote>
+<ol start="2">
+<li>If the <strong>Storefront API Playground</strong> link is not visible, the store is not enrolled in the Beta program. To enroll, <a href="https://support.bigcommerce.com/SubmitCase">contact support</a> (all stores using Stencil are now eligible).</li>
+</ol>
+</blockquote>
+</div> 
+</div>
+</div>
+<p><a id="using-the-graphql-playground" class="devdocsAnchor"></a></p>
+<h2 id="using-the-graphql-playground">Using the GraphQL Playground</h2>
+<p>To use the request runner, input queries on the left side and then click the play button. Query results will be displayed on the the right side:</p>
+<p><img src="https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/graphql-storefront-api-playground2.png" alt="GraphQL Playground Query" title="GraphQL Playground Query"></p>
+<p>Here's a sample Query to get you started:</p>
+<pre><code class="language-javascript"><div>query MyFirstQuery {
+  site {
+    settings {
+      storeName
+    }
+    products {
+      edges {
+        node {
+          name
+          sku
+          prices {
+            retailPrice {
+              value
+              currencyCode
+            }
+            price {
+              value
+              currencyCode
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</div></code></pre>
+<p>To explore the storefront GraphQL schema, checkout the Docs and Schema tabs on the right:</p>
+<p><img src="https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/graphql-playground-docs.png" alt="GraphQL Playground Docs" title="GraphQL Playground Docs"></p>
+<p>Click changelog in the top right to view a list of recent changes to the storefront API:</p>
+<p><img src="https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/graphql-playground-changelog.png" alt="GraphQL Playground Changelog" title="GraphQL Playground Changelog"></p>
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+<!-- theme: info -->
+<h3 id="note-2">Note</h3>
+<blockquote>
+<ul>
+<li>The changelog is updated with each deployment.</li>
+<li>Additive Changes are possible during beta, so we recommend checking for changes frequently</li>
+</ul>
+</blockquote>
+</div> 
+</div>
+</div>
+<p><a id="authentication" class="devdocsAnchor"></a></p>
+<h2 id="authentication">Authentication</h2>
+<p>GraphQL Storefront API requests are authenticated with tokens sent via the HTTP <code>Authorization</code> header:</p>
+<pre><code class="language-bash"><div>curl <span class="hljs-string">'https://www.{bigcommerce_storefront_domain}.com/graphql'</span>\
+  <span class="hljs-comment"># ...</span>
+  -H <span class="hljs-string">'Authorization: Bearer {token}'</span>\
+  <span class="hljs-comment"># ...</span>
+</div></code></pre>
+<h3 id="authenticating-with-a-stencil-simple-token">Authenticating with a Stencil Simple Token</h3>
+<p>Client code in BigCommerce Stencil themes can be passed a token at render time with the <code>{{settings.storefront_api.token}}</code> handlebars object:</p>
+<pre><code class="language-html"><div><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
+fetch(<span class="hljs-string">'/graphql'</span>, {
+       <span class="hljs-attr">method</span>: <span class="hljs-string">'POST'</span>,
+       <span class="hljs-attr">headers</span>: {
+           <span class="hljs-string">'Content-Type'</span>: <span class="hljs-string">'application/json'</span>,
+           <span class="hljs-string">'Authorization'</span>: <span class="hljs-string">'Bearer {{settings.storefront_api.token}}'</span>
+       },
+       <span class="hljs-attr">body</span>: <span class="hljs-built_in">JSON</span>.stringify({
+           <span class="hljs-attr">query</span>: <span class="hljs-string">`
+            query MyFirstQuery {...}
+  `</span>
+<span class="hljs-comment">// ...</span>
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
+</div></code></pre>
+<h3 id="authenticating-with-a-jwt">Authenticating with a JWT</h3>
+<p>JWT tokens for authenticating cross-origin requests to the Storefront API can be created using the <a href="https://developer.bigcommerce.com/api-reference/storefront/storefront-token-api/api-token/createtoken">Storefront API Token endpoint</a>:</p>
+<p><strong><code>POST</code></strong> <code>https://api.bigcommerce.com/stores/{store_hash}/v3/storefront/api-token</code></p>
+<pre><code class="language-javascript"><div>{
+  <span class="hljs-string">"channel_id"</span>: <span class="hljs-number">1</span>,            <span class="hljs-comment">// int (only ID 1 currently accepted)</span>
+  <span class="hljs-string">"expires_at"</span>: <span class="hljs-number">1602288000</span>,   <span class="hljs-comment">// double utc unix timestamp (required)</span>
+  <span class="hljs-string">"allowed_cors_origins"</span>: [   <span class="hljs-comment">// array (accepts 1 origin currently)</span>
+    <span class="hljs-string">"https://example.com"</span>
+  ]  
+}
+</div></code></pre>
+<p><strong>Response:</strong></p>
+<pre><code class="language-json"><div>{
+  <span class="hljs-attr">"token"</span>:<span class="hljs-string">"...eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9..."</span>,
+  <span class="hljs-attr">"meta"</span>: {
+    // ...
+  }
+}
+</div></code></pre>
+<div class="HubBlock--callout">
+<div class="CalloutBlock--warning">
+<div class="HubBlock-content">
+<!-- theme: warning -->
+<h3 id="note-3">Note</h3>
+<blockquote>
+<ul>
+<li><code>1</code> can be passed in for the <code>channel_id</code> for generating tokens for use on the storefront itself.</li>
+<li><code>1</code> is currently the only accepted <code>channel_id</code>.</li>
+<li>To create a channel for a remote site, see [Create Channel].(<a href="https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel">https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel</a>) in the API Reference.</li>
+<li><code>allowed_cors_origins</code> array accepts only a single origin currently -- one token must be generated for each origin.</li>
+<li><code>/storefront/api-token</code> endpoint requires the <code>Manage</code> <code>Storefront API Tokens</code> OAuth Scope.</li>
+<li><code>storefront/api-token-customer-impersonation</code> endpoint requires the <code>Manage</code> <code>Storefront API Customer Impersonation Tokens</code> OAuth Scope.</li>
+</ul>
+</blockquote>
+</div> 
+</div>
+</div>
+<h3 id="customer-impersonation-tokens">Customer Impersonation Tokens</h3>
+<p>Its also possible to generate tokens for use in server-to-server interactions with a trusted consumer by POSTing to the <a href="https://developer.bigcommerce.com/api-reference/storefront/storefront-token-api/api-token-customer-impersonation/createtokenwithcustomerimpersonation">API Token Customer Impersonation Endpoint</a> with the <code>X-Bc-Customer-Id</code> header set to the customer's ID:</p>
+<p><strong><code>POST</code></strong> <code>https://api.bigcommerce.com/stores/{store_id}/v3/storefront/api-token-customer-impersonation</code></p>
+<pre><code class="language-json"><div>{
+  <span class="hljs-attr">"channel_id"</span>: <span class="hljs-number">1</span>,
+  <span class="hljs-attr">"expires_at"</span>: <span class="hljs-number">1602288000</span>
+}
+</div></code></pre>
+<p><strong>Response</strong>:</p>
+<pre><code class="language-json"><div>{
+  <span class="hljs-attr">"data"</span>:
+  {
+    <span class="hljs-attr">"token"</span>: <span class="hljs-string">"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"</span>
+  }
+  <span class="hljs-string">"meta"</span>: {}
+}
+</div></code></pre>
+<p>Customer Impersonation Token authenticated requests made to the GraphQL API receive store information from the perspective of the customer corresponding to the customer ID specified in the <code>X-Bc-Customer-Id</code> header used to create the token -- for example: pricing, product availability, customer account, and customer details.</p>
+<p><a id="querying-within-a-bigcommerce-storefront" class="devdocsAnchor"></a></p>
+<h2 id="querying-within-a-bigcommerce-storefront">Querying Within a BigCommerce Storefront</h2>
+<p>GraphQL Storefront API calls can be made directly from within a Stencil theme or a from a script in <a href="https://support.bigcommerce.com/s/article/Using-Script-Manager">Storefront &gt; Script Manager</a>.</p>
+<p>Here's an an example request using the  <code>{{settings.storefront_api.token}}</code> handlebars object and <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API"><code>fetch()</code></a>:</p>
+<pre><code class="language-html"><div><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
+   fetch(<span class="hljs-string">'/graphql'</span>, {
+       <span class="hljs-attr">method</span>: <span class="hljs-string">'POST'</span>,
+       <span class="hljs-attr">headers</span>: {
+           <span class="hljs-string">'Content-Type'</span>: <span class="hljs-string">'application/json'</span>,
+           <span class="hljs-string">'Authorization'</span>: <span class="hljs-string">'Bearer {{ settings.storefront_api.token }}'</span>
+       },
+       <span class="hljs-attr">body</span>: <span class="hljs-built_in">JSON</span>.stringify({
+           <span class="hljs-attr">query</span>: <span class="hljs-string">`
+            query MyFirstQuery {
+            site {
+                settings {
+                storeName
+                }
+                products {
+                edges {
+                    node {
+                      name
+                      sku
+                      prices {
+                        retailPrice {
+                          value
+                          currencyCode
+                        }
+                        price {
+                          value
+                          currencyCode
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            `</span>
+       }),
+   })
+   .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json())
+   .then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> <span class="hljs-built_in">console</span>.log(json));
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
+</div></code></pre>
+<p>In addition to using <code>fetch()</code>, there's a other ways to query the API:</p>
+<ol>
+<li><strong>Using <a href="https://www.apollographql.com/docs/react/">Apollo Client</a></strong> - Apollo is a popular GraphQL client that's easy to use in BigCommerce themes. For a a quick example of adding Apollo Client to cornerstone, checkout this <a href="https://github.com/bigcommerce/cornerstone/commit/508feeb1b00d2bb2940771e5e91250a08b6be4d9">Cornerstone commit</a> on GitHub.</li>
+<li><strong>Using any GraphQL Client</strong> - GraphQL is standard with client libraries in many languages, so feel free to explore your options. The focus of the beta is on using the API from frontend JavaScript within Stencil; however, in the future, the API will also be opened up for server-to-server requests.</li>
+</ol>
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+<!-- theme: info -->
+<h3 id="note-4">Note</h3>
+<blockquote>
+<ul>
+<li>If pasted directly into a script in <a href="https://support.bigcommerce.com/s/article/Using-Script-Manager"><strong>Storefront</strong> &gt; <strong>Script Manager</strong></a>, the output from <code>console.log(json)</code> will be viewable in the browser's Javascript Console.</li>
+<li>The above code must be used in a place where the <code>{{settings.storefront_api.token}}</code> handlebars variable can be accessed in order to get credentials for the API request.</li>
+</ul>
+</blockquote>
+</div>
+</div>
+</div>
+<p><a id="resources" class="devdocsAnchor"></a></p>
+<h2 id="resources">Resources</h2>
+<h3 id="examples">Examples</h3>
+<ul>
+<li><a href="https://bigcommerce.github.io/storefront-api-examples/html-bootstrap-vanillajs/">Bootstrap + Vanilla JS Storefront API Example</a> (<a href="http://bigcommerce.github.io">bigcommerce.github.io</a>)</li>
+<li><a href="https://github.com/bigcommerce/storefront-api-examples">All BigCommerce Storefront API Examples</a> (<a href="http://github.com">github.com</a>)</li>
+<li><a href="https://support.bigcommerce.com/s/group/0F91B000000bo3TSAQ/storefront-api-beta">GraphQL Storefront API Community Group</a> (<a href="http://support.bigcommerce.com">support.bigcommerce.com</a>)</li>
+</ul>
+<h3 id="pull-requests">Pull Requests</h3>
+<ul>
+<li><a href="https://github.com/bigcommerce/cornerstone/compare/graphQL-example">Simple GraphQL Example Using Apollo Client with Cornerstone</a></li>
+</ul>
+<h3 id="additional-resources">Additional Resources</h3>
+<ul>
+<li><a href="https://devhints.io/graphql">GraphQL Cheat Sheet</a> (<a href="http://devhints.io">devhints.io</a>)</li>
+<li><a href="https://github.com/andev-software/graphql-ide">GraphQL IDE</a> (<a href="http://github.com">github.com</a>)</li>
+<li><a href="https://www.npmjs.com/package/graphql-playground-react">GraphQL Playground</a> (<a href="http://npmjs.com">npmjs.com</a>)</li>
+</ul>
+
+    </body>
+    </html>

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -171,8 +171,6 @@ fetch('/graphql', {
 </script>
 ```
 
-Tokens rendered by `{{settings.storefront_api.token}}` are non-JWT tokens that can only be used for same-origin requests.
-
 ### Authenticating with a JWT
 
 JWT tokens for authenticating cross-origin requests to the Storefront API can be created using the [Storefront API Token endpoint](https://developer.bigcommerce.com/api-reference/storefront/storefront-token-api/api-token/createtoken):


### PR DESCRIPTION
# [DEVDOCS-1294](https://jira.bigcommerce.com/browse/DEVDOCS-1294)

## What changed?
Removes the distinction that Storefront tokens are non-JWT, as this is no longer the case