### PR TITLE
Fixed missing link

### DIFF
--- a/docs/stencil-docs/deploying-a-theme/naming-your-theme.md
+++ b/docs/stencil-docs/deploying-a-theme/naming-your-theme.md
@@ -172,7 +172,7 @@ lineNumbers: true
 
 ## Preparing a Variation’s Thumbnails
 
-For details on preparing screenshots that enable merchants to preview each variation – and to preview your theme as a whole in the BigCommerce control panel and Theme Marketplace, see Preparing Thumbnail Images.
+For details on preparing screenshots that enable merchants to preview each variation – and to preview your theme as a whole in the BigCommerce control panel and Theme Marketplace, see [Preparing Thumbnail Images](https://developer.bigcommerce.com/stencil-docs/deploying-a-theme/preparing-thumbnail-images).
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--">


### PR DESCRIPTION
A link was missing a for "Preparing Thumbnail Images" so I added it. 
This link is in the Preparing a variation's thumbnails section.

# [DEVDOCS-1985](https://jira.bigcommerce.com/browse/DEVDOCS-1985)

## What changed?
Fixed link