### PR TITLE
Fix the custom template JS mapping path-separator slashes

### DIFF
--- a/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
@@ -300,7 +300,7 @@ Finally, use the customClasses function in `assets/js/app.js` to map the custom 
 
 ```js
 const customClasses = {
-    'pages/custom/product/customProd': () => import('./theme/custom')
+    'pages/custom/product/customProd': () => import('./theme/custom'), // Mac/Linux
     'pages\\custom\\product\\customProd': () => import('./theme/custom'), // Windows
 };
 /**

--- a/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
@@ -301,6 +301,7 @@ Finally, use the customClasses function in `assets/js/app.js` to map the custom 
 ```js
 const customClasses = {
     'pages/custom/product/customProd': () => import('./theme/custom')
+    // 'pages\\custom\\product\\customProd': () => import('./theme/custom') // for windows machine
 };
 /**
  * This function gets added to the global window and then called

--- a/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
@@ -301,7 +301,7 @@ Finally, use the customClasses function in `assets/js/app.js` to map the custom 
 ```js
 const customClasses = {
     'pages/custom/product/customProd': () => import('./theme/custom')
-    // 'pages\\custom\\product\\customProd': () => import('./theme/custom') // for windows machine
+    'pages\\custom\\product\\customProd': () => import('./theme/custom'), // Windows
 };
 /**
  * This function gets added to the global window and then called


### PR DESCRIPTION
Replace the single forward slash(/) path with a double backward-slash(\\) path for Windows machine, fixes the unsuccessful issue on the OS

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* added a commented line of code meant to be used on a Windows machine for local development
* for the local changes to work on cloud store, the path separator has to be reverted back to the forward slash
* the changes are only for local development, preview, and testing