### PR TITLE
Changing CORs to CORS

### DIFF
--- a/docs/api-docs/cart-and-checkout/working-sf-apis.md
+++ b/docs/api-docs/cart-and-checkout/working-sf-apis.md
@@ -19,7 +19,7 @@
 
 This tutorial reviews the Fetch API and then uses it to complete some storefront actions. 
 
-Interaction with the Storefront APIs should be done using JavaScript. The Storefront APIs do not require API Tokens to work. The URL should be served over https and be on the [permanent URL](https://forum.bigcommerce.com/s/article/Changing-Domains); otherwise, it can cause [CORs](https://developers.google.com/web/ilt/pwa/working-with-the-fetch-api#cross-origin_requests) errors in the console.
+Interaction with the Storefront APIs should be done using JavaScript. The Storefront APIs do not require API Tokens to work. The URL should be served over https and be on the [permanent URL](https://forum.bigcommerce.com/s/article/Changing-Domains); otherwise, it can cause [CORS](https://developers.google.com/web/ilt/pwa/working-with-the-fetch-api#cross-origin_requests) errors in the console.
 
 ## Create postData() function
 


### PR DESCRIPTION
# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
Updated the spelling of CORS within the following sentence: "_The URL should be served over https and be on the permanent URL; otherwise, it can cause **CORs** errors in the console._"

Now it reads "The URL should be served over https and be on the permanent URL; otherwise, it can cause **CORS** errors in the console."