### PR TITLE
Remove mention of Akamai image manager

### DIFF
--- a/docs/stencil-docs/storefront-customization/theme-assets.md
+++ b/docs/stencil-docs/storefront-customization/theme-assets.md
@@ -240,23 +240,6 @@ This subdirectory’s children contain CSS for the following page elements.
 | toggleLink  | Styles for collapsible/expandable components  |
 |writeReview   | Styles for product-review submission form  |
 
-<div class="HubBlock--callout">
-<div class="CalloutBlock--info">
-<div class="HubBlock-content">
-
-<!-- theme:info -->
-
-### Akamai image manager
-> For Stencil themes only, images that use the default zoom library pass through Akamai Image Manager. This chooses the best image to serve based on device. To bypass the image optimization, include `imbypass=on` as a query parameter in the image url. This will serve un-optimized images.
-
-* `<img src="{{cdn 'webdav:img/image.jpg?imbypass=on'}}">`
-* `<img src="{{getImage settings.store_logo.image 'logo_size'}}?imbypass=on">`
-* `<img src="{{cdn 'assets/img/image.jpg?imbypass=on'}}">`
-
-</div>
-</div>
-</div>
-
 ## Resources
 
 ### Sample apps


### PR DESCRIPTION
## What changed?
* Remove mention of Akamai Image Manager optimizations as it's [no longer a thing.](https://developer.bigcommerce.com/changelog#posts/per-device-image-resizing-based-on-user-agent-has-been-disabled-use-srcset)

FYI @chrisboulton 