### PR TITLE
Link to the newest API in the deprecation section, add V3 Redirects to available APIs

### DIFF
--- a/docs/api-docs/getting-started/available-apis.md
+++ b/docs/api-docs/getting-started/available-apis.md
@@ -104,6 +104,7 @@ Like the **V2 API**, BigCommerce's **V3 REST API** exposes many endpoints develo
 |  [Product Options](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/product-options) | Create and manage product variant options | `/catalog/products/{id}/options` |
 |  [Product Variants](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/product-variants) | Create and manage product variants | `/catalog/products/{id}/variants` |
 |  [Product Videos](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/product-videos) | Create and manage product videos | `/catalog/products/{id}/videos` |
+|  [Redirects](https://developer.bigcommerce.com/api-reference/storefront/redirects) | Manage 301 Redirects for Storefronts | `/storefront/redirects` |
 |  [Scripts](https://developer.bigcommerce.com/api-reference/store-management/scripts) | Add client-side code to a store | `/content/scripts` |
 |  [Sites](https://developer.bigcommerce.com/api-reference/cart-checkout/sites-routes-api) | Manage sites and routing for headless storefronts | `/sites` |
 |  [Storefront API Token](https://developer.bigcommerce.com/api-reference/cart-checkout/storefront-api-token/api-token) | Create Auth Tokens for use with Storefront APIs | `/api-token` |

--- a/docs/api-docs/getting-started/available-apis.md
+++ b/docs/api-docs/getting-started/available-apis.md
@@ -300,13 +300,13 @@ Sunset endpoints will be phased out and removed from the API. Once sunset, the e
 
 |Endpoint|Alternative |
 |-|-|
-|`/v2/brands`| `/v3/catalog/brands`|
-|`/v2/categories`| `/v3/catalog/categories`|
-|`/v2/customers`| `/v3/customers`|
+|`/v2/brands`| [`/v3/catalog/brands`](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/brands/getbrands)|
+|`/v2/categories`| [`/v3/catalog/categories`](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/category/getcategories)|
+|`/v2/customers`| [`/v3/customers`](https://developer.bigcommerce.com/api-reference/customer-subscribers/v3-customers-api)|
 |`/v2/options`| In V3, `options` and `modifiers` are attached directly to the product. Use `options` and `modifiers` together to access the contents of the former V2 `options` response.|
-|`/v2/option_sets`| `option_sets` endpoint is not available in the V3 API.|
-|`/v2/products `| `/v3/catalog/products`|
-|`/v2/redirects/`|`/v3/storefront/redirects`|
+|`/v2/option_sets`| `option_sets` endpoint is intentionally not available in the V3 API. See [V2 vs V3 Catalog APIs](https://developer.bigcommerce.com/legacy/v2-products/v2-v3) for more information.|
+|`/v2/products `| [`/v3/catalog/products`](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/products/getproducts)|
+|`/v2/redirects/`|[`/v3/storefront/redirects`](https://developer.bigcommerce.com/api-reference/storefront/redirects)|
 
 **V2 Sunsets**
 


### PR DESCRIPTION
## What changed?
* For each deprecated API, link to the newest API that should be used instead
* Add V3 Redirects to list of available V3 APIs