### PR TITLE
Update graphql-api-overview.md

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -25,7 +25,7 @@ BigCommerce's GraphQL Storefront API makes it possible to query storefront data 
 
 Additionally, by leveraging the power of [GraphQL](https://graphql.org/), data for multiple resources can be returned from a single API call, which simplifies integration and increases performance so that developers can focus on building delightful shopper experiences.
 
-This article is a general overview of the capabilities and usage of BigCommerce's GraphQL Storefront API; it includes sections on authentication and how to access a store's GraphQL Playground. To see specific examples of how GraphQL can be used to query storefront data, see [GraphQL Storefront API Code Samples](https://developer-beta.bigcommerce.com/api-docs/storefront/graphql/graphql-storefront-api-samples).
+This article is a general overview of the capabilities and usage of BigCommerce's GraphQL Storefront API; it includes sections on authentication and how to access a store's GraphQL Playground. To see specific examples of how GraphQL can be used to query storefront data, see [GraphQL Storefront API Code Samples](https://devcenter-production.docs.stoplight.io/api-docs/storefront/graphql/graphql-storefront-api-samples).
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -15,17 +15,17 @@
 
 </div>
 
-BigCommerce's GraphQL Storefront API makes it possible to query storefront data from within a [Stencil](https://devcenter-production.docs.stoplight.io/stencil-docs/getting-started/about-stencil) theme or remote site. This means information previously only available on the back-end via [Stencil's template logic](https://devcenter-production.docs.stoplight.io/stencil-docs/reference-docs/global-objects-and-properties) can now be accessed via front-end javascript. For example, with the Storefront API, it is possible to:
+BigCommerce's GraphQL Storefront API makes it possible to query storefront data from within a [Stencil](https://developer.bigcommerce.com/stencil-docs/getting-started/about-stencil) theme or remote site. This means information previously only available on the back-end via [Stencil's template logic](https://developer.bigcommerce.com/stencil-docs/reference-docs/global-objects-and-properties) can now be accessed via front-end javascript. For example, with the Storefront API, it is possible to:
 
 * Access product options, variations, and custom fields for any product from any page
 * Request any product's images at any resolution
 * Ask for customer details such as name, email address, and attributes (if logged in)
 * Look up objects (e.g. categories or brands) by URL, and fetch their details
-* Build front-end applications on top of a BigCommerce [Stencil](https://devcenter-production.docs.stoplight.io/stencil-docs/getting-started/about-stencil) theme or on a remote site
+* Build front-end applications on top of a BigCommerce [Stencil](https://developer.bigcommerce.com/stencil-docs/getting-started/about-stencil) theme or on a remote site
 
 Additionally, by leveraging the power of [GraphQL](https://graphql.org/), data for multiple resources can be returned from a single API call, which simplifies integration and increases performance so that developers can focus on building delightful shopper experiences.
 
-This article is a general overview of the capabilities and usage of BigCommerce's GraphQL Storefront API; it includes sections on authentication and how to access a store's GraphQL Playground. To see specific examples of how GraphQL can be used to query storefront data, see [GraphQL Storefront API Code Samples](https://devcenter-production.docs.stoplight.io/api-docs/storefront/graphql/graphql-storefront-api-samples).
+This article is a general overview of the capabilities and usage of BigCommerce's GraphQL Storefront API; it includes sections on authentication and how to access a store's GraphQL Playground. To see specific examples of how GraphQL can be used to query storefront data, see [GraphQL Storefront API Code Samples](https://developer.bigcommerce.com/api-docs/storefront/graphql/graphql-storefront-api-samples).
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">


### PR DESCRIPTION
Update https://developer-beta.bigcommerce.com/api-docs/storefront/graphql/graphql-storefront-api-samples to https://devcenter-production.docs.stoplight.io/api-docs/storefront/graphql/graphql-storefront-api-samples due to broken link on production site.