### PR TITLE
Update graphql-api-overview

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -175,10 +175,9 @@ fetch('/graphql', {
   headers: {
       'Content-Type': 'application/json',
       'Authorization': 'Bearer {{settings.storefront_api.token}}'
-      ''
   },
-  body: JSON.stringify({ query: `query MyFirstQuery {...}`
-);
+  body: JSON.stringify({ query: `query MyFirstQuery {...}`})
+});
 ```
 
 <div class="HubBlock--callout">


### PR DESCRIPTION
# [DEVDOCS-2847](https://jira.bigcommerce.com/browse/DEVDOCS-2847)

## What changed?
Updated the invalid syntax with the correct syntax. See the screenshots in the JIRA ticket showing the results with the invalid syntax versus the correct one.