### PR TITLE
Update customers-subscribers-overview.md

### DIFF
--- a/docs/api-docs/customers/customers-subscribers-overview.md
+++ b/docs/api-docs/customers/customers-subscribers-overview.md
@@ -95,7 +95,7 @@ Customers are any shopper that has created an account on the store. The Customer
 <!-- theme:  -->
 
 ### Name Value Pairs
-> Each customer can have up to 100 name, value pairs stored
+> Each customer can have up to 50 name, value pairs stored
 
 </div>
 </div>


### PR DESCRIPTION
Updated the limit of customer attributes name value pairs.  It was 100, now it is 50.

# [DEVDOCS-1930](https://jira.bigcommerce.com/browse/DEVDOCS-1930)

## What changed?
Under V3 Customer API> Name Value Pairs the doc says "Each customer can have up to 100 name, value pairs stored." This text was changed to "Each customer can have up to 50 name, value pairs stored."