### PR TITLE
Improve verbiage related to Enterprise API rate limits

### DIFF
--- a/docs/api-docs/getting-started/best-practices.md
+++ b/docs/api-docs/getting-started/best-practices.md
@@ -71,10 +71,12 @@ Apps that authenticate with OAuth are rate-limited based on a quota that is refr
 
 | Plans & sandboxes | Maximum quota |
 | -- | -- | 
-| Enterprise plans and Enterprise sandboxes (Enterprise-Test) | Unlimited (7mil / 30sec)| 
+| Enterprise plans and Enterprise sandboxes (Enterprise-Test) | Unlimited\*| 
 | Pro plans| 60k per hour (450 / 30sec) | 
 | All other sandboxes (Dev/Partner/Employee) | 20k per hour (150 / 30sec)| 
 | Plus & Standard plans| 20k per hour (150 / 30sec) | 
+
+_\* The "Unlimited" rate limit on BigCommerce Enterprise plans means that stores on these plans will not be artificially rate limited on the basis of API-requests-per-unit-of-time. However, there are physical limits to the infrastructure which may limit the maximum throughput of requests on any given API endpoint. BigCommerce reserves the right to limit unreasonable or abusive API activity in the interest platform stability, per our Terms of Service._
 
 Each request to the API consumes one available request from the quota. When an app hits the quota limit, subsequent requests are rejected until the quota is refreshed.
 

--- a/docs/api-docs/getting-started/best-practices.md
+++ b/docs/api-docs/getting-started/best-practices.md
@@ -76,7 +76,8 @@ Apps that authenticate with OAuth are rate-limited based on a quota that is refr
 | All other sandboxes (Dev/Partner/Employee) | 20k per hour (150 / 30sec)| 
 | Plus & Standard plans| 20k per hour (150 / 30sec) | 
 
-_\* The "Unlimited" rate limit on BigCommerce Enterprise plans means that stores on these plans will not be artificially rate limited on the basis of API-requests-per-unit-of-time. However, there are physical limits to the infrastructure which may limit the maximum throughput of requests on any given API endpoint. BigCommerce reserves the right to limit unreasonable or abusive API activity in the interest platform stability, per our Terms of Service._
+_\* The **Unlimited** rate limit on BigCommerce Enterprise plans means that stores on this plan will not be artificially rate-limited on the basis of API-requests-per-unit-of-time. However, there are physical limits to the infrastructure which may limit the maximum throughput of requests on any given API endpoint. BigCommerce also reserves the right to limit unreasonable or abusive API activity in the interest of platform stability, per our [Terms of Service](https://www.bigcommerce.com/terms/api-terms/)._
+
 
 Each request to the API consumes one available request from the quota. When an app hits the quota limit, subsequent requests are rejected until the quota is refreshed.
 

--- a/docs/api-docs/getting-started/best-practices.md
+++ b/docs/api-docs/getting-started/best-practices.md
@@ -76,7 +76,16 @@ Apps that authenticate with OAuth are rate-limited based on a quota that is refr
 | All other sandboxes (Dev/Partner/Employee) | 20k per hour (150 / 30sec)| 
 | Plus & Standard plans| 20k per hour (150 / 30sec) | 
 
-_\* The **Unlimited** rate limit on BigCommerce Enterprise plans means that stores on this plan will not be artificially rate-limited on the basis of API-requests-per-unit-of-time. However, there are physical limits to the infrastructure which may limit the maximum throughput of requests on any given API endpoint. BigCommerce also reserves the right to limit unreasonable or abusive API activity in the interest of platform stability, per our [Terms of Service](https://www.bigcommerce.com/terms/api-terms/)._
+<div class="HubBlock--callout">
+<div class="CalloutBlock--info">
+<div class="HubBlock-content">
+
+### Note
+The **Unlimited** rate limit on BigCommerce Enterprise plans means that stores on this plan will not be artificially rate-limited on the basis of API-requests-per-unit-of-time. However, there are physical limits to the infrastructure which may limit the maximum throughput of requests on any given API endpoint. BigCommerce also reserves the right to limit unreasonable or abusive API activity in the interest of platform stability, per our [Terms of Service](https://www.bigcommerce.com/terms/api-terms/).
+
+</div>
+</div>
+</div>
 
 
 Each request to the API consumes one available request from the quota. When an app hits the quota limit, subsequent requests are rejected until the quota is refreshed.


### PR DESCRIPTION
## What changed?
* Improve verbiage related to Enterprise API rate limits to better describe what "unlimited" means.