### PR TITLE
Updated Orders-api-overview.md

### DIFF
--- a/docs/api-docs/orders/orders-api-overview.md
+++ b/docs/api-docs/orders/orders-api-overview.md
@@ -563,7 +563,7 @@ We will go over creating a shipment for an order, shipping quotes, shipping carr
 * order_address_id
 * items
 
-Once an Order has products, a billing address and at least one shipping address a order shipment can be created. Order shipments are a way to mark an order as shipped with the shipping information.
+Once an order has products, a billing address, and at least one shipping address, you can create an order shipment. Order shipments are a way to mark an order as shipped with the shipping information. You can create multiple shipments for an order by specifying a subset of products or product quantities in each POST request.
 
 To get the `order_address_id`  use the ID returned in [Order Shipping Address](https://developer.bigcommerce.com/api-reference/orders/orders-api/order-shipping-addresses/getallshippingaddresses).
 


### PR DESCRIPTION
Updated per DEVDOCS-2069, added clarification to the _Create an order shipment_ section

# [DEVDOCS-2069](https://jira.bigcommerce.com/browse/DEVDOCS-2069)

## What changed?
Fixed the passive voice in the sentence and added the following:
You can create multiple shipments for an order by specifying a subset of products or product quantities in each POST request.