### PR TITLE
Update handlebars-helpers-reference

### DIFF
--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -120,7 +120,7 @@ Assume that `{{cart.items}}` returns 10 items. You can use this helper to limit 
 {{pluck limit collection path}}
 ```
 
-Retrieves corresponding values from some or all elements in a collection using specified search key(s). Returns retrieved values in an array when values are nested or returns values as strings if used alone.
+Retrieves corresponding values from some or all elements in a collection using specified search key(s). Returns retrieved values in a comma-separated string. When used in conjunction with the built-in `{{each}}` helper, returns retrieved values in an array. 
 
 #### Parameters
 

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -120,7 +120,7 @@ Assume that `{{cart.items}}` returns 10 items. You can use this helper to limit 
 {{pluck limit collection path}}
 ```
 
-Retrieves corresponding values from some or all elements in a collection using specified search key(s). Returns retrieved values in a comma-separated string.
+Retrieves corresponding values from some or all elements in a collection using specified search key(s). Returns retrieved values in an array of comma-separated strings.
 
 #### Parameters
 

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -120,7 +120,7 @@ Assume that `{{cart.items}}` returns 10 items. You can use this helper to limit 
 {{pluck limit collection path}}
 ```
 
-Retrieves corresponding values from some or all elements in a collection using specified search key(s). Returns retrieved values in an array of comma-separated strings.
+Retrieves corresponding values from some or all elements in a collection using specified search key(s). Returns retrieved values in an array when values are nested or returns values as strings if used alone.
 
 #### Parameters
 
@@ -161,6 +161,10 @@ users: [
 
 {{pluck users "image.url"}}'
 <!-- => barney.jpg,fred.jpg -->
+
+Standard pluck helper example:
+// {{pluck items "data.title"}}
+results in: '["aa", "bb", "cc"]'
 ```
 
 - [See it in GitHub](https://github.com/bigcommerce/paper-handlebars/blob/master/helpers/pluck.js)


### PR DESCRIPTION
# [DEVDOCS-2962](https://jira.bigcommerce.com/browse/DEVDOCS-2962)

## What changed?
Updated the definition for pluck helper based on the example below:
users: [
    { "user": "barney", "age": 36, "image": { "url": "barney.jpg" } },
    { "user": "fred",   "age": 40, "image": { "url": "fred.jpg" } }
]

And pluck is defined as an array in the table at the top of the page.

Helper | Category | Description
pluck   | array         | Uses search key to get values from collections.



