### PR TITLE
Update TR-500 Error Meaning

### DIFF
--- a/docs/stencil-docs/deploying-a-theme/troubleshooting-theme-uploads.md
+++ b/docs/stencil-docs/deploying-a-theme/troubleshooting-theme-uploads.md
@@ -49,7 +49,7 @@ Custom theme uploads must meet these restrictions:
   </tr>
   <tr>
     <td>TR-500</td>
-    <td>The .zip file is larger than the 50MB limit.</td>
+    <td>The .zip file is larger than the 50MB limit; or the parsed JSON for templates exceeds the 1MB size limit.</td>
   </tr>
   <tr>
     <td>TR-600</td>


### PR DESCRIPTION
# [DEVDOCS-1708](https://jira.bigcommerce.com/browse/DEVDOCS-1708)

## What changed?
* Updated TD-500 error meaning. Updated text: "The .zip file is larger than the 50MB limit; or the parsed JSON for templates exceeds the 1MB size limit."