### PR TITLE
Clarify payment_method_id description

### DIFF
--- a/reference/BigCommerce_Process_Payment_API.oas2.yml
+++ b/reference/BigCommerce_Process_Payment_API.oas2.yml
@@ -106,7 +106,7 @@ paths:
                   payment_method_id:
                     description: >-
                       Identifier for payment method that will be used for this
-                      payment
+                      payment and `id` from the Get Accepted Payment Methods API
                     type: string
                     minLength: 1
             required:
@@ -342,7 +342,7 @@ definitions:
             description: ''
             type: object
           payment_method_id:
-            description: Identifier for payment method that will be used for this payment
+            description: Identifier for payment method that will be used for this payment and `id` from the Get Accepted Payment Methods API
             type: string
             minLength: 1
         required:
@@ -367,7 +367,7 @@ definitions:
         description: ''
         type: object
       payment_method_id:
-        description: Identifier for payment method that will be used for this payment
+        description: Identifier for payment method that will be used for this payment and `id` from the Get Accepted Payment Methods API
         type: string
         minLength: 1
     required:


### PR DESCRIPTION
The description for the payment_method_id property in the request body for the Process Payment for an Order API does not make it clear what the source of the value should be. It is `id` from the Get Accepted Payment Methods API, but without reading additional documentation or examining the example requests, it may be confused with `method` from the Get Transactions API, or `code` or `name` from the Get All Payment Methods API.

## What changed?
* Appended  "and `id` from the Get Accepted Payment Methods API" to all descriptions of payment_method_id in the Process Payment for an Order reference.