### PR TITLE
DEVDOCS-2670: Update Config Meta Usage

### DIFF
--- a/docs/api-docs/channels/building-channel-apps.md
+++ b/docs/api-docs/channels/building-channel-apps.md
@@ -114,6 +114,8 @@ Once created, channels show up in the product list within the control panel so t
 > **Note**
 >
 > - You can find the app ID in the URL when editing the app in [DevTools](https://devtools.bigcommerce.com/). For more information, see [Finding an App's ID](https://developer.bigcommerce.com/api-docs/apps/tutorials/id).
+> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the it's user interface in the BigCommerce control panel works properly.
+> - Select partners who are promoted in the Channel Manager must build an app, and include the app ID in the create channel request.
 
 </div>
 </div>
@@ -273,7 +275,7 @@ To ensure that BigCommerce merchants are able to continue using their existing c
 - Creating orders as they are made on the external channel
 - Updating orders as changes are made on the external channel
 - Reading orders, via API or webhooks, to push any necessary changes/updates made by the merchant in the BigCommerce control panel to the external channel
-- Reading inventory levels via the Products API or webhooks to get up-to-date inventory levels for the channel. This is critical, because orders that impact available inventory can come from other channels including the main storefront. 
+- Reading inventory levels via the Products API or webhooks to get up-to-date inventory levels for the channel. This is critical, because orders that impact available inventory can come from other channels including the main storefront.
 
 
 To do this, integrate the following endpoints:

--- a/docs/api-docs/channels/building-channel-apps.md
+++ b/docs/api-docs/channels/building-channel-apps.md
@@ -114,7 +114,7 @@ Once created, channels show up in the product list within the control panel so t
 > **Note**
 >
 > - You can find the app ID in the URL when editing the app in [DevTools](https://devtools.bigcommerce.com/). For more information, see [Finding an App's ID](https://developer.bigcommerce.com/api-docs/apps/tutorials/id).
-> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the it's user interface in the BigCommerce control panel works properly.
+> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the user interface in the BigCommerce control panel works properly.
 > - Select partners who are promoted in the Channel Manager must build an app, and include the app ID in the create channel request.
 
 </div>

--- a/docs/api-docs/channels/channel-app-requirements.md
+++ b/docs/api-docs/channels/channel-app-requirements.md
@@ -20,7 +20,7 @@ Once approved, channel apps are discoverable on BigCommerce's App Marketplace. A
 All Partners:
 
 - Uses [Channels API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api)
-- [Creates a channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel) upon app installation using the `app_id`
+- [Creates a channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel) upon app installation.
 - Reads and updates channel status via [Channels endpoints](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api)
 - Follows requirements for specific channel type
 
@@ -29,6 +29,22 @@ All Partners:
 Select Partners:
 
 - Uses [Big Design](https://developer.bigcommerce.com/big-design/)
+- Includes `config_meta.app.id` in the [create channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel) request.
+
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+
+> ### Note
+>
+> - You can find the app ID in the URL when editing the app in the [Developer Portal](https://devtools.bigcommerce.com/). For more information, see [Finding an App's ID](https://developer.bigcommerce.com/api-docs/apps/tutorials/id).
+> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the user interface in the BigCommerce control panel works properly.
+> - Select partners who are promoted in the Channel Manager must build an app, and include the app ID in the create channel request.
+
+</div>
+</div>
+</div>
+
 
 ## Storefronts
 

--- a/docs/api-docs/channels/channel-app-requirements.md
+++ b/docs/api-docs/channels/channel-app-requirements.md
@@ -43,8 +43,8 @@ All Partners:
 - Must use [Listings API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api), if supporting per product listings.
 
 <div class="HubBlock--callout">
-<div class="CalloutBlock--info">	
-<div class="HubBlock-content">	
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
 
 <!-- theme: info -->
 

--- a/docs/api-docs/channels/channel-app-requirements.md
+++ b/docs/api-docs/channels/channel-app-requirements.md
@@ -29,7 +29,8 @@ All Partners:
 
 Select Partners:
 
-- Uses [Big Design](https://developer.bigcommerce.com/big-design/)
+- Uses [Big Design](https://developer.bigcommerce.com/big-design/).
+
 - Includes `config_meta.app.id` in the [create channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel) request.
 
 <div class="HubBlock--callout">

--- a/docs/api-docs/channels/channel-app-requirements.md
+++ b/docs/api-docs/channels/channel-app-requirements.md
@@ -21,7 +21,8 @@ All Partners:
 
 - Uses [Channels API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api)
 - [Creates a channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel) upon app installation.
-- Reads and updates channel status via [Channels endpoints](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api)
+- Reads and updates channel status using the [Channels API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api) endpoints.
+
 - Follows requirements for specific channel type
 
 - Contains an onboarding user flow

--- a/docs/api-docs/channels/channel-app-requirements.md
+++ b/docs/api-docs/channels/channel-app-requirements.md
@@ -19,7 +19,8 @@ Once approved, channel apps are discoverable on BigCommerce's App Marketplace. A
 
 All Partners:
 
-- Uses [Channels API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api)
+- Uses [Channels API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api).
+
 - [Creates a channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels/createchannel) upon app installation.
 - Reads and updates channel status using the [Channels API](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api) endpoints.
 

--- a/docs/api-docs/channels/channels-extending-existing.md
+++ b/docs/api-docs/channels/channels-extending-existing.md
@@ -128,6 +128,8 @@ Accept: application/json
 > **Note**
 >
 > - You can find the app ID in the URL when editing the app in the [Developer Portal](https://devtools.bigcommerce.com/). For more information, see [Finding an App's ID](https://developer.bigcommerce.com/api-docs/apps/tutorials/id).
+> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the it's user interface in the BigCommerce control panel works properly.
+> - Select partners who are promoted in the Channel Manager must build an app, and include the app ID in the create channel request.
 
 </div>
 </div>

--- a/docs/api-docs/channels/channels-extending-existing.md
+++ b/docs/api-docs/channels/channels-extending-existing.md
@@ -128,7 +128,7 @@ Accept: application/json
 > **Note**
 >
 > - You can find the app ID in the URL when editing the app in the [Developer Portal](https://devtools.bigcommerce.com/). For more information, see [Finding an App's ID](https://developer.bigcommerce.com/api-docs/apps/tutorials/id).
-> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the it's user interface in the BigCommerce control panel works properly.
+> - `config_meta.app.id` is optional; however, if you're building an app that creates or manages a channel, we recommend including the app ID to ensure the user interface in the BigCommerce control panel works properly.
 > - Select partners who are promoted in the Channel Manager must build an app, and include the app ID in the create channel request.
 
 </div>


### PR DESCRIPTION
# [DEVDOCS-2670](https://jira.bigcommerce.com/browse/DEVDOCS-2670)

## What changed?
* Added lines about config_meta.app.id being optional for create channel requests, but required for select partners. 