### PR TITLE
Update installing-stencil.md

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -49,9 +49,9 @@ nvm use 12
 npm install -g @bigcommerce/stencil-cli
 ```
 
-### Installing on Mac with Apple silicone
+### Installing on Mac with Apple silicon
 
-Installing Stencil CLI and its dependencies on Macs that use Apple silicone, such as the M1 chip, requires Rosetta. Rosetta allows a Mac with Apple silicon to use apps built for a Mac with an Intel processor. The following steps will guide you through the installation process:
+Installing Stencil CLI and its dependencies on Macs that use Apple silicon, such as the M1 chip, requires Rosetta. Rosetta allows a Mac with Apple silicon to use apps built for a Mac with an Intel processor. The following steps will guide you through the installation process:
 
 
 <div class="HubBlock--callout">

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -68,7 +68,8 @@ Installing Stencil CLI and its dependencies on Macs that use Apple silicon, such
 </div>
 
 
-Open terminal using Rosetta.
+Open the terminal using Rosetta.
+
 1. Open **Finder**.
 2. Go to **Applications** > **Utilities** > **Terminal**.
 3. Right-click **Terminal** and select **Get Info**.

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -69,12 +69,12 @@ Installing Stencil CLI and its dependencies on Macs that use Apple silicone, suc
 
 
 Open terminal using Rosetta.
-- Open **Finder**.
-- Go to **Applications** > **Utilities** > **Terminal**.
-- Right-click **Terminal** and select **Get Info**.
-- Check the **Open using Rosetta** checkbox.
-- Close the window and quit all terminal instances.
-- Start a new terminal, and install Rosetta if prompted.
+1. Open **Finder**.
+2. Go to **Applications** > **Utilities** > **Terminal**.
+3. Right-click **Terminal** and select **Get Info**.
+4. Check the **Open using Rosetta** checkbox.
+5. Close the window and quit all terminal instances.
+6. Start a new terminal, and install Rosetta if prompted.
 
 Run the following commands.
 ```shell

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -48,29 +48,38 @@ nvm use 12
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli
 ```
+
+### Installing on Mac with M1 chip
+To install Stencil CLI and its dependencies on Mac with a M1 chip, open a Rosetta terminal and run the following commands.
+
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">
 <div class="HubBlock-content">
 
 <!-- theme: info -->
 
-> Use these instructions for Mac's with a M1 chip.
+> These instructions have been tested on a **MacBook Air** with a M1 chip.
 
 </div>
 </div>
 </div>
 
+
+Open terminal using Rosetta.
+- Open **Finder**.
+- Go to **Applications** > **Utilities** > **Terminal**.
+- Right-click **Terminal** and select **Get Info**.
+- Check the **Open using Rosetta** checkbox.
+- Close the window and quit all terminal instances.
+- Start a new terminal, and install Rosetta if prompted.
+
+Run the following commands.
 ```shell
-
-# Install Node Version Manager (nvm)
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-
 # Install Stencil CLI supported version of Node.js
-nvm install 12.1
+nvm install 12
 
 # Switch to Stencil CLI supported version of Node.js
-
-nvm use 12.1
+nvm use 12
 
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -49,7 +49,8 @@ nvm use 12
 npm install -g @bigcommerce/stencil-cli
 ```
 
-### Installing on Mac with M1 chip
+### Installing on Mac with Apple silicone
+
 Installing Stencil CLI and its dependencies on Macs that use Apple silicone, such as the M1 chip, requires Rosetta. Rosetta allows a Mac with Apple silicon to use apps built for a Mac with an Intel processor. The following steps will guide you through the installation process:
 
 

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -59,7 +59,8 @@ Installing Stencil CLI and its dependencies on Macs that use Apple silicone, suc
 
 <!-- theme: info -->
 
-> These instructions have been tested on a **MacBook Air** with a M1 chip.
+> These instructions have been tested on a **MacBook Air** with an M1 chip.
+
 
 </div>
 </div>

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -50,7 +50,8 @@ npm install -g @bigcommerce/stencil-cli
 ```
 
 ### Installing on Mac with M1 chip
-To install Stencil CLI and its dependencies on Mac with a M1 chip, open a Rosetta terminal and run the following commands.
+Installing Stencil CLI and its dependencies on Macs that use Apple silicone, such as the M1 chip, requires Rosetta. Rosetta allows a Mac with Apple silicon to use apps built for a Mac with an Intel processor. The following steps will guide you through the installation process:
+
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">


### PR DESCRIPTION
# [DEVDOCS-3118](https://jira.bigcommerce.com/browse/DEVDOCS-3118)

## What changed?
I received the following instructions from Jordan Arldt today.

Awesome! Okay. So basically all you need to do is this:
Before running nvm install 12:
Open Finder
Go to the Applications directory
Open the Utilities folder
Scroll down to find Terminal, Right Click and click on Get Info
Check the Open using Rosetta checkbox
Close the window, and quit all terminal instances
Start a new Terminal, and Install Rosetta if prompted
In the terminal, run nvm install 12
Type nvm use 12 after the installation finishes
Run npm install -g @bigcommerce/stencil-cli

As long as you run nvm install 12 while the terminal is launched with rosetta, the npm install -g @bigcommerce/stencil-cli  will should install without errors :thumbsup: