### PR TITLE
Updating Node Version

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -26,10 +26,10 @@ To install Stencil CLI and it's dependencies on Mac, open a terminal and run the
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
 
 # Install Stencil CLI supported version of Node.js
-nvm install 10.16
+nvm install 10.17
 
 # Switch to Stencil CLI supported version of Node.js:
-nvm use 10.16
+nvm use 10.17
 
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli
@@ -60,7 +60,7 @@ iex ((New-Object System.Net.WebClient).DownloadString("https://chocolatey.org/in
 choco install git
 
 # Install nvm-windows and stencil compatible node.js
-choco install nvm; nvm install 10.16; nvm use 10.16
+choco install nvm; nvm install 10.17; nvm use 10.17
 
 #####################################################################################
 # Close PowerShell and re-open as admin
@@ -99,7 +99,7 @@ If you're a pro at installing and configuring Python and Node.js environments on
 **Required Dependencies:**
 * [Git](https://git-scm.com/downloads) - required to run npm install
 * [Python 2.7.x](https://www.python.org/downloads/) - required to build some dependencies
-* [Node.js 10.16 and npm](https://nodejs.org/en/download/releases/) - later versions not currently supported on Windows
+* [Node.js 10.17 and npm](https://nodejs.org/en/download/releases/) - later versions not currently supported on Windows
 * [Visual C++ Build Tools 2015](https://www.npmjs.com/package/windows-build-tools) - required to compile some dependencies
 
 Once they're installed and configured, use `npm` to install Stencil CLI:
@@ -136,7 +136,7 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | b
 source ~/.bashrc
 
 # Explicitly install supported node version
-nvm install 10.16
+nvm install 10.17
 
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli


### PR DESCRIPTION
Updating to use node 10.17

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* Updating node installation instructions to reference 10.17 as running under 10.16 returns `Error: You are running an unsupported version of node. Please upgrade to ^10.17 || ^12`.

## Notes: 
* Tested on Mac, untested on windows (But I assume 10.16 isn't supported there either).
* On a basic `stencil init` check 10.17 appears to work fine. No idea if it works beyond that, I used 12 when the error gave me the suggestion to.
* It would probably be better to suggest installing the **newest possible version** for each platform rather than the oldest if there's no technical reasons to suggest the older version. 12.19 worked fine on Mac for my needs; but I'm not clear on the windows support there, and it seemed easier to keep this PR to the 10.17 branch to avoid a big version change without fuller testing.
