### PR TITLE
Fix #sample-configuration anchor

### DIFF
--- a/docs/api-docs/channels/channels-extending-existing.md
+++ b/docs/api-docs/channels/channels-extending-existing.md
@@ -49,7 +49,7 @@ To be visible in Channel Manager once installed, apps must meet certain requirem
 
 - Update UI to use [BigDesign](https://developer.bigcommerce.com/big-design/) and the general design patterns and user flows demonstrated in the sample app (shown in the screenshots below) with channel name, icon, and menu nav sections.
 
-- Include sections in the [Channel API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api) request in the [app config object](#sample-channel-app-configuration).
+- Include sections in the [Channel API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api) request in the [app config object](#sample-configuration).
 
 ### Channel app import section
 


### PR DESCRIPTION
## What changed?
"app config object" pointed to `#sample-channel-app-configuration`, changed to `#sample-configuration`