### PR TITLE
DEVDOCS-3468: Update Payments API docs to clarify what "verification_value" is

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -197,8 +197,9 @@ lineNumbers: true
 **Get payment methods = process payment**
 * type = type
 * token = token
-* last_four = verification_value
 * id = payment_method_id
+
+When paying with a stored card, you can send the card's CVV in the `verification_value` field. When included, it will be sent to the payment provider wherever possible and used for verification. If you do not have the CVV, then exclude this field.
 
 The headers to process a payment are different than the headers you normally send with a BigCommerce API. The authorization token is the ID returned in Get Payment Access Token (step two).
 
@@ -240,7 +241,7 @@ curl -X POST \
     "instrument": {
       "type": "stored_card",
       "token": "050a1e5c982e5905288ec5ec33f292772762033a0704f46fccb16bf1940b51ef", // from Get Payment Methods
-      "verification_value": "4242"
+      "verification_value": "900"
     },
     "payment_method_id": "stripe.card"
   }


### PR DESCRIPTION
# [DEVDOCS-3468](https://jira.bigcommerce.com/browse/DEVDOCS-3468)

## What
Update Payments API docs to clarify what "verification_value" is.

## Why
verification_value isn't the last_four, but rather the CVC

ping @bigcommerce/payments