### PR TITLE
DEVDOCS-1384: Remove Verbiage on Swapping Foundation

### DIFF
--- a/docs/stencil-docs/getting-started/about-stencil.md
+++ b/docs/stencil-docs/getting-started/about-stencil.md
@@ -4,7 +4,11 @@
 
 ### On This Page
 - [Cornerstone](#cornerstone)
-- [Stencil Development Features](#stencil-development-features)
+- [Stencil CLI](#stencil-cli)
+- [Flexible Templates](#flexible-templates)
+- [Powerful CSS Stack](#powerful-css-stack)
+- [Front Matter](#front-matter)
+- [JavaScript Event Hooks](#javascript-event-hooks)
 - [Blueprint (Legacy Framework)](#blueprint-legacy-framework)
 - [Support](#support)
 - [Resources](#resources)
@@ -19,9 +23,9 @@ BigCommerce Stencil themes are responsive, mobile friendly themes, allowing shop
 
 ## Cornerstone
 
-Stencil powers BigCommerce’s [Cornerstone](https://github.com/bigcommerce/cornerstone) theme, which serves as your base Stencil theme for creating custom sites. Cornerstone is available open source on [Github](https://github.com/bigcommerce/cornerstone).
+BigCommerce's [Cornerstone](https://github.com/bigcommerce/cornerstone) theme is the building block and starting point for rapidly developing themes for BigCommerce. Cornerstone is available open source on [Github](https://github.com/bigcommerce/cornerstone).
 
-The Cornerstone theme comes with three style variations that are each fully responsive and ideal for a large catalog. The variations include:
+Cornerstone comes in three, fully-responsive variations:
 
 * Cornerstone Light
 * Cornerstone Warm
@@ -29,55 +33,39 @@ The Cornerstone theme comes with three style variations that are each fully resp
 
 See the [Cornerstone Light theme demo](http://cornerstone-light-demo.mybigcommerce.com/) to experience a Stencil theme's capabilities.
 
-As the default theme on new/trial stores, Cornerstone is typically the first theme to support new theme-related features and improvements. See the [BigCommerce Developer Changelog](https://developer.bigcommerce.com/changelog) for the latest Cornerstone news and release notes.
+As the default theme on new stores, Cornerstone is typically the first theme to support new theme-related features and improvements. See the [BigCommerce Developer Changelog](https://developer.bigcommerce.com/changelog) for the latest Cornerstone news and release notes.
 
-## Stencil Development Features
-
-Stencil contains features that allow BigCommerce theme developers to create beautiful, dynamic, and powerful storefronts.
-
-### Stencil Command Line Interface (Stencil CLI)
+## Stencil CLI
 
 The Stencil CLI enables developers to locally develop and customize on any Stencil theme with no impact on a merchant's live storefront during the development process. When developing locally, developers have access to real-time Browsersync preview and testing across desktop, mobile, and tablet devices/viewports.
 
 Stencil CLI runs on the [Node.js](https://nodejs.org/en/) runtime environment. Installing Node.js also provides the required [npm package manager](https://www.npmjs.com/package/npm).
 
-### Logic-Based Templates
+## Flexible Templates
 
 Stencil's logic based templates allow BigCommerce developers to customize storefront pages efficiently with the lightweight templating language, [Handlebars.js](https://handlebarsjs.com/). Handlebars.js allows you to efficiently embed dynamic and conditional logic onto your storefront pages.
 
-### CSS and Design Assets
+## Powerful CSS Stack
 
-Stencil's Sass and SCSS support allows developers to nest properties, variables, and mix-ins. Cornerstone uses a BigCommerce pattern library called [Citadel](https://www.npmjs.com/package/@bigcommerce/citadel), which is built on top of the [ZURB Foundation framework](https://foundation.zurb.com/sites/docs/), version 5.5.3. Foundation assets are located in these subdirectories in the base Stencil theme, Cornerstone:
+Stencil themes support both **Sass** and **SCSS**. Developers can use these popular CSS pre-processors to nest CSS properties, variables, and mix-ins. 
 
-* <span class="fp">cornerstone/assets/scss/settings/foundation/</span>
-* <span class="fp">cornerstone/assets/scss/components/foundation/</span>
+Cornerstone uses a BigCommerce SCSS Framework [Citadel](https://www.npmjs.com/package/@bigcommerce/citadel), which is built on top of [Foundation](https://foundation.zurb.com/sites/docs/) `v5.5.3` (Foundation `v6.x` not currently supported).
 
-Foundation offers the framework for creating a responsive theme. You have the option of swapping out Foundation for another framework, although doing so would require significant work. Stencil does not support Foundation 6.x, due to incompatible updates introduced between versions 5.x and 6.x.
+Foundation assets are located in the following directories:
+* <span class="fp">assets/scss/settings/foundation/</span>
+* <span class="fp">assets/scss/components/foundation/</span>
 
-<div class="HubBlock--callout">
-<div class="CalloutBlock--">
-<div class="HubBlock-content">
+## Front Matter
 
-<!-- theme:  -->
+Stencil's use of **YAML Front Matter** allows developers to request only the objects needed on the storefront, increasing page speed and allowing developers to define the content to render with just a few keystrokes.
 
-### Edit HTML and CSS Files from the BigCommerce Control Panel
-> If you are more comfortable working in HTML and CSS, Stencil's *Edit Theme Files* feature allows you to directly edit many of your theme's files from the Control Panel. See [Edit Theme Files](https://www.youtube.com/watch?v=waJ1dg_dAh8&index=related) to learn how (Youtube).
+## JavaScript Event Hooks
 
-</div>
-</div>
-</div>
-
-### Page-specific Resource Definition
-
-Stencil's use of YAML front matter allows you to request only the objects you need on the storefront, increasing page speed and allowing you to define the content to render with just a few keystrokes.
-
-### Javascript Event Hooks
-
-Stencil themes can access remote objects through event hooks, using the hooks to trigger defined events based on shopper behavior. This will allow you to collect product data and optimize a shopper's experience. To facilitate theme-building, BigCommerce provides the [stencil-utils client-side JavaScript library](/stencil-docs/adding-event-hooks-to-your-theme/stencil-utils-api-reference) for managing event hooks.
+Stencil themes can access remote objects through event hook and use the hooks to trigger defined events based on shopper behavior. This will allow you to collect product data and optimize a shopper's experience. To facilitate theme-building, BigCommerce provides [stencil-utils](https://developer.bigcommerce.com/stencil-docs/reference-docs/stencil-utils-api-reference) -- a client-side library for managing event hooks.
 
 ## Blueprint (Legacy Framework)
 
-If you are looking for information on Blueprint, BigCommerce's legacy theme framework, you can visit [Blueprint Themes](https://developer.bigcommerce.com/legacy/blueprint-themes).
+For information on Blueprint, BigCommerce's legacy theme framework, see: [Blueprint Themes](https://developer.bigcommerce.com/legacy/blueprint-themes).
 
 ## Support
 


### PR DESCRIPTION
# [DEVDOCS-1384](https://jira.bigcommerce.com/browse/DEVDOCS-1384)

## What changed?
* Removed the verbiage on removing Foundation and replacing it with another framework -- its not necessary
* Cleaned up verbiage in a few other spots and pulled some H3s out to H2s. 