### PR TITLE
Update localizing-stores.md

### DIFF
--- a/docs/stencil-docs/localization/localizing-stores.md
+++ b/docs/stencil-docs/localization/localizing-stores.md
@@ -52,7 +52,6 @@ BigCommerce supports these uneditable strings in the following languages:
 * [German](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-de-DE.po)
 * [Italian](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-it-IT.po)
 * [Portuguese (Brazil)](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-pt-BR.po)
-* [Spanish (Mexico)](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-es-MX.po)
 * [Swedish](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-sv-SE.po)
 
 
@@ -155,7 +154,4 @@ To customize payment and checkout messages, define these variables in the theme 
 * [German](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-de-DE.po)
 * [Italian](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-it-IT.po)
 * [Portuguese (Brazil)](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-pt-BR.po)
-
-* [Spanish (Mexico)](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-es-MX.po)
-
 * [Swedish](https://bigcommerce.github.io/dev-docs/assets/PO/storefront-sv-SE.po)


### PR DESCRIPTION
# [DEVDOCS-3080](https://jira.bigcommerce.com/browse/DEVDOCS-3080)

## What changed?
Removed Spanish (Mexico) from the list of supported languages for uneditable string translation. Currently, only Spanish (Castilian) is supported in the control panel.