### PR TITLE
Remove duplicate complexity-limits anchor

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -374,9 +374,6 @@ Use normal Storefront API Tokens. According to the [Principle of least privilege
 
 Use a Customer Impersonation Storefront API Token and store it securely on your server like other secrets. When you need to run requests in the context of a particular Customer (for example, if they've logged in to your application), send their BigCommerce Customer ID along with the request as the `X-Bc-Customer-Id` header.
 
-
-<a id="complexity-limits" class="devdocsAnchor"></a>
-
 ## Pagination
 
 The GraphQL Storefront API follows the [GraphQL Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm) for pagination. If this is your first time working with GraphQL pagination, see [Apollo's Blog Post "Explaining GraphQL Connections"](https://blog.apollographql.com/explaining-graphql-connections-c48b7c3d6976) for an accessible introduction. If you've worked with other GraphQL APIs, pagination on BigCommerce should look familiar.


### PR DESCRIPTION
# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* Removed an `<a>` tag with a `#complexity-limits` ID to stop it from superseding the autogenerated anchor to the Complexity Limits subheading later in the page