### PR TITLE
Fix anchor on Stencil CLI installation docs page

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -6,7 +6,7 @@
 - [Obtaining Store API Credentials](#obtaining-store-api-credentials)
 - [Downloading a Theme](#downloading-a-theme)
 - [Installing Theme Modules](#installing-theme-modules)
-- [Serving Live Preview](#serving-live-preview)
+- [Serving Live Preview](#serving-a-live-preview)
 - [Resources](#resources)
 
 </div>


### PR DESCRIPTION
# [DEVDOCS-1966](https://jira.bigcommerce.com/browse/DEVDOCS-1966)

## What changed?
* Fixed anchor on Stencil CLI installation docs page

https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/live-previewing-a-theme#serving-live-preview doesn't scroll to the section, but https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/live-previewing-a-theme#serving-a-live-preview does