### PR TITLE
Create a Product Review Incorrect Documentation

### DIFF
--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -381,7 +381,7 @@ X-Auth-Token: {{ACCESS_TOKEN}}
   "text": "This coffee mug kept my liquids hot for several hours.",
   "status": "pending",
   "rating": 5,
-  "email": "testing@bigcommerce.com",
+  "email": "", //This throws an error 
   "name": "BigCommerce",
   "date_reviewed": "2018-07-20T17:45:13+00:00"
 }


### PR DESCRIPTION
In the Request body it says:
email: The email of the reviewer. Must be a valid email, or an empty string.

But passing in an empty string throws an error.

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* thing_that_changed