### PR TITLE
update webhook-events.md

### DIFF
--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -71,6 +71,7 @@
 | store/order/archived | Order is archived |
 | store/order/statusUpdated | This will only fire if the order status has changed. Such as Pending to Awaiting Payment |
 | store/order/message/created | Order message is created by customer or in control panel |
+| store/order/refund/created | A refund has been submitted against an order |
 
 ### The same response is returned for the following events:
 
@@ -152,7 +153,32 @@
     "producer": "stores/{store_hash}"
 }
 ```
+### The same response is returned for the following events:
 
+- `store/order/refund/created`
+
+**Response Fields**
+
+- type -- Will always be order
+- id -- Order ID
+- refund
+	- refund_id -- ID of the refund submitted against the order
+```json
+{
+    "scope": "store/order/refund/created",
+    "store_id": "1025646",
+    "data": {
+        "type": "order",
+        "id": 250,
+        "refund": {
+            "refund_id": 3
+        }
+    },
+    "hash": "cb07cdbdda8b1965e812693d5988154807eeed02",
+    "created_at": 1561479923,
+    "producer": "stores/{store_hash}"
+}
+```
 <a id="webhook-events_products"></a>
 
 ## Products


### PR DESCRIPTION
New refund created webhook should be added to the public api documentation.

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-1918)

## What changed?
* added a row to the orders table for the new webhook (store/order/refund/created)
* added events, response fields, and response code