### PR TITLE
Moved item to supported features list

### DIFF
--- a/docs/bigcommerce-for-wordpress/getting-started/supported-features.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/supported-features.md
@@ -16,7 +16,7 @@
 The open source BigCommerce for Wordpress plugin currently supports the following features and capabilities that are native to the BigCommerce platform and more:
 
 * Complex Product Catalog (600 SKUs per product, 250 product values for a single option)
-* Product Pick Lists and Bundled * Products
+* Product Pick Lists and Bundled Products
 * Product Variants and Product Variant Pricing
 * Product Promotions
 * Secure Shopper Accounts and Logins with PCI Compliant Checkout

--- a/docs/bigcommerce-for-wordpress/getting-started/supported-features.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/supported-features.md
@@ -16,6 +16,7 @@
 The open source BigCommerce for Wordpress plugin currently supports the following features and capabilities that are native to the BigCommerce platform and more:
 
 * Complex Product Catalog (600 SKUs per product, 250 product values for a single option)
+* Product Pick Lists and Bundled * Products
 * Product Variants and Product Variant Pricing
 * Product Promotions
 * Secure Shopper Accounts and Logins with PCI Compliant Checkout
@@ -47,7 +48,6 @@ Unsupported Hosted Payment Gateways are Amazon Pay, AfterPay, Google Pay, Chase 
 
 The BigCommerce for Wordpress plugin does not currently support the following features: 
 
-* Product Pick Lists and Bundled * Products
 * Product File Upload Field
 * Warranty, Availability Fields
 * Persistent Cart


### PR DESCRIPTION
Product Pick Lists feature is now supported. This item was moved to the supported BigCommerce for Wordpress Supported Features list.
I am wondering why this item has an asterisk in the name. What does it mean? Product Pick Lists and Bundled * Products

Is it "Page Builder Plugins Support" or "Page Builder Plugin Support". I am not sure.

# [DEVDOCS-1970](https://jira.bigcommerce.com/browse/DEVDOCS-1970)

## What changed?
Moved Product Pick list to the supported features list.
Possible editorial change for Page Builder Plugins Support