### PR TITLE
Fix orderID in store/shipment/created webhook event to reflect integer

### DIFF
--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -626,7 +626,7 @@ Changes to the following store settings will trigger a `store/information/update
     "data": {
         "type": "shipment",
         "id": 12,
-        "orderId": "251"
+        "orderId": 251
     },
     "hash": "8b98021cb0faa7e3a58a0e4182d3696a4bdd24ab",
     "created_at": 1561482857,


### PR DESCRIPTION
# [DEVDOCS-1668](https://jira.bigcommerce.com/browse/DEVDOCS-1668)

## What changed?
* We've changed the response so that BC sends the `OrderId` as an integer. Updated documentation example of payload to reflect this change