### PR TITLE
Update about-webhooks.md

### DIFF
--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -149,13 +149,16 @@ After the final retry attempt (cumulatively **48 hours** after the first deliver
 </div>
 </div>
 
+### Uninstalling app
+
+To avoid accumulating unused webhooks, BigCommerce automatically deactivates registered webhooks on app uninstall.
+
 ## Security
 
 To ensure webhook callback requests are secure, BigCommerce takes the following precautions:
 
 * Webhook payloads contain minimal information about the store and event
 * Webhook payloads are sent over **TLS-encrypted** connection
-* Registered webhooks are automatically deactivated in our system on app uninstall
 * Create Webhook requests accept an optional header object which can be used to authenticate callbacks requests
 
 **POST requests that includes header object**

--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -149,7 +149,7 @@ After the final retry attempt (cumulatively **48 hours** after the first deliver
 </div>
 </div>
 
-### Uninstalling app
+### Post app uninstall actions
 
 To avoid accumulating unused webhooks, BigCommerce automatically deletes registered webhooks on app uninstall.
 

--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -151,7 +151,7 @@ After the final retry attempt (cumulatively **48 hours** after the first deliver
 
 ### Uninstalling app
 
-To avoid accumulating unused webhooks, BigCommerce automatically deactivates registered webhooks on app uninstall.
+To avoid accumulating unused webhooks, BigCommerce automatically deletes registered webhooks on app uninstall.
 
 ## Security
 

--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -2,7 +2,7 @@
 
 <div class="otp" id="no-index">
 
-### On this Page
+### On this page
 
 - [Creating a webhook](#creating-a-webhook)
 - [Callback payload](#callback-payload)
@@ -153,9 +153,9 @@ After the final retry attempt (cumulatively **48 hours** after the first deliver
 
 To ensure webhook callback requests are secure, BigCommerce takes the following precautions:
 
-
 * Webhook payloads contain minimal information about the store and event
 * Webhook payloads are sent over **TLS-encrypted** connection
+* Registered webhooks are automatically deactivated in our system on app uninstall
 * Create Webhook requests accept an optional header object which can be used to authenticate callbacks requests
 
 **POST requests that includes header object**


### PR DESCRIPTION
# [DEVDOCS-2289](https://jira.bigcommerce.com/browse/DEVDOCS-2289)

## What changed?

- Updated webhooks documentation to inform partners that registered webhooks are deactivated upon app uninstall
- This change was added in the Security section