### PR TITLE
Revert "Removes mention of category association begin a requirement for products"

### DIFF
--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -971,9 +971,11 @@ Complex rules must consist of multiple conditions that trigger the rule adjustme
 
 ## Categories
 
-[Categories](/api-reference/catalog/catalog-api/category/getcategories) are a hierarchy of products available on the store, presented in a tree structure. A store’s category structure determines the primary menu structure of most storefront themes, which are directly tied to it. 
+[Categories](/api-reference/catalog/catalog-api/category/getcategories) are a hierarchy of products available on the store, presented in a tree structure. A store’s category structure determines the primary menu structure of most storefront themes, which are directly tied to it.
 
-Unlike some e-commerce platforms, products on BigCommerce can be associated with more than one Category. A product associated with categories does not currently have any priority or weighted order (there’s no “primary category”), which can make it difficult to integrate with some external systems which might wish to use a product’s categories to map to a category structure in that external system.
+All products must be associated with at least one Category, although a Category does not need to contain any products. Unlike some e-commerce platforms, products on BigCommerce can be associated with more than one Category.
+
+A product associated with categories does not currently have any priority or weighted order (there’s no “primary category”), which can make it difficult to integrate with some external systems which might wish to use a product’s categories to map to a category structure in that external system.
 
 ```http
 POST https://api.bigcommerce.com/stores/{store_hash}/v3/catalog/categories


### PR DESCRIPTION
Reverts DEVDOCS-1912 after receiving DM from Dymtro that he was mistaken about this change being rolled out yesterday 6/25