### PR TITLE
Devdocs 2650 update shipping providers docs developing apps section

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -49,6 +49,7 @@ Please include:
 - App ID (see below)
 - Email
 - Description of the app
+- Your service URLs (see below)
 
 To get your app ID, create an app in [Developer Tools](https://devtools.bigcommerce.com/), and fill out the information on [Step 3 Technical](https://developer.bigcommerce.com/api-docs/apps/guide/publishing#add-technical-information). In the URL, the app will have a unique ID. Send the unique ID in exchange for a carrier ID to test the app.
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -95,7 +95,11 @@ Example:
 
 ## Developing the app
 
-The intended use of the Shipping Provider API is to create an app that merchants can install on their store. The Shipping Provider API can be a standalone app or part of an existing application. When developing the app, there are a few things to consider, which are listed below.
+Shipping providers are required to build a BigCommerce [single-click app](https://developer.bigcommerce.com/api-docs/apps/guide/types#single-click) in order to utilise the Shipping Provider API to provide shipping quotes. A BigCommerce app provides many benefits to merchants, for example, it enables shipping providers to promote their solution in the BigCommerce apps marketplace, ask for merchant authorisation of API scopes during app install, as well as enable configuration of shipping provider settings and/or order fulfilment via an iFrame in the BigCommerce control panel.
+
+Review our [introduction to building apps](https://developer.bigcommerce.com/api-docs/apps/guide/intro) guide and use the sidebar to explore topics including but not limited to; [types of apps](https://developer.bigcommerce.com/api-docs/apps/guide/types), [managing apps in the dev portal](https://developer.bigcommerce.com/api-docs/apps/guide/developer-portal), [implementing OAuth](https://developer.bigcommerce.com/api-docs/apps/guide/auth) and [designing the UI](https://developer.bigcommerce.com/api-docs/apps/guide/ui).
+
+Make sure to also review our [app development best practices](https://developer.bigcommerce.com/api-docs/apps/guide/best-practices) for some tips.
 
 ## Control Panel installation workflow
 


### PR DESCRIPTION
## What
Updated the "Developing the apps" section of the Shipping Providers docs with additional information links to relevant resources

## Why
Previously, no mentioned that building a single-click app is required, leading to tech partners going down the route of a connector app, which, while is theory is supported is not a scalable approach for mass adoption nor a good onboarding experience for merchants.

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/112422128-81ee2700-8d84-11eb-9cdd-44368a78785a.png)

### After
![image](https://user-images.githubusercontent.com/80028746/112422220-a1854f80-8d84-11eb-8e59-d953061d987b.png)