### PR TITLE
Update live-previewing-a-theme.md

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -18,7 +18,7 @@ The steps in this article assume you've installed Stencil CLI on your system. If
 
 ## Obtaining store API credentials
 
-Stencil CLI uses various BigCommerce APIs to inject store-specific data, like carousel images and products, into the live theme preview it serves up. To do so, you must supply the Stencil CLI with a store API token. For detailed instructions, see [Store API Accounts](https://support.bigcommerce.com/s/article/Store-API-Accounts).
+Stencil CLI uses various BigCommerce APIs to inject store-specific data, like carousel images and products, into the live theme preview it serves up. To do so, you must supply the Stencil CLI with a stencil CLI token. For detailed instructions, see [Store API Accounts](https://support.bigcommerce.com/s/article/Store-API-Accounts).
 
 
 To automatically create a store API account with the scopes and permissions required by Stencil CLI, select **Create Stencil-CLI Token** in the **Create API Accounts** dropdown:

--- a/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -18,7 +18,8 @@ The steps in this article assume you've installed Stencil CLI on your system. If
 
 ## Obtaining store API credentials
 
-Stencil CLI uses various BigCommerce APIs to inject store-specific data, like carousel images and products, into the live theme preview it serves up. To do so, you must supply the Stencil CLI with a stencil CLI token. For detailed instructions, see [Store API Accounts](https://support.bigcommerce.com/s/article/Store-API-Accounts).
+Stencil CLI uses various BigCommerce APIs to inject store-specific data, like carousel images and products, into the live theme preview it serves up. To do so, you must supply the Stencil CLI with a Stencil CLI token. For detailed instructions, see [Store API Accounts](https://support.bigcommerce.com/s/article/Store-API-Accounts).
+
 
 
 To automatically create a store API account with the scopes and permissions required by Stencil CLI, select **Create Stencil-CLI Token** in the **Create API Accounts** dropdown:


### PR DESCRIPTION
# [DEVDOCS-2928](https://jira.bigcommerce.com/browse/DEVDOCS-2928)

## What changed?
Updated docs to state to use a stencil token rather than the current verbiage of 'a store api token.