### PR TITLE
Added a link

### DIFF
--- a/docs/stencil-docs/developing-further/google-analytics-enhanced-ecommerce.md
+++ b/docs/stencil-docs/developing-further/google-analytics-enhanced-ecommerce.md
@@ -43,7 +43,7 @@ If you would like to implement Data Tags on your custom theme and do not already
 ### Prerequisites
 * [BigCommerce Store](https://support.bigcommerce.com/s/article/Starting-a-Bigcommerce-Trial)
 * [Optimized One-Page Checkout enabled](https://support.bigcommerce.com/s/article/Optimized-Single-Page-Checkout)
-* Cornerstone theme installed
+* [Cornerstone theme installed](https://developer.bigcommerce.com/stencil-docs/getting-started/about-stencil#cornerstone)
 
 ### Include the Enhanced ECommerce Property
 


### PR DESCRIPTION
Needed to add a link to _Cornerstone theme installed_ as the other prerequisites are all links
https://developer.bigcommerce.com/stencil-docs/developing-further/updates/google-analytics-enhanced-ecommerce

# [DEVDOCS-1985](https://jira.bigcommerce.com/browse/DEVDOCS-1985)

## What changed?
Ticket (DEVDOCS-1985) is closed but I couldn't find an open ticket to put this under.  All prerequisites are links now