### PR TITLE
Removed duplicate text

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-examples.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-examples.md
@@ -47,7 +47,6 @@ query CustomerAttributes {
 ```
 
 <a href="https://developer.bigcommerce.com/graphql?playground_tab=customerDetails" target="_blank">**Try it in GraphQL Playground**</a>
-**[Try it in GraphQL Playground](https://developer.bigcommerce.com/graphql?playground_tab=customerDetails)**
 
 ## Get First Three Levels of Category Tree
 


### PR DESCRIPTION
Removed the following line because it appears twice under the code sample for Get a Customer's Details.
**[Try it in GraphQL Playground](https://developer.bigcommerce.com/graphqlplayground_tab=customerDetails)**

## What changed?
Removed duplicate text