### PR TITLE
Update incorrect filename reference

### DIFF
--- a/docs/stencil-docs/storefront-customization/custom-sass-functions.md
+++ b/docs/stencil-docs/storefront-customization/custom-sass-functions.md
@@ -41,7 +41,7 @@ To add a custom Sass file, place it at this path location, using an arbitrary fi
 
 <span class="fp">/assets/scss/foobar.scss</span>
 
-Next, import the custom file into `theme.css`.
+Next, import the custom file into `theme.scss`.
 
 ```scss
 @import "foobar";


### PR DESCRIPTION
Docs incorrectly state that custom sass files should be imported to theme.css
as opposed to theme.scss

# [DEVDOCS-](https://jira.bigcommerce.com/browse/DEVDOCS-)

## What changed?
* thing_that_changed