### PR TITLE
Update stencil-cli-options-and-commands.md

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -204,7 +204,8 @@ Usage: stencil push [<OPTIONS>]
 |`--version`                    |`-V` | Output the version number                                                           |
 |`--host [HOSTNAME]`            |     | Specify the API host (default: `api.bigcommerce.com`)                               |
 |`--file [<FILENAME>]`          |`-f` | Specify the filename of the bundle to upload                                        |
-|`--save [<FILENAME]`           |`s`  | Specify the filename to save the bundle as                                          |
+|`--save [<FILENAME]`           |`-s` | Specify the filename to save the bundle as                                          |
+|`--channel_id [<CHANNEL_ID>]`  |`-c` | Specify the channel ID of the storefront, if the store has multiple storefronts.    |
 |`--activate [<VARIATIONNAME>]` |`-a` | Skip activation prompt; specify variation or leave blank to select first variation  |
 |`--delete`                     |`-d` | Delete oldest private, non-active theme if upload limit reached                     |
 |`--help`                       |`-h` | Output usage information                                                            |

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -204,7 +204,7 @@ Usage: stencil push [<OPTIONS>]
 |`--version`                    |`-V` | Output the version number                                                           |
 |`--host [HOSTNAME]`            |     | Specify the API host (default: `api.bigcommerce.com`)                               |
 |`--file [<FILENAME>]`          |`-f` | Specify the filename of the bundle to upload                                        |
-|`--save [<FILENAME]`           |`-s` | Specify the filename to save the bundle as                                          |
+|`--save [<FILENAME]`           |`-s` | Specify the filename of the saved bundle                                          |
 |`--channel_id [<CHANNEL_ID>]`  |`-c` | Specify the channel ID of the storefront, if the store has multiple storefronts.    |
 |`--activate [<VARIATIONNAME>]` |`-a` | Skip activation prompt; specify variation or leave blank to select first variation  |
 |`--delete`                     |`-d` | Delete oldest private, non-active theme if upload limit reached                     |

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -205,7 +205,7 @@ Usage: stencil push [<OPTIONS>]
 |`--host [HOSTNAME]`            |     | Specify the API host (default: `api.bigcommerce.com`)                               |
 |`--file [<FILENAME>]`          |`-f` | Specify the filename of the bundle to upload                                        |
 |`--save [<FILENAME]`           |`-s` | Specify the filename of the saved bundle                                          |
-|`--channel_id [<CHANNEL_ID>]`  |`-c` | Specify the channel ID of the storefront, if the store has multiple storefronts.    |
+|`--channel_id [<CHANNEL_ID>]`  |`-c` | Specify the channel ID of the storefront, if the store has multiple storefronts    |
 |`--activate [<VARIATIONNAME>]` |`-a` | Skip activation prompt; specify variation or leave blank to select first variation  |
 |`--delete`                     |`-d` | Delete oldest private, non-active theme if upload limit reached                     |
 |`--help`                       |`-h` | Output usage information                                                            |


### PR DESCRIPTION
# [DEVDOCS-2860](https://jira.bigcommerce.com/browse/DEVDOCS-2860)

## What changed?
Document --channel_id in exactly the same way as it is currently documented for stencil pull in the stencil push options table 