### PR TITLE
Fix Category Tree Request

### DIFF
--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -1002,7 +1002,7 @@ X-Auth-Client: {{CLIENT_ID}}
 [Category Tree](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/category/getcategorytree) returns a simple view of the parent > child relationship of all categories in the store. This endpoint can be used to fetch the categories if building out a custom navigation for a store.
 
 ```http
-GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/catalog/summary
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/catalog/categories/tree
 Accept: application/json
 Content-Type: application/json
 X-Auth-Token: {{ACCESS_TOKEN}}


### PR DESCRIPTION
Previous request referenced https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/catalog/summary, which is not the Category Tree.

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* thing_that_changed