### PR TITLE
Update bundling and pushing

### DIFF
--- a/docs/stencil-docs/deploying-a-theme/bundling-and-pushing.md
+++ b/docs/stencil-docs/deploying-a-theme/bundling-and-pushing.md
@@ -22,7 +22,6 @@ Follow the link for your scenario:
 
 If you downloaded a refreshed version of Stencil's default Cornerstone theme: Run `npm install` in the theme directory to install refreshed JavaScript dependencies, as outlined in [Installing Stencil](/stencil-docs/getting-started/installing-stencil#installing_installing-stencils-js-utilities).
 
-If you downloaded a different Marketplace theme with a version lower than 1.10.0, run `jspm install` in the theme directory.
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">


### PR DESCRIPTION
# [DEVDOCS-2064](https://jira.bigcommerce.com/browse/DEVDOCS-2064)

## What changed?
I removed one last occurrence of jspm in dev docs.  This is the last one I found when did a search.