### PR TITLE
Fixed typo

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -165,7 +165,7 @@ subtitle: "POST https://developerserver.com/shipping/carrier/connection"
 lineNumbers: true
 -->
 
-**Exampe Request with Empty Object**
+**Example Request with Empty Object**
 `/POST https://developerserver.com/shipping/carrier/connection`
 
 ```json


### PR DESCRIPTION
Changed "Exampe Request with Empty Object" to "Example Request with Empty Object"

## What changed?
fixed typo