### PR TITLE
docs(orders): DEVDOCS-2742 Update Orders Refunds API Docs

### DIFF
--- a/docs/api-docs/orders/order-refunds.md
+++ b/docs/api-docs/orders/order-refunds.md
@@ -301,7 +301,7 @@ Use the V2 Orders Endpoint to get the required ID:
   - `HANDLING` -- Order Address ID
   - `ORDER` -- Order ID
 
-**Will this trigger an email to the merchant?**
+**Will this trigger an email to the shopper?**
 
 Yes, if you configure the store to send an email when an order status changes to _Refunded_ or _Partially Refunded_.
 


### PR DESCRIPTION
# [DEVDOCS-2742](https://jira.bigcommerce.com/browse/DEVDOCS-2742)

## What
Within the [Order Refunds API Docs](https://developer.bigcommerce.com/api-docs/store-management/order-refunds#faq) FAQ section, updated the copy of the below question:
> Will this trigger an email to the merchant?

To instead say:
>Will this trigger an email to the shopper?

## Why
The previous copy was not representative of functionality.

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/114504283-fcb6ad80-9c71-11eb-9243-b8f25eebeda8.png)

### After
![image](https://user-images.githubusercontent.com/80028746/114504252-ef99be80-9c71-11eb-9461-43386c80fd30.png)

## How can this change be undone in case of failure?
Revert this PR.

ping @uwikaiddi @bigcommerce/orders 