### PR TITLE
Devdocs 2975 - Wrong anchor link

### DIFF
--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -386,7 +386,7 @@ X-Auth-Token: {{ACCESS_TOKEN}}
 }
 ```
 
-[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/product-reviews/createproductreview#requestrunner)
+[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/store-management/catalog/product-reviews/createproductreview#requestrunner)
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">

--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -204,7 +204,7 @@ X-Auth-Token: {{ACCESS_TOKEN}}
 }
 ```
 
-[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/catalog-api/catalog/product-images/createproductimage#requestrunner)
+[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/store-management/catalog/product-images/createproductimage#requestrunner)
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">

--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -179,7 +179,7 @@ X-Auth-Token: {{ACCESS_TOKEN}}
 <!-- theme:  -->
 
 ### Note
-> Files can only be added to digital products via [control panel or WebDav](https://support.bigcommerce.com/articles/Public/Creating-Downloadable-Products/#adding-downloadable-product) -- attaching via the API is not supported. You can also set additional settings such as file description and maximum downloads in the control panel.
+> Files can only be added to digital products via [control panel or WebDav](https://support.bigcommerce.com/s/article/Creating-Downloadable-Products) -- attaching via the API is not supported. You can also set additional settings such as file description and maximum downloads in the control panel.
 
 </div>
 </div>

--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -240,7 +240,7 @@ X-Auth-Token: {{ACCESS_TOKEN}}
 }
 ```
 
-[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/catalog/catalog-api/product-videos/createproductvideo#requestrunner)
+[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](https://developer.bigcommerce.com/api-reference/store-management/catalog/product-videos/createproductvideo#requestrunner)
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">

--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -5,7 +5,7 @@
 ### On this page
 - [OAuth scopes](#oauth-scopes)
 - [Products overview](#products-overview)
-- [Creating products with options](#creating-products-with-options)
+- [Creating products with variant options](#creating-products-with-variant-options)
 - [Creating digital products](#creating-digital-products)
 - [Adding product images](#adding-product-images)
 - [Adding product videos](#adding-product-videos)

--- a/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -46,24 +46,11 @@ Cornerstone and other themes can also be downloaded from the BigCommerce control
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">
 <div class="HubBlock-content">
-<<<<<<< HEAD
 
 <!-- theme: info -->
 
 ### Note  
 Downloading a theme does not include the current configuration of a theme. Run a [stencil pull](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands#stencil-pull) command to obtain the theme's most recently saved version (appears only for themes customized for this store).
-
-=======
-
-<!-- theme: info -->
-
-### Note  
-Downloading a theme does not include the current configuration of a theme. Run a [stencil pull](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands#stencil-pull) command to obtain the theme's most recently saved version (appears only for themes customized for this store).
-
->>>>>>> master
-</div>
-</div>
-</div>
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">

--- a/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -52,6 +52,10 @@ Cornerstone and other themes can also be downloaded from the BigCommerce control
 ### Note  
 Downloading a theme does not include the current configuration of a theme. Run a [stencil pull](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands#stencil-pull) command to obtain the theme's most recently saved version (appears only for themes customized for this store).
 
+</div>
+</div>
+</div>
+
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">
 <div class="HubBlock-content">


### PR DESCRIPTION
# [DEVDOCS-2975](https://jira.bigcommerce.com/browse/DEVDOCS-2975)

## What changed?
* Update anchor link in TOC as requested
* Found and updated several other URLs that were broken