### PR TITLE
Stencil CLI Theme Editor Deprecated

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -116,7 +116,8 @@ stencil start --open # opens live theme preview in default browser
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
 | `--theme-editor`             |`-e` | Run Theme Editor server (Deprecated as of v1.23.1)                                                               |
 | `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)             |
-| `--theme-editor-port [port]` |     |Run the Theme Editor on a different port (Deprecated as of v1.23.1)                                              |
+| `--theme-editor-port [port]` |     |Run the Theme Editor on a different port (**Deprecated as of v1.23.1**)                                              |
+
 | `--help`                     |`-h` | Output usage information                                                              |
 
 <div class="HubBlock--callout">

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -114,10 +114,24 @@ stencil start --open # opens live theme preview in default browser
 | `--variation [<NAME>]`       |`-v` | Set which theme variation to use while developing                                     |
 | `--test`                     |`-t` | Enable QA mode which will bundle all javascript for speed to test locally             |
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
-| `--theme-editor`             |`-e` | Run Theme Editor server                                                               |
+| `--theme-editor`             |`-e` | Run Theme Editor server (Deprecated as of v1.23.1)                                                               |
 | `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)             |
-| `--theme-editor-port [port]` |     |Run the Theme Editor on a different port                                               |
+| `--theme-editor-port [port]` |     |Run the Theme Editor on a different port (Deprecated as of v1.23.1)                                              |
 | `--help`                     |`-h` | Output usage information                                                              |
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+    
+<!-- theme: {{callout_type}} -->
+
+### --theme-editor and --theme-editor-port [port]:
+>`-theme-editor` and `--theme-editor-port [port]` options are deprecated as of v1.23.1. Please use [Store Design](https://developer.bigcommerce.com/stencil-docs/configure-store-design-ui/store-design-overview) instead.
+
+
+</div>
+</div>
+</div>
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -114,7 +114,8 @@ stencil start --open # opens live theme preview in default browser
 | `--variation [<NAME>]`       |`-v` | Set which theme variation to use while developing                                     |
 | `--test`                     |`-t` | Enable QA mode which will bundle all javascript for speed to test locally             |
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
-| `--theme-editor`             |`-e` | Run Theme Editor server (Deprecated as of v1.23.1)                                                               |
+| `--theme-editor`             |`-e` | Run Theme Editor server (**Deprecated as of v1.23.1**)                                                               |
+
 | `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)             |
 | `--theme-editor-port [port]` |     |Run the Theme Editor on a different port (**Deprecated as of v1.23.1**)                                              |
 


### PR DESCRIPTION
# [DEVDOCS-1613](https://jira.bigcommerce.com/browse/DEVDOCS-1613)

## What changed?
* added a note to `stencil start` about --theme-editor and --theme-editor-port [port] being deprecated as of v1.23.1.