### PR TITLE
removed duplicate letter a

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -305,7 +305,7 @@ Here's an an example request using the  `{{settings.storefront_api.token}}` hand
 ```
 
 In addition to using `fetch()`, there's a other ways to query the API:
-* **Using [Apollo Client](https://www.apollographql.com/docs/react/)** - Apollo is a popular GraphQL client that's easy to use in BigCommerce themes. For a a quick example of adding Apollo Client to cornerstone, checkout this [Cornerstone commit](https://github.com/bigcommerce/cornerstone/commit/508feeb1b00d2bb2940771e5e91250a08b6be4d9) on GitHub.
+* **Using [Apollo Client](https://www.apollographql.com/docs/react/)** - Apollo is a popular GraphQL client that's easy to use in BigCommerce themes. For a quick example of adding Apollo Client to cornerstone, checkout this [Cornerstone commit](https://github.com/bigcommerce/cornerstone/commit/508feeb1b00d2bb2940771e5e91250a08b6be4d9) on GitHub.
 * **Using any GraphQL Client** - GraphQL is a standard with client libraries in many languages, so feel free to explore your options.
 
 <div class="HubBlock--callout">


### PR DESCRIPTION
Changed "For a a quick example..." to "For a quick example..."

## What changed?
Removed duplicate letter a from sentence under the _Querying Within a BigCommerce Storefront_ section.