### PR TITLE
DEVDOCS-2579: Fix spelling error

### DIFF
--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -1007,7 +1007,7 @@ Converts a JavaScript object into a JSON string.
 
 #### Parameters
 
-- `object` {Object}: A JavaScrip object.
+- `object` {Object}: A JavaScript object.
 
 #### Example
 


### PR DESCRIPTION
# [DEVDOCS-2579](https://jira.bigcommerce.com/browse/DEVDOCS-2579)

## What changed?
* Fixed "JavaScript" spelling error