### PR TITLE
DEVDOCS-3094: remove order/updated from the status specific change pa…

### DIFF
--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -365,7 +365,6 @@ Updates to the following fields trigger a `store/channel/updated` event.
 ### The same response is returned for the following events:
 
 - `store/order/statusUpdated`
-- `store/order/updated` (if status updated)
 
 **Response fields**
 


### PR DESCRIPTION
…yload

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
Recently we're fixing an issue with duplicated order events firing, as part of the fix, we noticed that the order/updated event is not firing consistent payload, which we addressed in the PR (https://github.com/bigcommerce/bigcommerce/pull/42271#discussion_r686548304)

So this is just to update the documentation around that to avoid confusion. 