### PR TITLE
Added MyVirtualMerchant to stored cards list

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -56,6 +56,7 @@ Payments can be processed using cards stored with the BigCommerce Stored Credit 
 * AdyenV2
 * Authorize.net
 * CyberSource
+* MyVirtualMerchant
 * Paymetric
 * Paypal Powered by Braintree
 * Stripe


### PR DESCRIPTION
My understanding from the ticket is to add MyVirtualMerchant to the list of stored cards gateways. I asked Kyle Nowakowski to confirm that no other changes are needed.

# [DEVDOCS-1962](https://jira.bigcommerce.com/browse/DEVDOCS-1962)

## What changed?
MyVirtualMerchant is now available to process payments and the documentation should be updated to let our customers know.