### PR TITLE
Update recaptcha-two.md

### DIFF
--- a/docs/legacy/blueprint-themes/recaptcha-two.md
+++ b/docs/legacy/blueprint-themes/recaptcha-two.md
@@ -89,13 +89,6 @@ var RecaptchaOptions = {
 
 In each of the three template files, add the following script tag to the top of the page.
 
-
-<div class="HubBlock-header">
-    <div class="HubBlock-header-title flex items-center">
-        <div class="HubBlock-header-name">Script Tag to Remove</div>
-    </div><div class="HubBlock-header-subtitle"></div>
-</div>
-
 <!--
 title: "Script Tag to Update"
 subtitle: ""
@@ -105,6 +98,12 @@ lineNumbers: true
 ```html
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 ```
+
+<div class="HubBlock-header">
+    <div class="HubBlock-header-title flex items-center">
+        <div class="HubBlock-header-name">Script Tag to Remove</div>
+    </div><div class="HubBlock-header-subtitle"></div>
+</div>
 
 Then replace the "before" code block just below with the simplified "after" code that follows.
 


### PR DESCRIPTION
@uwikaiddi  This got merged incorrectly. The "reCAPTCHA Script to Update" section should include the next code snippet, but it is shown in the next section under "Script Tag to Remove" by mistake. The code snippet is:

`<script src="https://www.google.com/recaptcha/api.js" async defer></script>`

I moved the title of "Script Tag to Remove" section to reflect this change.

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* thing_that_changed