### PR TITLE
Update checkout-sdk-example.md

### DIFF
--- a/docs/stencil-docs/customizing-checkout/checkout-sdk-example.md
+++ b/docs/stencil-docs/customizing-checkout/checkout-sdk-example.md
@@ -143,12 +143,12 @@ git clone git@github.com:bigcommerce/checkout-sdk-js-example.git ../checkout-sdk
 mkdir assets/js/checkout-app
 
 # copy example source code to directory you just created
-cp ../checkout-sdk-example/src/* assets/js/checkout-app/
+cp -R ../checkout-sdk-example/src/* assets/js/checkout-app/
 ```
 
 ### Import Dependencies
 
-In `/assets/js/app.js`, add the following lines blow the existing `import` statements:
+In `/assets/js/app.js`, add the following lines below the existing `import` statements:
 
 <div class="HubBlock-header">
     <div class="HubBlock-header-title flex items-center">


### PR DESCRIPTION
Add flag "-R" to copy example source code command, without this flag React component directories aren't copied and cause subsequent commands to fail. Fix typo "blow" to "below".