### PR TITLE
Update installing-stencil.md

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -188,7 +188,3 @@ stencil start
 ## Resources
 
 * [Dockerizing BigCommerce's Stencil CLI](https://medium.com/bigcommerce-developer-blog/dockerizing-bigcommerces-stencil-cli-f508ddc0c3c0) (medium.com)
-
-### Additional resources
-
-* [Demonstration of Stencil Installation and Launch](https://www.youtube.com/watch/iWBrJalyM0A) (youtube.com)


### PR DESCRIPTION
# [DEVDOCS-3088](https://jira.bigcommerce.com/browse/DEVDOCS-3088)

## What changed?
Removed the YouTube link "Demonstration of Stencil Installation and Launch(youtube.com)" because the video is very old (~2009).  The video is outdated that is why the link does not work.

Leah Spector allowed me access to view the video and I confirmed with Albert Singh to remove the link. Leah made the link private again and I want to remove it from our docs.