### PR TITLE
docs(shipping): DEVDOCS-2618 Update Shipping Providers API Docs

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -49,7 +49,8 @@ Please include:
 - App ID (see below)
 - Email
 - Description of the app
-- Your service URLs (see below)
+- [Your service URLs](#your-service-urls) 
+
 
 To get your app ID, create an app in [Developer Tools](https://devtools.bigcommerce.com/), and fill out the information on [Step 3 Technical](https://developer.bigcommerce.com/api-docs/apps/guide/publishing#add-technical-information). In the URL, the app will have a unique ID. Send the unique ID in exchange for a carrier ID to test the app.
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -49,6 +49,7 @@ Please include:
 - App ID (see below)
 - Email
 - Description of the app
+- Your service URLs (see below)
 
 To get your app ID, create an app in [Developer Tools](https://devtools.bigcommerce.com/), and fill out the information on [Step 3 Technical](https://developer.bigcommerce.com/api-docs/apps/guide/publishing#add-technical-information). In the URL, the app will have a unique ID. Send the unique ID in exchange for a carrier ID to test the app.
 


### PR DESCRIPTION
## What
Added content to clarify the required values that external developers should send BC in order for us to create a shipping provider configuration for them.

Specifically, added the following point to the **Sign-up** section of the **Shipping Providers** [API Docs](https://developer.bigcommerce.com/api-docs/providers/shipping).

> - Your service URLs (see below)

## Why
External developers were emailing us requesting a shipping provider config to be set up without including their service URLs, requiring BC to email them back requesting this information before we could complete creation of their shipping provider configuration.

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/110903186-2c188880-835b-11eb-9dd6-294bdf7ceb61.png)

### After
![image](https://user-images.githubusercontent.com/80028746/110903143-186d2200-835b-11eb-8b41-bd0296566194.png)