### PR TITLE
Update passwordless login per review

### DIFF
--- a/docs/api-docs/customers/passwordless-login.md
+++ b/docs/api-docs/customers/passwordless-login.md
@@ -2,20 +2,20 @@
 
 <div class="otp" id="no-index">
 
-### On This Page
-- [Logging in Customers Via Email Link](#logging-in-customers-via-email-link)
-- [Sending The Request](#sending-the-request)
-- [Additional Resources](#additional-resources)
+### On this Page
+- [Logging in customers via email link](#logging-in-customers-via-email-link)
+- [Sending the request](#sending-the-request)
+- [Additional resources](#additional-resources)
 </div>
 
-## Logging in Customers Via Email Link
+## Logging in customers via email link
 Your application can send shoppers a one-time link via email that will sign them in to their [storefront account](https://support.bigcommerce.com/s/article/Customer-Account-Creation).
 
 Use cases for this include:
 * Reducing friction for customers, allowing them to proceed without needing to reset their passwords
 * An alternate method for signing in customers versus using the [Customer Login API](https://developer.bigcommerce.com/api-docs/customers/customer-login-api)
 
-## Sending The Request
+## Sending the request
 
 Send a `POST` request to 
 `{store-url}/login.php?action=passwordless_login`
@@ -51,8 +51,8 @@ Example:
 
 Upon receiving a successful `POST` request, BigCommerce will send a response that contains:
 
-* `expiry`: The time in seconds during which the login link is valid
-* `sent_email`: A value of `sign_in` indicates BigCommerce sent the login link to the customer via the email provided. A value of `password_reset` means BigCommerce emailed the customer a link with password reset instructions because they were previously flagged as needing to reset their password.
+* `expiry`: The time in seconds during which the login link is valid.
+* `sent_email`: A value of `sign_in` indicates BigCommerce sent the login link to the customer via the email provided. A value of `password_reset` means the customer requested a sign-in link, however BigCommerce sent a reset password email instead. 
 
 Example:
 


### PR DESCRIPTION
I also fixed some section headings.

# [DEVDOCS-2032](https://jira.bigcommerce.com/browse/DEVDOCS-2032)

## What changed?
I resolved comments given by Austin in PR-513.
Luis Sanchez said the following:
It means the customer requested a sign in link, but because it's been flagged as "reset password on next login", they will receive instead a reset password email