### PR TITLE
Update nextjs-commerce-guide.md

### DIFF
--- a/docs/api-docs/building-storefronts/nextjs-commerce-guide.md
+++ b/docs/api-docs/building-storefronts/nextjs-commerce-guide.md
@@ -105,7 +105,7 @@ To get started with Next.js Commerce, you’ll need to deploy a live version dir
 ```bash
 BIGCOMMERCE_STOREFRONT_API_URL=https://store-${STORE_ID}.mybigcommerce.com/graphql
 BIGCOMMERCE_STOREFRONT_API_TOKEN=${STOREFRONT_TOKEN}
-BIGCOMMERCE_STORE_API_URL=https://api.bigcommerce.com/stores/${STORE_ID}
+BIGCOMMERCE_STORE_API_URL=https://api.bigcommerce.com/stores/${STORE_ID}/v3/
 BIGCOMMERCE_STORE_API_TOKEN=${STORE_TOKEN}
 BIGCOMMERCE_STORE_API_CLIENT_ID=${STORE_CLIENT}
 ```


### PR DESCRIPTION
Fixes broken BIGCOMMERCE_STORE_API_URL.

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* BIGCOMMERCE_STORE_API_URL