### PR TITLE
Updated TR-300 Error in Documentation

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.md
+++ b/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.md
@@ -232,6 +232,14 @@ The `eval-cheap-module-source-map` option performs faster rebuilds, but omits li
 
 If uploading your theme triggers a TR-300 error, this can indicate an included source-map file (`bundle.js.map`) that exceeds its size limit of 5 MB. If your `bundle.js.map` exceeds that limit, the workaround is to move this file outside your theme directory before re-running `stencil bundle`.
 
+Other reasons for this error include exceeding these stencil theme limitations:
+* Max directory size: /templates/ and /parsed/templates/ 1 MB
+* Max for any single file in the bundle: 5 MB
+* Zip size max: 50 MB
+* Unzipped size max: 100 MB
+* Total number of files: 2500
+
+
 ## Reinstalling Stencil CLI
 
 If you encounter persistent problems in initializing or starting Stencil, you have the option of completely removing Stencil CLI and doing a fresh reinstall. You would do so as follows:


### PR DESCRIPTION
## What changed?
* Updated TR-300 Error in Documentation to give more information about the error as when we encountered it. It was very unclear and only after digging into the issues for stencil-cli did we find the root cause.
* See closed ticket https://github.com/bigcommerce/stencil-cli/issues/510 for the source of the information.