### PR TITLE
DEVDOCS-3315: add webhook events for transactions

### DIFF
--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -336,6 +336,8 @@ Updates to the following fields trigger a `store/channel/updated` event.
 | store/order/statusUpdated | This will only fire if the order status has changed. Such as Pending to Awaiting Payment |
 | store/order/message/created | Order message is created by customer or in control panel |
 | store/order/refund/created | A refund has been submitted against an order |
+| store/order/transaction/created | Fires when a transaction record is created |
+| store/order/transaction/updated | Fires when a transaction record is updated  |
 
 ### The same response is returned for the following events:
 
@@ -439,6 +441,32 @@ Updates to the following fields trigger a `store/channel/updated` event.
     },
     "hash": "cb07cdbdda8b1965e812693d5988154807eeed02",
     "created_at": 1561479923,
+    "producer": "stores/{store_hash}"
+}
+```
+
+### The same response is returned for the following events:
+
+* `store/order/transaction/created`
+* `store/order/transaction/updated`
+
+**Response fields**
+- type -- Will always be transaction
+- order_id -- ID of the order associated with the transaction
+- transaction_id -- ID of the transaction created by the payment provider
+
+```json
+{
+    "scope": "store/order/transaction/created",
+    "channel_id": null,
+    "store_id": "1025646",
+    "data": {
+        "type": "transaction",
+        "order_id": 250,
+        "transaction_id": "176342342"
+    },
+    "hash": "dd70c0976e06b67aaf671e73f49dcb79230ebf9d",
+    "created_at": 1561479335,
     "producer": "stores/{store_hash}"
 }
 ```

--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -72,9 +72,9 @@ This article contains a complete reference of all BigCommerce webhook events and
 |-|-|
 | store/cart/* | Subscribe to all cart events. This will also subscribe you to cart/lineItem. |
 | store/cart/created | This webhook will fire whenever a new cart is created, either via a storefront shopper adding their first item to the cart, or when a new cart is created via an API consumer. If it is from the storefront, then it fires when the first product is added to a new session.(The cart did not exist before). For the API it means a `POST` to /carts, (V3 and Storefront API). The `store/cart/updated` hook will also fire.|
-| store/cart/updated | This webhook is fired whenever a cart is modified through the changes in its line items. Eg. when a new item is added to a cart or an existing item’s quantity is updated. This hook also fires when the email is changed during guest checkout or when an existing item is deleted. The payload will include the ID of the cart being updated. <br> This webhook also fires along with the cart created hook, because the first product being added to an empty cart triggers an update. It will also fire for the following events: <br> - Logging into customer account after creating a cart (email is inherited from customer account email) <br>- Entering email address via guest checkout <br> -Changing the email in guest checkout |
+| store/cart/updated | This webhook is fired whenever a cart is modified through the changes in its line items. Eg. When a new item is added to a cart or an existing item’s quantity is updated. This hook also fires when the email is changed during guest checkout or when an existing item is deleted. The payload will include the ID of the cart being updated. <br> This webhook also fires along with the cart created hook, because the first product being added to an empty cart triggers an update. It will also fire for the following events: <br> - Logging into customer account after creating a cart (email is inherited from customer account email) <br>- Entering email address via guest checkout <br> -Changing the email in guest checkout |
 | store/cart/deleted| This webhook will fire whenever a cart is deleted. This will occur either when all items have been removed from a cart and it is auto-deleted, or when the cart is explicitly removed via a `DELETE` request by an API consumer. This ends the lifecycle of the cart. The  `store/cart/updated`  webhook will also fire when the last item is removed.|
-| store/cart/couponApplied | This webhook will fire whenever a new coupon code is applied to a cart. It will include the ID of the coupon code |
+| store/cart/couponApplied | This webhook will fire whenever a new coupon code is applied to a cart. It will include the ID of the coupon code. |
 | store/cart/abandoned | This webhook will fire once after a cart is abandoned. A cart is considered abandoned if no changes have been made for at least one hour after the last modified property. This hook is available for all store plans, regardless of whether the Abandoned Cart Saver feature is enabled.|
 | store/cart/converted | This hook fires when a cart is converted into an order, which is typically after the payment step of checkout on the storefront. At this point, the cart is no longer accessible and has been deleted. This hook returns both the cart ID and order ID for correlation purposes. |
 
@@ -161,9 +161,9 @@ The same response is returned for the following events.
 | Name | Description |
 |-|-|
 | store/cart/lineItem/* | Subscribe to all cart line item events. This webhook will fire when a change occurs to line items in the cart. This can be when items are added to a cart, removed or updated.(Ex. change to quantity, product options or price). |
-| store/cart/lineItem/created | When a new item is added to the cart  |
+| store/cart/lineItem/created | When a new item is added to the cart.  |
 | store/cart/lineItem/updated | When an item’s quantity has changed or the product options change. |
-| store/cart/lineItem/deleted | When an item is deleted from the cart|
+| store/cart/lineItem/deleted | When an item is deleted from the cart.|
 
 ### The same response is returned for the following endpoints:
 * `store/cart/lineItem/created`
@@ -196,10 +196,10 @@ The same response is returned for the following events.
 
 | Name | Description |
 |-|-|
-| store/category/* | Subscribe to all store/category events |
-| store/category/created | Category is created |
-| store/category/updated | Category is updated |
-| store/category/deleted | Category is deleted |
+| store/category/* | Subscribe to all store/category events. |
+| store/category/created | Category is created. |
+| store/category/updated | Category is updated. |
+| store/category/deleted | Category is deleted. |
 
 ### The same response is returned for the following endpoints:
 
@@ -230,8 +230,8 @@ The same response is returned for the following events.
 | Name                    | Description                                              |
 |-------------------------|----------------------------------------------------------|
 | `store/channel/*`       | Subscribe to all `store/channel` events.                 |
-| `store/channel/created` | Fires when a channel is created via control panel or API |
-| `store/channel/updated` | Fires when a channel is updated via control panel or API |
+| `store/channel/created` | Fires when a channel is created via control panel or API. |
+| `store/channel/updated` | Fires when a channel is updated via control panel or API. |
 
 ```json
 {
@@ -265,14 +265,14 @@ Updates to the following fields trigger a `store/channel/updated` event.
 
 | Name | Description |
 |-|-|
-| store/customer/* | Subscribe to all store/customer events |
-| store/customer/created | A new customer is created|
+| store/customer/* | Subscribe to all store/customer events. |
+| store/customer/created | A new customer is created.|
 | store/customer/updated | Customer is updated. Does not currently track changes to the customer address. |
-| store/customer/deleted | Customer is deleted |
-| store/customer/address/created | Customer address is created |
-| store/customer/address/updated | Customer address is updated |
-| store/customer/address/deleted | Customer address is deleted |
-| store/customer/payment/instrument/default/updated | Customer default payment instrument is updated |
+| store/customer/deleted | Customer is deleted. |
+| store/customer/address/created | Customer address is created. |
+| store/customer/address/updated | Customer address is updated. |
+| store/customer/address/deleted | Customer address is deleted. |
+| store/customer/payment/instrument/default/updated | Customer default payment instrument is updated. |
 
 ### The same response is returned for the following endpoints:
 * `store/customer/created`
@@ -329,15 +329,15 @@ Updates to the following fields trigger a `store/channel/updated` event.
 
 | Name | Description |
 |-|-|
-| store/order/* | Subscribe to all store/order events  |
+| store/order/* | Subscribe to all store/order events.  |
 | store/order/created |Fires if an order is created using the control panel, an app or via the API.|
-| store/order/updated| Fires when an already created order is updated. Any changes to an existing order will fire this webhook. Updates can include changing the status, updating a coupon or changing an address.|
-| store/order/archived | Order is archived |
-| store/order/statusUpdated | This will only fire if the order status has changed. Such as Pending to Awaiting Payment |
-| store/order/message/created | Order message is created by customer or in control panel |
-| store/order/refund/created | A refund has been submitted against an order |
-| store/order/transaction/created | Fires when a transaction record is created |
-| store/order/transaction/updated | Fires when a transaction record is updated  |
+| store/order/updated| Fires when an already created order is updated. Any changes to an existing order will fire this webhook. Updates can include changing the status, updating a coupon, or changing an address.|
+| store/order/archived | Order is archived. |
+| store/order/statusUpdated | This will only fire if the order status has changed, such as Pending to Awaiting Payment. |
+| store/order/message/created | Order message is created by customer or in control panel. |
+| store/order/refund/created | A refund has been submitted against an order. |
+| store/order/transaction/created | Fires when a transaction record is created. |
+| store/order/transaction/updated | Fires when a transaction record is updated.  |
 
 ### The same response is returned for the following events:
 
@@ -475,10 +475,10 @@ Updates to the following fields trigger a `store/channel/updated` event.
 
 | Name | Description |
 |-|-|
-| store/product/* | Subscribe to all store/product events |
-|store/product/deleted| Product is deleted|
-| store/product/created | A new product is created |
-| store/product/updated |Occurs when product details are edited. For a full list of product fields that trigger an updated event, see **Product updated events** below |
+| store/product/* | Subscribe to all store/product events. |
+|store/product/deleted| Product is deleted.|
+| store/product/created | A new product is created. |
+| store/product/updated |Occurs when product details are edited. For a full list of product fields that trigger an updated event, see **Product updated events** below. |
 | store/product/inventory/updated| Product inventory is updated. |
 | store/product/inventory/order/updated| Fires if a product’s inventory is decremented or incremented, including when an order is placed. Webhook responds to inventory updates made using the control panel, CSV import, API or an app.|
 
@@ -568,10 +568,10 @@ Changes to any of the following fields will trigger a `store/product/updated` ev
 
 | Name | Description |
 |-|-|
-| store/shipment/* | Subscribe to all store/shipment events |
-| store/shipment/created | Shipment is created |
-| store/shipment/updated | Shipment is updated |
-| store/shipment/deleted | Shipment is deleted |
+| store/shipment/* | Subscribe to all store/shipment events. |
+| store/shipment/created | Shipment is created. |
+| store/shipment/updated | Shipment is updated. |
+| store/shipment/deleted | Shipment is deleted. |
 
 ### The same response is returned for the following endpoints:
 
@@ -603,11 +603,11 @@ Changes to any of the following fields will trigger a `store/product/updated` ev
 
 | Name | Description |
 |-|-|
-| store/sku/* |Subscribe to all store/sku events |
-| store/sku/created | A new sku is created |
-| store/sku/updated | SKU is updated |
-| store/sku/deleted| SKU is deleted |
-| store/sku/inventory/updated| SKU is updated|
+| store/sku/* |Subscribe to all store/sku events. |
+| store/sku/created | A new sku is created. |
+| store/sku/updated | SKU is updated. |
+| store/sku/deleted| SKU is deleted. |
+| store/sku/inventory/updated| SKU is updated.|
 | store/sku/inventory/order/updated| This will fire when the inventory is updated via API, the control panel, when an order is placed and when an order is refunded and the inventory is returned to stock. This hook will fire based on a store's Inventory settings. |
 
 ### The same response is returned for the following endpoints:
@@ -680,8 +680,8 @@ Changes to any of the following fields will trigger a `store/product/updated` ev
 
 |Name|Description|
 | - | - |
-| store/app/uninstalled | Occurs when a client store is cancelled and uninstalled from the platform |
-|store/information/updated | Occurs when changes are made to store settings. For a full list of fields that can trigger this event, see **Store information updated events** below |
+| store/app/uninstalled | Occurs when a client store is cancelled and uninstalled from the platform. |
+|store/information/updated | Occurs when changes are made to store settings. For a full list of fields that can trigger this event, see **Store information updated events** below. |
 
 ### Store information updated events
 
@@ -738,10 +738,10 @@ Changes to the following store settings will trigger a `store/information/update
 
 | Name | Description |
 |-|-|
-| store/subscriber/* | Subscribe to all store/subscriber events |
-| store/subscriber/created | Subscriber is created |
-| store/subscriber/updated| Subscriber is updated |
-| store/subscriber/deleted | Subscriber is deleted |
+| store/subscriber/* | Subscribe to all store/subscriber events. |
+| store/subscriber/created | Subscriber is created. |
+| store/subscriber/updated| Subscriber is updated. |
+| store/subscriber/deleted | Subscriber is deleted. |
 
 ### The same response is returned for the following endpoints:
 * `store/subscriber/created`


### PR DESCRIPTION
# [DEVDOCS-3315](https://jira.bigcommerce.com/browse/DEVDOCS-3315)
https://jira.bigcommerce.com/browse/DEVDOCS-3315

## What changed?
* added summary for  store/order/transaction/created and store/order/transaction/updated
* added schema summary for store/order/transaction/created and store/order/transaction/updated