### PR TITLE
Fix examples in Variables helpers

### DIFF
--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -859,7 +859,7 @@ Save a variable for later use in the template.
 #### Example
 
 ```handlebars
-{{assignVar foo = 10}}
+{{assignVar "foo" 10}}
 ```
 
 [See it in Cornerstone](https://github.com/bigcommerce/cornerstone/search?l=HTML&q=assignVar).
@@ -871,7 +871,7 @@ Get a variable set by [assignVar](#assignVar).
 #### Example
 
 ```handlebars
-{{getVar foo}}
+{{getVar "foo"}}
 ```
 
 [See it in Cornerstone](https://github.com/bigcommerce/cornerstone/search?l=HTML&q=getVar).
@@ -883,7 +883,7 @@ Decrement variable assigned by [assignVar](#assignVar) by 1.
 #### Example
 
 ```handlebars
-{{decrementVar foo}}
+{{decrementVar "foo"}}
 ```
 
 [See it in Cornerstone](https://github.com/bigcommerce/cornerstone/search?l=HTML&q=decrementVar).
@@ -895,7 +895,7 @@ Increment variable assigned by [assignVar](#assignVar) by 1.
 #### Example
 
 ```handlebars
-{{incrementVar foo}}
+{{incrementVar "foo"}}
 ```
 
 [See it in Cornerstone](https://github.com/bigcommerce/cornerstone/search?l=HTML&q=incrementVar).


### PR DESCRIPTION
Variables helpers (assignVar, getVar, decrementVar, incrementVar) currently have invalid examples. This commit fixes these examples.

With the current example, the console returns "assignVar helper key must be a string". The updated example is valid.

## What changed?
* Example code for assignVar
* Example code for getVar
* Example code for decrementVar
* Example code for incrementVar