### PR TITLE
docs(tax): TAX-1051 Improve partner sandbox store description

### DIFF
--- a/docs/api-docs/provider-apis/tax/overview.md
+++ b/docs/api-docs/provider-apis/tax/overview.md
@@ -58,7 +58,7 @@ Once your tax provider configuration is ready, we'll let you know via email. The
 | Adjust URL                            | Optional                       | URL                          | URL BigCommerce should use for Tax Provider API quote requests.                                       | `https://sampletax.example.com/doc/adjust`        |
 | Void URL                              | Optional                       | URL                          | URL BigCommerce should use for Tax Provider API quote requests.                                       | `https://sampletax.example.com/doc/void`          |
 | **Testing**                               |                                |                              |                                                                                                       |                                                   |
-| Partner sandbox store domain          | Required                       | Domain name                  | Share your partner sandbox store for testing purposes prior to launching your tax provider. Learn how to [create a partner sandbox store here](https://developer.bigcommerce.com/api-docs/partner/getting-started/create-a-sandbox-store).                 | `https://sampletax-test-store.mybigcommerce.com/` |
+| Partner sandbox store domain          | Required                       | Domain name                  | Share your partner sandbox store for testing purposes prior to launching your tax provider. Learn how to [create a partner sandbox store](https://developer.bigcommerce.com/api-docs/partner/getting-started/create-a-sandbox-store).                 | `https://sampletax-test-store.mybigcommerce.com/` |
 
 ### Sandbox tax provider configuration
 

--- a/docs/api-docs/provider-apis/tax/overview.md
+++ b/docs/api-docs/provider-apis/tax/overview.md
@@ -58,7 +58,7 @@ Once your tax provider configuration is ready, we'll let you know via email. The
 | Adjust URL                            | Optional                       | URL                          | URL BigCommerce should use for Tax Provider API quote requests.                                       | `https://sampletax.example.com/doc/adjust`        |
 | Void URL                              | Optional                       | URL                          | URL BigCommerce should use for Tax Provider API quote requests.                                       | `https://sampletax.example.com/doc/void`          |
 | **Testing**                               |                                |                              |                                                                                                       |                                                   |
-| Partner test store domain(s)          | Required                       | Domain name                  | Share your test store domain(s) sow we can test prior to launching your tax provider.                 | `https://sampletax-test-store.mybigcommerce.com/` |
+| Partner sandbox store domain          | Required                       | Domain name                  | Share your partner sandbox store for testing purposes prior to launching your tax provider. Learn how to [create a partner sandbox store here](https://developer.bigcommerce.com/api-docs/partner/getting-started/create-a-sandbox-store).                 | `https://sampletax-test-store.mybigcommerce.com/` |
 
 ### Sandbox tax provider configuration
 


### PR DESCRIPTION
Note: Created a TAX ticket for internal team tracking purposes.

## What
Improved partner sandbox description and introduced a link to creating a partner sandbox store on the following page https://developer.bigcommerce.com/api-docs/providers/tax.

## Why
Partners were creating trial stores for integration testing purposes. The trial store would then expire and they would be blocked from testing their integration until they figured out how to create a partner sandbox store. 

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/117093348-07152480-ada4-11eb-9962-77020f6398c0.png)

### After
![image](https://user-images.githubusercontent.com/80028746/117093420-3f1c6780-ada4-11eb-98f1-5362cd934393.png)

## How can this change be undone in case of failure?
Revert this PR.

ping @bigcommerce/shipping @uwikaiddi 
