### PR TITLE
Remove Operation Level Security from S2S Checkout

### DIFF
--- a/reference/json/BigCommerce_Server_to_Server_Checkout_API.oas2.json
+++ b/reference/json/BigCommerce_Server_to_Server_Checkout_API.oas2.json
@@ -92,7 +92,6 @@
             }
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -238,7 +237,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -383,7 +381,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -622,7 +619,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -851,7 +847,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -904,7 +899,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -974,7 +968,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,
@@ -1030,7 +1023,6 @@
             "$ref": "#/responses/CheckoutResponse"
           }
         },
-        "security": [],
         "x-unitTests": [],
         "x-operation-settings": {
           "CollectParameters": false,


### PR DESCRIPTION
## What changed?
* The auth token and client id settings weren't available because no-security was set at the operation level. Removed that so that global security could take affect. 