### PR TITLE
Remove Adyen from Payment Limitation

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -91,7 +91,7 @@ Payments can be processed using cards stored with the BigCommerce Stored Credit 
 
 <!-- theme:  -->
 ### Hosted Providers
-> The API flow does not currently support hosted/offsite providers such as PayPal and Adyen and wallet type payments such as Amazon Pay.
+> The API flow does not currently support hosted/offsite providers, such as PayPal, and wallet type payments, such as Amazon Pay.
 
 </div>
 </div>


### PR DESCRIPTION
# [DEVDOCS-1727](https://jira.bigcommerce.com/browse/DEVDOCS-1727)

## What changed?
* removed "Adyen" from the Hosted Provider section of the Payments API documentation