### PR TITLE
Remove mention of OAuth scopes for storefront APIs

### DIFF
--- a/docs/api-docs/cart-and-checkout/cart-and-checkout-overview.md
+++ b/docs/api-docs/cart-and-checkout/cart-and-checkout-overview.md
@@ -19,14 +19,6 @@
 
 The Storefront APIs are for managing the contents of a shopper's cart and checkout using JavaScript in the context of a storefront session.
 
-### Prerequisites:
-The following [OAuth scopes](https://developer.bigcommerce.com/api-docs/getting-started/authentication#authentication_oauth-scopes) are required:
-
-* Carts
-* Checkouts
-* Products
-* Checkout Content
-* Order Transactions
 
 ### When to use the Storefront APIs
 


### PR DESCRIPTION
## What changed?
* Removed mention of needing OAuth scopes for Storefront APIs; they require no scopes, as they are authenticated by the storefront session cookie.