### PR TITLE
remove otp typo in BP docs

### DIFF
--- a/docs/legacy/blueprint-themes/blueprint-template-syntax.md
+++ b/docs/legacy/blueprint-themes/blueprint-template-syntax.md
@@ -1,6 +1,5 @@
 # Template Syntax
 
-.otp
 <div class="otp" id="no-index">
 
 ### On This Page


### PR DESCRIPTION
# [DEVDOCS-n/a](https://jira.bigcommerce.com/browse/DEVDOCS-n/a)

## What changed?
Fix typo on /legacy/blueprint-themes/blueprint-template-syntax