### PR TITLE
This information should not have been removed

### DIFF
--- a/docs/stencil-docs/javascript-and-event-hooks/dynamic-content-rendering.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/dynamic-content-rendering.md
@@ -82,7 +82,7 @@ Here is an example of some HTML that we actually use:
 
 ### Dropzones JavaScript
 
-The content is moved from the default location to the dropzone by JavaScript we added to the PageManager class. In BigCommerce's Cornerstone base theme and other Stencil themes, PageManager is the parent class of all page classes. So, its methods get invoked on every page. This makes it a great place to put code like this, which needs to run every time a page is loaded.
+The content is moved from the default location to the dropzone by JavaScript we added to the PageManager class. In BigCommerce's Cornerstone base theme, Pixel Union's Merchant theme, and other Stencil themes, PageManager is the parent class of all page classes. So, its methods get invoked on every page. This makes it a great place to put code like this, which needs to run every time a page is loaded.
 
 We modified our theme's PageManager.before method to invoke a new method named `gr_moveHtmlToDropzones`:
 


### PR DESCRIPTION
Adding back in "Pixel Union Merchant theme".  Brandy Simek did not want this information removed because it was a customer tutorial. Sorry this was not clear in the initial PR.

# [DEVDOCS-1985](https://jira.bigcommerce.com/browse/DEVDOCS-1985)

## What changed?
Adding back in Pixel Union Merchant Theme. Brandy said the following, "i would not remove that. that was a customer-written tutorial"