### PR TITLE
DEVDOCS-2133: Update Webhooks Retries Info

### DIFF
--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -17,7 +17,7 @@
 
 Webhooks notify applications when specific events occur on a BigCommerce store. For example when:
 
-* an order is created, 
+* an order is created,
 * a product's inventory changes
 * an item is added to a shopper's cart
 
@@ -45,7 +45,7 @@ Accept: application/json
 
 [![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/webhooks/webhooks/createwebhooks#requestrunner)
 
-**Response**  
+**Response**
 
 ```json
 {
@@ -64,7 +64,7 @@ Accept: application/json
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">
 <div class="HubBlock-content">
-    
+
 <!-- theme: warning -->
 
 ### Note
@@ -93,7 +93,7 @@ When a webhook is triggered, BigCommerce will `POST` a light payload containing 
  }
 ```
 
-A request can then be made to [/orders/{id}](https://developer.bigcommerce.com/api-reference/store-management/orders/orders/getanorder) to obtain full order details. 
+A request can then be made to [/orders/{id}](https://developer.bigcommerce.com/api-reference/store-management/orders/orders/getanorder) to obtain full order details.
 
 For more information on specific webhook events and their payloads, see [Webhook Events](https://developer.bigcommerce.com/api-docs/getting-started/webhooks/webhook-events).
 
@@ -105,9 +105,9 @@ Need to set up a quick webhook destination URL for testing? See [Tools for Debug
 
 ## Callback retry mechanism
 
-The webhooks service will do its best to deliver events to the destination callback URI. It is best practice for the application to respond to the callback before taking any other action that would slow its response. Doing otherwise triggers BigCommerce's callback retry mechanism. 
+The webhooks service will do its best to deliver events to the destination callback URI. It is best practice for the application to respond to the callback before taking any other action that would slow its response. Doing otherwise triggers BigCommerce's callback retry mechanism.
 
-The webhook service may send many payloads to a single URI in quick succession. Because of this, we use a sliding scale across a **two minute window** to calculate a callback response success rate for each remote destination. When the webhook service receives a `2xx` response, the destination's success count is increased. If there's no response or the remote server times out, the destination's failure count is increased. Based on these two numbers, a success ratio is calculated. 
+The webhook service may send many payloads to a single URI in quick succession. Because of this, we use a sliding scale across a **two minute window** to calculate a callback response success rate for each remote destination. When the webhook service receives a `2xx` response, the destination's success count is increased. If there's no response or the remote server times out, the destination's failure count is increased. Based on these two numbers, a success ratio is calculated.
 
 The following process will determine whether the destination URI gets blacklisted:
 
@@ -120,26 +120,26 @@ Once a domain is no longer blacklisted, all new webhook requests will be sent as
 
 The webhook dispatcher will then attempt several retries (at increasing intervals) until the maximum retry limit is reached.
 
-**Retry Intervals**:
-* `60` seconds after the most recent failure  
-* `180` seconds after the most recent failure  
-* `180` seconds after the most recent failure  
-* `300` seconds after the most recent failure  
-* `600` seconds after the most recent failure  
-* `900` seconds after the most recent failure  
-* `1800` seconds after the most recent failure  
-* `3600` seconds after the most recent failure  
-* `7200` seconds after the most recent failure  
-* `21600` seconds after the most recent failure  
-* `50400` seconds after the most recent failure  
-* `86400` seconds (24 hours) after the most recent failure
+|Queue|Interval|
+|-|-|
+|`dispatches.retries.60`|Retries after 60 seconds|
+|`dispatches.retries.180`|Retries after 180 seconds|
+|`dispatches.retries.300`|Retries after 300 seconds|
+|`dispatches.retries.600`|Retries after 600 seconds|
+|`dispatches.retries.900`|Retries after 900 seconds|
+|`dispatches.retries.1800`|Retries after 1800 seconds|
+|`dispatches.retries.3600`|Retries after 3600 seconds|
+|`dispatches.retries.7200`|Retries after 7200 seconds|
+|`dispatches.retries.21600`|Retries after 21600 seconds|
+|`dispatches.retries.50400`|Retries after 50400 seconds|
+|`dispatches.retries.86400`|Retries after 86400 seconds|
 
 After the final retry attempt (cumulatively **48 hours** after the first delivery attempt), the webhook will be deactivated, and an email will be sent to the email address registered for the subscribing app. To reactivate the webhook, set `is_active`  back to `true` by making a `PUT` request to `/hooks/{id}`.
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">
 <div class="HubBlock-content">
-    
+
 ### Note
 > * A domain's success rate for a given sliding window is not calculated until `100` webhook requests are sent - this means the domain will not be blacklisted for the first `100` webhooks sent within the time window (regardless of response), as all webhooks are sent until the minimum threshold has been reached for the current time window.
 > * The webhook dispatcher determines whether retries are needed based on responses from the subscribed domain as a whole, not by specific hooks. For example, `domain.com/webhook-1` and `domain.com/webhook-2` will affect each other for failures and retries, as both URLs belong to the same domain.

--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -107,7 +107,8 @@ Need to set up a quick webhook destination URL for testing? See [Tools for Debug
 
 The webhooks service will do its best to deliver events to the destination callback URI. It is best practice for the application to respond to the callback before taking any other action that would slow its response. Doing otherwise triggers BigCommerce's callback retry mechanism.
 
-The webhook service may send many payloads to a single URI in quick succession. Because of this, we use a sliding scale across a **two minute window** to calculate a callback response success rate for each remote destination. When the webhook service receives a `2xx` response, the destination's success count is increased. If there's no response or the remote server times out, the destination's failure count is increased. Based on these two numbers, a success ratio is calculated.
+The webhook service may send many payloads to a single URI in quick succession. Because of this, we use a sliding scale across a ** two-minute window** to calculate a callback response success rate for each remote destination. When the webhook service receives a `2xx` response, the destination's success count is increased. If there's no response or the remote server times out, the destination's failure count is increased. Based on these two numbers, a success ratio is calculated.
+
 
 The following process will determine whether the destination URI gets blacklisted:
 


### PR DESCRIPTION
# [DEVDOCS-2133](https://jira.bigcommerce.com/browse/DEVDOCS-2133)

## What changed?
* Updated webhooks retries intervals.