### PR TITLE
Use correct types for given enum values

### DIFF
--- a/reference/json/BigCommerce_Catalog_API.oas2.json
+++ b/reference/json/BigCommerce_Catalog_API.oas2.json
@@ -144,7 +144,7 @@
             "description": "Filter items by condition.\n",
             "required": false,
             "in": "query",
-            "type": "integer",
+            "type": "string",
             "enum": [
               "new",
               "used",
@@ -2211,7 +2211,7 @@
             "description": "Filter items by condition.\n",
             "required": false,
             "in": "query",
-            "type": "integer",
+            "type": "string",
             "enum": [
               "new",
               "used",

--- a/reference/json/BigCommerce_Channels_Listings_API.oas2.json
+++ b/reference/json/BigCommerce_Channels_Listings_API.oas2.json
@@ -868,6 +868,7 @@
           "description": "Description of the product for this channel listing specifically. This overrides the description in the catalog "
         },
         "state": {
+          "type": "string",
           "enum": [
             "active",
             "disabled",
@@ -928,6 +929,7 @@
           "description": "Description of the product for this channel listing specifically. This overrides the description in the catalog "
         },
         "state": {
+          "type": "string",
           "enum": [
             "active",
             "disabled",
@@ -986,6 +988,7 @@
           "description": "Description of the product for this channel listing specifically. This overrides the description in the catalog "
         },
         "state": {
+          "type": "string",
           "enum": [
             "active",
             "disabled",
@@ -1045,6 +1048,7 @@
           "description": "Description of the product for this channel listing specifically. This overrides the description in the catalog "
         },
         "state": {
+          "type": "string",
           "enum": [
             "active",
             "disabled",
@@ -1095,6 +1099,7 @@
           "description": "Description of the product for this channel listing specifically. This overrides the description in the catalog "
         },
         "state": {
+          "type": "string",
           "enum": [
             "active",
             "disabled",

--- a/reference/json/BigCommerce_Orders_API.oas2.json
+++ b/reference/json/BigCommerce_Orders_API.oas2.json
@@ -2366,7 +2366,7 @@
           "type": "string"
         },
         "type": {
-          "type": "string",
+          "type": "integer",
           "title": "Order Coupon Discount Type",
           "enum": [
             0,
@@ -3461,7 +3461,7 @@
       }
     },
     "OrderCouponDiscountType": {
-      "type": "string",
+      "type": "integer",
       "title": "Order Coupon Discount Type",
       "enum": [
         0,


### PR DESCRIPTION
Somehow, it's not against the OpenAPI spec to have a type of "integer"
but enum values as strings. However, openapi-generator-cli can't
generate code for these schemas.

## What changed?
* Product condition is a string, not an integer.
* Listing states are explicitly strings.
* Order coupon discount types are integers, not strings.