### PR TITLE
Update about-webhooks.md

### DIFF
--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -67,7 +67,7 @@ Accept: application/json
 
 ### Note
 > * Following the creation of a webhook, it can take up to one minute for BigCommerce to start making `POST` requests to the destination server.
-> * The `destination` URL must be served on port **433**; custom ports are not currently supported.
+> * The `destination` URL must be served on port **443**; custom ports are not currently supported.
 
 </div>
 </div>


### PR DESCRIPTION
# [DEVDOCS-3092](https://jira.bigcommerce.com/browse/DEVDOCS-3092)

## What changed?
I was able to confirm that the requestor is correct. 
See [support article](https://support.bigcommerce.com/s/question/0D54O00006DSw7aSAD/can-webhook-url-use-custom-port-number?language=en_US).