### PR TITLE
fixed link in multi-language-checkout.md

### DIFF
--- a/docs/stencil-docs/localization/multi-language-checkout.md
+++ b/docs/stencil-docs/localization/multi-language-checkout.md
@@ -83,7 +83,7 @@ You can provide values for all of checkout's supported translation keys – for 
 
 1. Download and unzip a local copy of the [opt-checkout-en.json.zip file](https://storage.googleapis.com/bigcommerce-production-dev-center/template-files/opt-checkout-en.json.zip), also linked above in [Browsing Hidden Translation Keys](/stencil-docs/localization/translation-keys).
 
-2. Copy and paste the whole file's contents into your theme's `en.json` file and into the `.json` file for each language you want to translate your checkout page's text. To see requirements for naming and deploying these translation files, please this documentation's [Internationalization section](/stencil-docs/internationalization-and-localization/).
+2. Copy and paste the whole file's contents into your theme's `en.json` file and into the `.json` file for each language you want to translate your checkout page's text. To see requirements for naming and deploying these translation files, see [The Schema](https://developer.bigcommerce.com/stencil-docs/localization/translation-keys#the-schema).
 
 3. Replace the keys' values with appropriate phrases in each file's target language.
 

--- a/docs/stencil-docs/localization/multi-language-checkout.md
+++ b/docs/stencil-docs/localization/multi-language-checkout.md
@@ -83,7 +83,8 @@ You can provide values for all of checkout's supported translation keys – for 
 
 1. Download and unzip a local copy of the [opt-checkout-en.json.zip file](https://storage.googleapis.com/bigcommerce-production-dev-center/template-files/opt-checkout-en.json.zip), also linked above in [Browsing Hidden Translation Keys](/stencil-docs/localization/translation-keys).
 
-2. Copy and paste the whole file's contents into your theme's `en.json` file and into the `.json` file for each language you want to translate your checkout page's text. To see requirements for naming and deploying these translation files, see [The Schema](https://developer.bigcommerce.com/stencil-docs/localization/translation-keys#the-schema).
+2. Copy and paste the whole file's contents into your theme's `en.json` file and into the `.json` file for each language you want to translate your checkout page's text. To see requirements for naming and deploying these translation files, see the [schema section](https://developer.bigcommerce.com/stencil-docs/localization/translation-keys#the-schema).
+
 
 3. Replace the keys' values with appropriate phrases in each file's target language.
 


### PR DESCRIPTION
Under Adding Your Own Translation Values, the Internationalization section link needed to go to a different section

# [DEVDOCS-1985](https://jira.bigcommerce.com/browse/DEVDOCS-1985)

## What changed?
updated Internationalization section link