### PR TITLE
Update Checkout-sdk.md

### DIFF
--- a/docs/api-docs/cart-and-checkout/checkout-sdk.md
+++ b/docs/api-docs/cart-and-checkout/checkout-sdk.md
@@ -2,7 +2,7 @@
 
 <div class="otp" id="no-index">
 
-### On This Page
+### On this page
 - [What Can I Do with the SDK?](#what-can-i-do-with-the-sdk)
 - [Where Can I Get the SDK?](#where-can-i-get-the-sdk)
 - [Support and Customization](#support-and-customization)
@@ -15,7 +15,7 @@ It allows a developer to create a custom checkout experience to move a customer 
 The SDK handles all the ‘heavy-lifting’ such as customer login, getting shipping quotes and submitting payment for an order.
 With the Checkout JS SDK, you can build a [custom checkout presentation](https://github.com/bigcommerce/checkout-sdk-js-example) layer in popular frontend frameworks such as React.
 
-## What Can I Do with the SDK?
+## What can I do with the SDK?
 
 -   It can initialize payment and shipping providers that require client-side setup through a common interface. Below are some examples of these providers:
 
@@ -45,9 +45,9 @@ The Checkout JS SDK allows you to present the checkout process to the shopper in
 However, the Checkout JS SDK does not allow you to change the underpinnings of the checkout - you must still conform to the model of the Checkout API underpinning the SDK to complete a Checkout and create an Order in BigCommerce.
 The SDK does not allow you to implement custom payment, shipping, or tax calculation providers into the checkout - instead, the configured providers for these services on a given store are expressed via our Checkout API.
 
-## Where Can I Get the SDK?
+## Where can I get the SDK?
 The Checkout JS SDK and associated documentation is available from the [BigCommerce SDK Repo.](https://github.com/bigcommerce/checkout-sdk-js)
 
-## Support and Customization
+## Support and customization
 - Enterprise clients can reach out to their account manager to review services and resources available.
 - For more on our design policy please visit [Design Support](https://forum.bigcommerce.com/s/article/BigCommerce-Design-Policy#support).

--- a/docs/api-docs/cart-and-checkout/checkout-sdk.md
+++ b/docs/api-docs/cart-and-checkout/checkout-sdk.md
@@ -24,7 +24,6 @@ With the Checkout JS SDK, you can build a [custom checkout presentation](https:/
     -   Stripe
     -   Square
     -   Amazon
-    -   Klarna
 
 -   It provides a JavaScript interface for interacting with the web API.
     -   Fetch and submit resources:


### PR DESCRIPTION
# [DEVDOCS-2375](https://jira.bigcommerce.com/browse/DEVDOCS-2375)

## What changed?
While listening to the Checkout Domain Overview Demo, I learned that Klarna has been removed.  I went to our dev documentation and noticed that we refer to Klarna in the Checkout SDK article.  I am thinking that it should be removed.  Can you confirm? Thank you for the video, it was very helpful.