### PR TITLE
Remove "on this page" tocs

### DIFF
--- a/_project/_page_template.md
+++ b/_project/_page_template.md
@@ -1,14 +1,6 @@
 # Title
 
-<div class="otp" id="no-index">
 
-### On this Page	
-- [Section1](#section1)
-- [Section2](#section2)
-- [Section3](#section3)
-- [Resources](#resources)
-
-</div>
 
 Introduction
 

--- a/_project/request_runner.md
+++ b/_project/request_runner.md
@@ -1,12 +1,6 @@
 # Request Runner
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Adding a Button](#adding-a-button)
-- [Demo Buttons](#demo-buttons)
-
-</div>
 
 This page demos this Request Runner.
 

--- a/docs/api-docs/apps/apps-quick-start.md
+++ b/docs/api-docs/apps/apps-quick-start.md
@@ -1,20 +1,5 @@
 # BigCommerce Apps Quick Start
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Prerequisites](#prerequisites)
-- [Get started](#get-started)
-- [Add and start ngrok](#add-and-start-ngrok)
-- [Register the app](#register-the-app)
-- [Configure environment variables](#configure-environment-variables)
-- [Start dev environment](#start-dev-environment)
-- [Install the app](#install-the-app)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
-
 In this quick start tutorial, you will create a [single-click app](https://developer.bigcommerce.com/api-docs/getting-started/building-apps-bigcommerce/types-of-apps) using [Node.js](https://nodejs.org/en/), [React](https://www.reactjs.org/), [Next.js](https://nextjs.org/), and [BigDesign](https://developer.bigcommerce.com/big-design/). 
 
 ## Prerequisites

--- a/docs/api-docs/apps/building-apps-guide.md
+++ b/docs/api-docs/apps/building-apps-guide.md
@@ -1,29 +1,5 @@
 # Building Apps
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Get Started](#get-started)
-- [Decide App Type](#decide-app-type)
-- [Start with Hello World](#start-with-hello-world)
-- [Test Locally](#test-locally)
-- [Register the App](#register-the-app)
-- [Install Draft App](#install-draft-app)
-- [Implement OAuth Flow](#implement-oauth-flow)
-- [Test OAuth Locally](#test-oauth-locally)
-- [Handle Callbacks](#handle-callbacks)
-- [Support Multiple Users](#support-multiple-users)
-- [Listen for Events](#listen-for-events)
-- [Design the UI](#design-the-ui)
-- [Create Install Buttons](#create-install-buttons)
-- [Follow Best Practices](#follow-best-practices)
-- [Check Requirements](#check-requirements)
-- [Deploy the App](#deploy-the-app)
-- [Publish to Marketplace](#publish-to-marketplace)
-- [Resources](#resources)
-
-</div>
-
 This article is an in-depth, comprehensive guide to building apps on BigCommerce. For a step-by-step tutorial, see []().
 
 ## Get Started

--- a/docs/api-docs/apps/guide/apps-01-introduction.md
+++ b/docs/api-docs/apps/guide/apps-01-introduction.md
@@ -1,16 +1,5 @@
 # Introduction to Building Apps
 
-<div class="otp" id="no-index">
-
-### On this page
-- [About BigCommerce apps](#about-bigcommerce-apps)
-- [Use cases](#use-cases)
-- [Getting started](#getting-started)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
-
 Using BigCommerce's powerful APIs, SDKs, and toolkits, developers can build apps that are installable on BigCommerce stores. Once approved, apps can be sold (or made available free of charge) to all BigCommerce merchants on the [Apps Marketplace](https://www.bigcommerce.com/apps). This is the first article in a comprehensive developer's guide to building BigCommerce apps. It provides a brief, high-level introduction for developers new to the platform. If you already have experience developing for BigCommerce, feel free to [skip ahead](#next-steps) or check out the [quick start tutorial](https://developer.bigcommerce.com/api-docs/apps/quick-start).
 
 

--- a/docs/api-docs/apps/guide/apps-02-types.md
+++ b/docs/api-docs/apps/guide/apps-02-types.md
@@ -1,14 +1,6 @@
 # Types of Apps
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Single-Click](#single-click)
-- [Connector](#connector)
-- [Visibility](#visibility)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-</div>
 
 The first step when developing an app is deciding which type of app to develop. The two types of apps, single-click and connector, are defined by the method of authentication. [Single-click](#single-click) apps use an OAuth Authorization Code Grant flow. [Connector apps](#connector) require store owners to manually generate and configure store API credentials. In addition to the authentication method, apps can differ by [visibility](#visibility).
 

--- a/docs/api-docs/apps/guide/apps-03-developing.md
+++ b/docs/api-docs/apps/guide/apps-03-developing.md
@@ -1,17 +1,6 @@
 # Beginning App Development
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Getting started](#getting-started)
-- [Beginning quickly](#beginning-quickly)
-- [Testing locally with ngrok](#testing-locally-with-ngrok)
-- [Registering a draft app](#registering-a-draft-app)
-- [Installing a draft app](#installing-a-draft-app)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 The BigCommerce team has developed an array of sample apps and tools to assist developers in the initial phase of app development. In this article, we'll introduce those tools and go over how to begin app development by installing and registering a draft app.
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -1,18 +1,6 @@
 # Managing Apps in the Developer Portal
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Signing in](#signing-in)
-- [Creating apps](#creating-apps)
-- [Editing apps](#editing-apps)
-- [Editing technical details](#editing-technical-details)
-- [Viewing credentials](#viewing-credentials)
-- [Submitting apps](#submitting-apps)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 App developers create, edit, and submit apps for approval using the [Developer Portal](https://devtools.bigcommerce.com/). In [Beginning App Development](https://developer.bigcommerce.com/api-docs/apps/guide/development) we briefly touched on how to create a draft app. In this article, we'll go over how to perform other common app management tasks in the [Developer Portal](https://devtools.bigcommerce.com/). For detailed instructions on submitting apps for approval, see [Publishing Apps](https://developer.bigcommerce.com/api-docs/apps/guide/publishing).
 

--- a/docs/api-docs/apps/guide/apps-05-oauth.md
+++ b/docs/api-docs/apps/guide/apps-05-oauth.md
@@ -1,21 +1,7 @@
 # Single-Click App OAuth Flow
 
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Helpful tools](#helpful-tools)
-- [OAuth summary](#oauth-summary)
-- [Receiving the GET request](#receiving-the-get-request)
-- [Responding to the GET request](#responding-to-the-get-request)
-- [Making the POST request](#making-the-post-request)
-- [Receiving the POST response](#receiving-the-post-response)
-- [Code samples](#code-samples)
-- [Security considerations](#security-considerations)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 If you're developing a single-click app, you'll need to handle the OAuth flow that begins when a merchant clicks **Install**. This article contains the technical details necessary to do so. If you don't want to start from scratch, see [Helpful tools](#helpful-tools) for a list of API clients that expose OAuth related helper methods. This documentation assumes you're an experienced developer familiar with web app authentication. If this is your first time approaching OAuth, see [Additional resources](#additional-resources) for links to introductory articles on the [OAuth framework](https://tools.ietf.org/html/rfc6749) (tools.ietf.org).
 

--- a/docs/api-docs/apps/guide/apps-06-callbacks.md
+++ b/docs/api-docs/apps/guide/apps-06-callbacks.md
@@ -1,21 +1,7 @@
 # Single-Click App Callbacks
 
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Overview](#overview)
-- [Load callback](#load-callback)
-- [Uninstall callback](#uninstall-callback)
-- [Remove user callback](#remove-user-callback)
-- [Verifying the signed payload](#verifying-the-signed-payload)
-- [Identifying users](#identifying-users)
-- [Code samples](#code-samples)
-- [Helpful tools](#helpful-tools)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 After installing a single-click app, store owners and authorized users *load* the app by clicking the app's icon in the control panel. Store owners can also *uninstall* your app and *remove users* they've authorized to use it. Each of these events triggers a `GET` request (or "callback") from BigCommerce to your app's callback URL configured in the [Developer Portal](https://devtools.bigcommerce.com/my/apps). This article describes how your app should handle each callback and explains how to [verify the `signed_payload`](#verifying-the-signed-payload) and [identify users](#identifying-users).
 

--- a/docs/api-docs/apps/guide/apps-07-users.md
+++ b/docs/api-docs/apps/guide/apps-07-users.md
@@ -1,17 +1,6 @@
 # Supporting Multiple Users
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Enabling multiple users](#enabling-multiple-users)
-- [The control panel experience](#the-control-panel-experience)
-- [The load request](#the-load-request)
-- [The remove user request](#the-remove-user-request)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-- [Related articles](#related-articles)
-
-</div>
 
 When you register your app in the [Developer Portal](https://devtools.bigcommerce.com/), you'll have the option of enabling **Multiple Users**. This allows store administrators to manually authorize users to load the app. This article describes how enabling **Multiple Users** impacts the app's user experience in the control panel, and discusses important implications for app developers to consider before enabling the feature.
 

--- a/docs/api-docs/apps/guide/apps-08-events.md
+++ b/docs/api-docs/apps/guide/apps-08-events.md
@@ -1,14 +1,6 @@
 # Listening for Events
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Available webhooks](#available-webhooks)
-- [Creating webhooks](#creating-webhooks)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 Your app may need to be notified when specific events occur on a BigCommerce store (for example, when an order is created). Your app can programmatically subscribe to such events via [webhooks](https://developer.bigcommerce.com/api-reference/webhooks/webhooks/createwebhooks). We'll briefly introduce webhooks in this article (for visibility); to take a deeper dive, see [Webhooks Overview](https://developer.bigcommerce.com/api-docs/getting-started/webhooks/about-webhooks).
 

--- a/docs/api-docs/apps/guide/apps-09-ui.md
+++ b/docs/api-docs/apps/guide/apps-09-ui.md
@@ -1,15 +1,6 @@
 # Designing a Single-Click App's UI
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Installing BigDesign React components](#installing-bigdesign-react-components)
-- [Using BigDesign tools](#using-bigdesign-tools)
-- [Developing for the iFrame](#developing-for-the-iframe)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 Your app's user interface is loaded inside an iFrame in a store's control panel after a user clicks the app's icon in the left nav and tirggers the [`load` callback](https://developer.bigcommerce.com/api-docs/apps/guide/callbacks). To ensure a seamless user experience, you should design your app's UI to match the design of BigCommerce's control panel. We've built a collection of reusable React components, design guidelines, and UI patterns (known collectively as *BigDesign*) that you can use to rapidly develop an app front-end that's consistent with BigCommerce's UI.
 

--- a/docs/api-docs/apps/guide/apps-10-buttons.md
+++ b/docs/api-docs/apps/guide/apps-10-buttons.md
@@ -1,18 +1,7 @@
 # Creating an External Installation Button
 
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Creating an install button](#creating-an-install-button)
-- [Configuring the button](#configuring-the-button)
-- [Rendering success and failure pages](#rendering-success-and-failure-pages)
-- [Handling errors](#handling-errors)
-- [Code samples](#code-samples)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 Single-click apps can be installed from outside the BigCommerce control panel. For example, an install button on your company's site that directs the merchant to download your app. This tutorial provides step-by-step instructions for creating an external install button for BigCommerce single-click apps.
 

--- a/docs/api-docs/apps/guide/apps-11-best-practices.md
+++ b/docs/api-docs/apps/guide/apps-11-best-practices.md
@@ -1,17 +1,6 @@
 # App Development Best Practices
 
-<div class="otp" id="no-index">
 
-### On this page
-- [OAuth flow](#oauth-flow)
-- [API requests](#api-requests)
-- [Webhook events](#webhook-events)
-- [User interface](#user-interface)
-- [Deployment](#deployment)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 Review the following best practices before submitting your app to the [Apps Marketplace](https://www.bigcommerce.com/apps/).
 

--- a/docs/api-docs/apps/guide/apps-12-requirements.md
+++ b/docs/api-docs/apps/guide/apps-12-requirements.md
@@ -1,18 +1,6 @@
 # App Store Approval Requirements
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [General requirements](#general-requirements)
-- [Listing](#listing)
-- [Functionality](#functionality)
-- [Installation](#installation)
-- [FAQ](#faq)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 The Apps Marketplace team reviews all app submissions and tests apps to verify they meet [Marketplace](https://www.bigcommerce.com/apps/) listing standards. Verify your app meets the requirements below before submitting it for approval.
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -1,20 +1,6 @@
 # Publishing an App
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Before you begin](#before-you-begin)
-- [Provide a summary](#provide-a-summary)
-- [Add technical information](#add-technical-information)
-- [Fill in details](#fill-in-details)
-- [Review submission](#review-submission)
-- [Submit your app for approval](#submit-your-app-for-approval)
-- [FAQ](#faq)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 After completing development, verifying best practices, and checking approval requirements, you may submit your app for Marketplace approval in the [Developer Portal](https://devtools.bigcommerce.com/). This article takes you step-by-step through the submission form and provides descriptions for each field.
 

--- a/docs/api-docs/apps/tutorials/apps-id.md
+++ b/docs/api-docs/apps/tutorials/apps-id.md
@@ -1,14 +1,6 @@
 # Find an App's ID
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Find in control panel](#find-in-control-panel)
-- [Find in Developer Portal](#find-in-developer-portal)
-- [Usage](#usage)
-- [Resources](#resources)
-
-</div>
 
 Select partners [building channel apps](https://developer.bigcommerce.com/api-docs/channels/building-channel-apps) need to know their app's ID in order to create and modify the channel's configuration. This tutorial demonstrates how to find an app's ID in the [Developer Portal](#find-in-devtools) and the [control panel](#find-in-control-panel).
 

--- a/docs/api-docs/apps/tutorials/apps-node-react.md
+++ b/docs/api-docs/apps/tutorials/apps-node-react.md
@@ -1,8 +1,2 @@
 # Building an App with Laravel and React
 
-<div class="otp" id="no-index">
-
-### On This Page
-
-
-</div>

--- a/docs/api-docs/apps/tutorials/sample-app-next/introduction.md
+++ b/docs/api-docs/apps/tutorials/sample-app-next/introduction.md
@@ -1,11 +1,6 @@
 # Introduction
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Prerequisites](#prerequisites)
-
-</div>
 
 This tutorial demonstrates how to build and embed a BigCommerce app using Node.js, React, Next.js, and BigDesign, BigCommerce's library of React components. 
 

--- a/docs/api-docs/apps/tutorials/sample-app-next/step-1-setup.md
+++ b/docs/api-docs/apps/tutorials/sample-app-next/step-1-setup.md
@@ -1,19 +1,6 @@
 # Step 1: Set up Your Local Environment
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Install Node](#install-node)
-- [Set up a project directory](#set-up-a-project-directory)
-- [Generate a package.json file](#generate-a-packagejson-file)
-- [Install npm packages](#install-npm-packages)
-- [Add scripts](#add-scripts)
-- [Create a starter page](#create-a-starter-page)
-- [Initialize BigDesign](#initialize-bigdesign)
-- [Initialize styled-components](#initialize-styled-components)
-- [Start the development server](#start-the-development-server)
-
-</div>
 
 Start by setting up your local development environment.
 

--- a/docs/api-docs/apps/tutorials/sample-app-next/step-2-connect-to-bc.md
+++ b/docs/api-docs/apps/tutorials/sample-app-next/step-2-connect-to-bc.md
@@ -1,17 +1,6 @@
 # Step 2: Connect Your App to BigCommerce
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Install node-bigcommerce](#install-node-bigcommerce)
-- [Setup the auth lib page](#setup-the-auth-lib-page)
-- [Add API endpoints](#add-api-endpoints)
-- [Create an HTTPS tunnel](#create-an-https-tunnel)
-- [Register the draft app](#register-the-draft-app)
-- [Add your Client ID and Client Secret Key](#add-your-client-id-and-client-secret-key)
-- [Install and launch the app](#install-and-launch-the-app)
-
-</div>
 
 In this step, you connect your app to the BigCommerce ecosystem embedding it into **Draft Apps**.
 

--- a/docs/api-docs/apps/tutorials/sample-app-next/step-3-integrate-api.md
+++ b/docs/api-docs/apps/tutorials/sample-app-next/step-3-integrate-api.md
@@ -1,26 +1,6 @@
 # Step 3: Integrate the BigCommerce API and Add a Database
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Install npm packages](#install-npm-packages)
-- [Add TypeScript definitions](#add-typescript-definitions)
-- [Initialize React Context](#initialize-react-context)
-- [Update environment variables](#update-environment-variables)
-- [Update the auth lib page](#update-the-auth-lib-page)
-- [Add a database](#add-a-database)
-- [Set up Firebase database](#set-up-firebase-database)
-- [Set up MySQL database](#set-up-mysql-database)
-- [Set up a db lib page](#set-up-a-db-lib-page)
-- [Upgrade the endpoints](#upgrade-the-endpoints)
-- [Add the Products endpoint](#add-the-products-endpoint)
-- [Create a custom hook](#create-a-custom-hook)
-- [Create a header component](#create-a-header-component)
-- [Update the homepage](#update-the-homepage)
-- [Update the user interface](#update-the-user-interface)
-- [Test your app](#test-your-app)
-
-</div>
 
 Now that you have embedded your app in the BigCommerce platform, you're ready to integrate the BigCommerce API.
 

--- a/docs/api-docs/apps/tutorials/sample-app-next/step-4-enhance-ux.md
+++ b/docs/api-docs/apps/tutorials/sample-app-next/step-4-enhance-ux.md
@@ -1,24 +1,6 @@
 # Step 4: Enhance the User Experience with BigDesign
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Create the Products List route](#create-the-products-list-route)
-- [Update custom hooks](#update-custom-hooks)
-- [Create the Products page](#create-the-products-page)
-- [Add the InnerHeader component](#add-the-innerheader-component)
-- [Update the Header component](#update-the-header-component)
-- [Create the ErrorMessage component](#create-the-errormessage-component)
-- [Create the Loading component](#create-the-loading-component)
-- [Add system checks](#add-system-checks)
-- [Update TypeScript definitions](#update-typescript-definitions)
-- [Create the Form component](#create-the-form-component)
-- [Create dynamic product routes](#create-dynamic-product-routes)
-- [Integrate dynamic routes with the internal API](#integrate-dynamic-routes-with-the-internal-api)
-- [Style the home page](#style-the-home-page)
-- [Start the app](#start-the-app)
-
-</div>
 
 [BigDesign](https://developer.bigcommerce.com/big-design/) plays a pivotal part in the BigCommerce control panel and ecosystem. App developers are encouraged to use BigDesign to develop apps that have a native BigCommerce look and feel.
 

--- a/docs/api-docs/building-checkouts/checkout-consignment.md
+++ b/docs/api-docs/building-checkouts/checkout-consignment.md
@@ -1,15 +1,6 @@
 # Checkout Consignment API
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Overview](#overview)
-- [Creating a consignment](#creating-a-consignment)
-- [Updating a consignment](#updating-a-consignment)
-- [Further reading](#further-reading)
-- [Related documentation](#related-documentation)
-
-</div> 
+ 
 
 This article discusses how to create and update a consignment.
 

--- a/docs/api-docs/building-checkouts/checkout-customizability.md
+++ b/docs/api-docs/building-checkouts/checkout-customizability.md
@@ -1,12 +1,6 @@
 # Checkout Customizability
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Checkout options](#checkout-options)
-- [Resources](#resources)
-
-</div> 
+ 
 
 BigCommerce provides significant levels of checkout customizability. There are two paths that a developer can choose to use. 
 		

--- a/docs/api-docs/building-storefronts/abandoned-carts.md
+++ b/docs/api-docs/building-storefronts/abandoned-carts.md
@@ -1,16 +1,6 @@
 # Recovering Abandoned Carts
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Abandoned Cart Saver](#abandoned-cart-saver)
-- [Setting up the abandoned cart route](#setting-up-the-abandoned-cart-route)
-- [Leveraging the Abandoned Carts API](#leveraging-the-abandoned-carts-api)
-- [Implementing cart recovery on headless storefronts](#implementing-cart-recovery-on-headless-storefronts)
-- [Resources](#resources)
-
-</div>
 
 BigCommerce offers a powerful cart recovery system to help merchants recover lost business by effectively converting abandoned carts into orders. Using BigCommerce's built-in [Abandoned Cart Saver](https://support.bigcommerce.com/s/article/Using-the-Abandoned-Cart-Saver?language=en_US) tool, merchants can automate email campaigns to encourage customers to complete transactions after leaving items in their cart.
 

--- a/docs/api-docs/building-storefronts/nextjs-commerce-guide.md
+++ b/docs/api-docs/building-storefronts/nextjs-commerce-guide.md
@@ -1,15 +1,6 @@
 # Next.js Commerce Quick Start
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Overview](#overview)
-- [Getting started](#getting-started)
-- [Application](#application)
-- [Application settings](#application-settings)
-- [Resources](#resources)
-</div>
 
 ## Overview
 

--- a/docs/api-docs/cart-and-checkout/add-to-cart-url.md
+++ b/docs/api-docs/cart-and-checkout/add-to-cart-url.md
@@ -1,13 +1,6 @@
 # Add to Cart URLs
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Parameters](#parameters)
-- [Common usage](#common-usage)
-- [Adding multiple products](#adding-multiple-products)
-
-</div>
 
 Query string parameters can be appended to Bigcommerce product and `/cart.php` urls in order to pre-select an SKU or add a product to cart. These parameters make it possible to build custom add to cart links and forms for use on BigCommerce storefronts and remote sites (such as WordPress, blog posts, and social media).
 

--- a/docs/api-docs/cart-and-checkout/cart-and-checkout-overview.md
+++ b/docs/api-docs/cart-and-checkout/cart-and-checkout-overview.md
@@ -1,16 +1,6 @@
 # Cart and Checkout
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Storefront Cart and Checkout](#storefront-cart-and-checkout)
-- [Server-to-Server Cart and Checkout](#server-to-server-cart-and-checkout)
-- [When to use](#when-to-use)
-- [Persistent cart](#persistent-cart)
-- [Troubleshooting cart errors](#troubleshooting-cart-errors)
-- [Related resources](#related-resources)
-
-</div>
 
 ## Storefront Cart and Checkout
 

--- a/docs/api-docs/cart-and-checkout/channels-sites-routes.md
+++ b/docs/api-docs/cart-and-checkout/channels-sites-routes.md
@@ -1,15 +1,6 @@
 # Channels, Sites and Routes APIs
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [How They Work](#how-they-work)
-- [Channels and Listings](#channels-and-listings)
-- [Sites and Routes](#sites-and-routes)
-- [Channel Manager vs. App Marketplace](#channel-manager-vs-app-marketplace)
-- [What Do I Need to Build a Channel App?](#what-do-i-need-to-build-a-channel-app)
-
-</div>
 
 <a id="channels-sites-routes-how"></a>
 

--- a/docs/api-docs/cart-and-checkout/checkout-sdk.md
+++ b/docs/api-docs/cart-and-checkout/checkout-sdk.md
@@ -1,13 +1,6 @@
 #  Checkout SDK
 
-<div class="otp" id="no-index">
 
-### On this page
-- [What can I do with the SDK?](#what-can-i-do-with-the-sdk)
-- [Where can I get the SDK?](#where-can-i-get-the-sdk)
-- [Support and customization](#support-and-customization)
-
-</div>
 
 The Checkout JS SDK is a wrapper for the BigCommerce Storefront Checkout API.
 

--- a/docs/api-docs/cart-and-checkout/custom-order-confirmation.md
+++ b/docs/api-docs/cart-and-checkout/custom-order-confirmation.md
@@ -1,16 +1,6 @@
 # Installing a Custom Order Confirmation Page
 
-<div class="otp" id="no-index">
 
-
-### On this page
-
-- [Generate the JavaScript loader file](#generate-the-javascript-loader-file)
-- [Hosting a custom order confirmation page](#hosting-a-custom-order-confirmation-page)
-- [Installing a custom order confirmation page](#installing-a-custom-order-confirmation-page)
-- [Related resources](#related-resources)
-
-</div>
 
 You can engage with your customers after purchase with a custom order confirmation page. This article outlines how to package a custom order confirmation file, and install a custom confirmation file via the control panel.
 The installation process is the same as [Installing a Custom Checkout](https://developer.bigcommerce.com/stencil-docs/customizing-checkout/installing-custom-checkouts), except you will modify a different [file](https://github.com/bigcommerce/checkout-js/blob/master/src/app/order/OrderConfirmation.tsx) in [Open Source Checkout](https://github.com/bigcommerce/checkout-js).

--- a/docs/api-docs/cart-and-checkout/embedded-checkout-overview.md
+++ b/docs/api-docs/cart-and-checkout/embedded-checkout-overview.md
@@ -1,15 +1,6 @@
 # Embedded Checkout Overview
 
-<div class="otp" id="no-index">
 
-### On this page
-- [How it works](#how-it-works)
-- [Channels, Sites, and Routes APIs](#channels-sites-and-routes-apis)
-- [BigCommerce Checkout SDK](#bigcommerce-checkout-sdk)
-- [Logged-In customers](#logged-in-customers)
-- [FAQ](#faq)
-
-</div>
 
 The [Checkout SDK's`embedded-checkout` sub-module](https://github.com/bigcommerce/checkout-sdk-js/blob/master/docs/README.md#embedcheckout) can be used to embed [BigCommerce's Optimized One-Page Checkout](https://support.bigcommerce.com/s/article/Optimized-Single-Page-Checkout) into non-native storefronts like WordPress. You can see this in action within the BigCommerce for WordPress plugin, which uses the same process described here as a checkout option for merchants. For more information about the plugin, see [BigCommerce for Wordpress](https://developer.bigcommerce.com/bigcommerce-for-wordpress/getting-started/introduction).
 

--- a/docs/api-docs/cart-and-checkout/embedded-checkout-tutorial.md
+++ b/docs/api-docs/cart-and-checkout/embedded-checkout-tutorial.md
@@ -1,16 +1,6 @@
 # Embedded Checkout
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Creating a channel](#creating-a-channel)
-- [Creating a site](#creating-a-site)
-- [Creating a cart](#creating-a-cart)
-- [Embedding the checkout](#embedding-the-checkout)
-- [FAQ](#faq)
-- [Related resources](#related-resources)
-
-</div>
 
 Embedded Checkout lets you place BigCommerce’s Optimized One-Page checkout onto an external site. This tutorial will walk you through the sequence of API calls your application should make to create a working Embedded Checkout.
 

--- a/docs/api-docs/cart-and-checkout/open-source-checkout.md
+++ b/docs/api-docs/cart-and-checkout/open-source-checkout.md
@@ -1,16 +1,6 @@
 # Installing a Custom Checkout
 
-<div class="otp" id="no-index">
 
-
-### On this page
-
-- [Obtaining the JavaScript loader file](#obtaining-the-javascript-loader-file)
-- [Hosting a custom checkout](#hosting-a-custom-checkout)
-- [Installing custom checkouts](#installing-custom-checkouts)
-- [Related resources](#related-resources)
-
-</div>
 
 You can create unique shopping experiences that fit the look and feel of a store's brand using custom checkouts. This article will outline how to package a custom checkout file, and install a custom checkout via the control panel.
 

--- a/docs/api-docs/cart-and-checkout/working-sf-apis.md
+++ b/docs/api-docs/cart-and-checkout/working-sf-apis.md
@@ -1,16 +1,6 @@
 # Working with the Storefront Cart and Checkout APIs
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Prerequisites](#prerequisites)
-- [Getting started](#getting-started)
-- [Storefront Cart](#storefront-cart)
-- [Storefront Checkout](#storefront-checkout)
-- [Troubleshooting](#troubleshooting)
-- [Related resources](#related-resources)
-
-</div>
 
 BigCommerce's [Storefront API](https://developer.bigcommerce.com/api-reference#storefront-api) exposes storefront data to Stencil themes. You can use this client API to manage a shopper's cart, checkout, and order data via client-side JavaScript.
 

--- a/docs/api-docs/catalog/currencies/currencies-overview.md
+++ b/docs/api-docs/catalog/currencies/currencies-overview.md
@@ -1,18 +1,6 @@
 # Currencies Overview
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Display vs. transactional](#display-vs-transactional)
-- [Preconfiguring the store](#preconfiguring-the-store)
-- [Adding a currency](#adding-a-currency)
-- [How currencies work](#how-currencies-work)
-- [Supported and unsupported features](#supported-and-unsupported-features)
-- [Multi-currency definitions](#multi-currency-definitions)
-- [FAQ](#faq)
-- [Related resources](#related-resources)
-
-</div>
 
 BigCommerce’s flexible Currency settings assist developers in building Multi-Currency storefronts that empower shoppers and merchants to do business in their currency of choice. Allowing customers to shop and check out in their native currency provides a more consistent and positive shopping experience, and maintaining price expectations throughout the shopping process encourages conversions for merchants.
 

--- a/docs/api-docs/catalog/currencies/how-currencies-work.md
+++ b/docs/api-docs/catalog/currencies/how-currencies-work.md
@@ -1,23 +1,6 @@
 # How Currencies Work
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Catalog pricing](#catalog-pricing)
-- [Currencies](#currencies)
-- [Price Lists](#price-lists)
-- [Price list modifiers](#price-list-modifiers)
-- [Price records](#price-records)
-- [S-2-S cart and checkout](#s-2-s-cart-and-checkout)
-- [Storefront cart and checkout](#storefront-cart-and-checkout)
-- [Orders](#orders)
-- [Promotions](#promotions)
-- [Shipping](#shipping)
-- [Refunds](#refunds)
-- [Payment methods supported](#payment-methods-supported)
-- [Gift certificates](#gift-certificates)
-
-</div>
 
 This article details how you can surface currencies throughout BigCommerce APIs, user interfaces, and storefront components. It assumes you're already familiar with the core concepts behind BigCommerce's multi-currency settings. For a high-level overview and instructions on how to add currencies to a BigCommerce store, see [Currencies Overview](https://developer.bigcommerce.com/api-docs/catalog/currencies/currencies-overview).
 

--- a/docs/api-docs/catalog/price-list-overview.md
+++ b/docs/api-docs/catalog/price-list-overview.md
@@ -1,16 +1,5 @@
 # Price List API
-<div class="otp" id="no-index">
-	
-### On this page
-- [What is a price list?](#what-is-a-price-list)
 
-- [Price list definitions](#price-list-definitions)
-- [Price list assignments](#price-list-assignments)
-- [Price list notes](#price-list-notes)      
-- [Related resources](#related-resources)
-
-       
-</div>
 
 ## What is a price list?
 

--- a/docs/api-docs/catalog/products-overview.md
+++ b/docs/api-docs/catalog/products-overview.md
@@ -1,30 +1,6 @@
 # Catalog Overview
 
-<div class="otp" id="no-index">
 
-### On this page
-- [OAuth scopes](#oauth-scopes)
-- [Products overview](#products-overview)
-- [Creating products with variant options](#creating-products-with-variant-options)
-- [Creating digital products](#creating-digital-products)
-- [Adding product images](#adding-product-images)
-- [Adding product videos](#adding-product-videos)
-- [Adding custom fields](#adding-custom-fields)
-- [Adding bulk pricing rules](#adding-bulk-pricing-rules)
-- [Pricing precision](#pricing-precision)
-- [Adding product metafields](#adding-product-metafields)
-- [Adding product reviews](#adding-product-reviews)
-- [Variant options](#variant-options)
-- [Variants](#variants)
-- [Creating variants](#creating-variants)
-- [Modifier options](#modifier-options)
-- [Complex rules](#complex-rules)
-- [Creating brands](#creating-brands)
-- [Categories](#categories)
-- [Product Sort Order](#product-sort-order)
-- [Related resources](#related-resources)
-
-</div>
 
 The Catalog refers to a store's collection of physical and digital products. The Catalog includes all the information about a product such as MPN, warranty, price, and images.
 

--- a/docs/api-docs/catalog/v2-v3-examples.md
+++ b/docs/api-docs/catalog/v2-v3-examples.md
@@ -1,14 +1,6 @@
 # V2 to V3 Catalog Operations Comparison
 
-<div class="otp" id="no-index">
 
-### On This Page
-
-- [V2 and V3 operations](#v2-and-v3-operations)
-- [Interoperability between V2 and V3](#interoperability-between-v2-and-v3)
-- [Related resources](#related-resources)
-
-</div>
 
 This article illustrates the difference between V2 and V3 Catalog APIs by comparing major operations. 
 

--- a/docs/api-docs/catalog/v2-vs-v3.md
+++ b/docs/api-docs/catalog/v2-vs-v3.md
@@ -1,13 +1,6 @@
 # Difference between V2 and V3 Catalog REST APIs
 
-<div class="otp" id="no-index">
 
-### On this page
-- [V3 improvements](#v3-improvements)
-- [Difference between V2 and V3 Catalog APIs](#difference-between-v2-and-v3-catalog-apis)
-- [Related resources](#related-resources)
-
-</div>
 
 V2 and V3 Catalog REST APIs allow you to manage your store's products, categories, and brands, along with their sub-resources.
 

--- a/docs/api-docs/channels/building-channel-apps.md
+++ b/docs/api-docs/channels/building-channel-apps.md
@@ -2,26 +2,7 @@
 
 # Building Channel Apps
 
-<div class="otp" id="no-index">
 
-## On this page
-
-  - [Getting started](#getting-started)
-  - [Beginning development](#beginning-development)
-  - [Gathering materials](#gathering-materials)
-  - [Creating a channel](#creating-a-channel)
-  - [Getting catalog data](#getting-catalog-data)
-  - [Creating listings](#creating-listings)
-  - [Importing and exporting sales](#importing-and-exporting-sales)
-  - [Managing orders and inventory](#managing-orders-and-inventory)
-  - [Syncing gift card balances](#syncing-gift-card-balances)
-  - [B2B and wholesale integration](#b2b-and-wholesale-integration)
-  - [Handling notifications](#handling-notifications)
-  - [Developing the UI](#developing-the-ui)
-  - [Next steps](#next-steps)
-  - [Related resources](#related-resources)
-
-</div>
 
 Using BigCommerce's [Channels Toolkit](https://developer.bigcommerce.com/api-docs/channels/channels-toolkit-reference), developers can create channel apps that integrate with point-of-sale devices, [headless storefronts](https://developer.bigcommerce.com/api-docs/storefronts/developers-guide-headless), online marketplaces, marketing platforms, and social networking sites. BigCommerce lists all approved channel apps on the [Apps Marketplace](https://www.bigcommerce.com/apps/) and markets channel apps developed by [select partners](https://www.bigcommerce.com/partners/) in [Channel Manager](https://support.bigcommerce.com/s/article/Selling-Everywhere-with-Channel-Manager).
 

--- a/docs/api-docs/channels/channel-app-best-practices.md
+++ b/docs/api-docs/channels/channel-app-best-practices.md
@@ -2,17 +2,7 @@
 
 <!-- Dev Center URL: https://developer.bigcommerce.com/api-docs/channels/guide/channel-app-best-practices -->
 
-<div class="otp" id="no-index">
 
-## On this page
-
-  - [Modular features](#modular-features)
-  - [Syncing](#syncing)
-  - [Performance](#performance)
-  - [Logging](#logging)
-  - [Related resources](#related-resources)
-
-</div>
 
 To enable the best user experience, below are a few items to keep in mind when developing a BigCommerce Channel App.
 

--- a/docs/api-docs/channels/channel-app-requirements.md
+++ b/docs/api-docs/channels/channel-app-requirements.md
@@ -2,17 +2,6 @@
 
 <!-- Dev Center URL: https://developer.bigcommerce.com/api-docs/channels/guide/channel-app-requirements -->
 
-<div class="otp" id="no-in">
-
-## On this page
-
- - [General requirements](#general-requirements)
- - [Storefronts](#storefronts)
- - [Marketplaces and marketing](#marketplaces-and-marketing)
- - [Related resources](#related-resources)
-
-</div>
-
 Once approved, channel apps are discoverable on BigCommerce's App Marketplace. Additionally, apps developed by [select partners](https://www.bigcommerce.com/partners/) are marketed in the Channel Manager within the Control Panel of every store. To be approved, channel apps must meet certain requirements. This article lists the requirements for publishing channel apps to both locations.
 
 ## General requirements

--- a/docs/api-docs/channels/channel-webhooks.md
+++ b/docs/api-docs/channels/channel-webhooks.md
@@ -1,15 +1,6 @@
 # Channel Webhooks
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Channel webhook events](#channel-webhook-events)
-- [Channel webhook callbacks](#channel-webhook-callbacks)
-- [Creating a channel webhook](#creating-a-channel-webhook)
-- [Resources](#resources)
-
-</div>
 
 Developers building third-party sales channels or multi-storefront capabilities might need notification when a channel in BigCommerce changes so that they can perform downstream actions required to set up or deactivate the channel. To facilitate this, we've added `store/channel` webhook events that fire when you create or update a channel. We'll assume you're familiar with webhooks and briefly introduce the channel events in this article; however, if you would like an introduction to webhooks, see [Webhooks Overview](https://developer.bigcommerce.com/api-docs/getting-started/webhooks/about-webhooks).
 

--- a/docs/api-docs/channels/channels-extending-existing.md
+++ b/docs/api-docs/channels/channels-extending-existing.md
@@ -2,19 +2,7 @@
 
 <!-- Dev Center URL: https://developer.bigcommerce.com/api-docs/channels/tutorials/extend-existing-apps -->
 
-<div class="otp" id="no-index">
 
-## On this page
-
- - [Step 1: Update API credentials](#step-1-update-api-credentials)
- - [Step 2: Integrate channel API](#step-2-integrate-channel-api)
- - [Step 3: Migrate existing data](#step-3-migrate-existing-data)
- - [App requirements](#app-requirements)
- - [Sample configuration](#sample-configuration)
- - [Terminology](#terminology)
- - [Related resources](#related-resources)
-
-</div>
 
 This article provides a guide to partners who would like to update or replace their existing sales channel apps to leverage new functionality available via Channels Toolkit.
 

--- a/docs/api-docs/channels/channels-overview.md
+++ b/docs/api-docs/channels/channels-overview.md
@@ -2,18 +2,6 @@
 
 <!-- Dev Center URL: https://developer.bigcommerce.com/api-docs/channels/guide/overview -->
 
-## On this page
-
-<div class="otp" id="no-index">
-
- - [Channels Toolkit](#channels-toolkit)
- - [Channel apps](#channel-apps)
- - [Types of channels](#types-of-channels)
- - [Building a channel app](#building-a-channel-app)
- - [Related resources](#related-resources)
-
-</div>
-
 BigCommerce's Channel Manager is the central place for merchants to discover, connect to, and manage their sales channels, including external channels like eBay, Amazon, Facebook, and Instagram. These external sales channels can extend the merchant's control panel experience in a number of ways, such as pushing orders from these external channels into the control panel alongside their BigCommerce storefront orders, allowing them to be fulfilled in the same way, and managing products on these channel from within the control panel in many of the same ways as they do for their BigCommerce storefronts.
 
 Using BigCommerce's [Channels Toolkit](https://developer.bigcommerce.com/api-docs/channels/channels-toolkit-reference), any BigCommerce [partner](https://www.bigcommerce.com/partners/) can create and list a sales channel app on BigCommerce's [App Marketplace](https://www.bigcommerce.com/apps/) for any merchant to install. Additionally, approved apps developed by [select partners](https://www.bigcommerce.com/partners/) are marketed and discoverable from within the Channel Manager in every BigCommerce store's control panel.

--- a/docs/api-docs/channels/channels-pos-tutorial.md
+++ b/docs/api-docs/channels/channels-pos-tutorial.md
@@ -1,18 +1,6 @@
 # Building Point-of-Sale Channels
 
-<div class="otp" id="no-index">
 
-### On this page
-
-
- - [Prerequisites](#prerequisites)
- - [Creating a channel](#creating-a-channel)
- - [Specifying the platform](#specifying-the-platform)
- - [Configuring UI sections](#configuring-ui-sections)
- - [Rendering UI sections](#rendering-ui-sections)
- - [Related resources](#related-resources)
-
-</div>
 
 This article documents how to use [Channels Toolkit](https://developer.bigcommerce.com/api-docs/channels/guide/channels-toolkit-reference) to install a POS channel into [Channel Manager](https://support.bigcommerce.com/s/article/Selling-Everywhere-with-Channel-Manager) during a [single-click app's](https://developer.bigcommerce.com/api-docs/apps/guide/types) installation. We'll assume you're an experienced app and POS developer familiar with channels on BigCommerce.
 

--- a/docs/api-docs/channels/channels-quick-start.md
+++ b/docs/api-docs/channels/channels-quick-start.md
@@ -2,17 +2,7 @@
 
 # Building Channels Quick Start
 
-<div class="otp" id="no-index">
 
-### On this page
-
-
- - [Prerequisites](#prerequisites)
- - [Create a channel](#create-a-channel)
- - [Create a channel with navigation](#create-a-channel-with-navigation)
- - [Related resources](#related-resources)
-
-</div>
 
 This advanced, quick-start tutorial is for [BigCommerce partners](https://www.bigcommerce.com/partners/) wishing to market their solution within [Channel Manager's](https://developer.bigcommerce.com/api-docs/channels/overview#resources) **Create Channel** flow. For an introduction to channels on BigCommerce, see [Channels Overview](https://developer.bigcommerce.com/api-docs/channels/overview).
 

--- a/docs/api-docs/channels/channels-storefront-tutorial.md
+++ b/docs/api-docs/channels/channels-storefront-tutorial.md
@@ -2,21 +2,7 @@
 
 <!-- Dev Center URL: https://developer.bigcommerce.com/api-docs/channels/tutorials/storefront#building-a-channel-app -->
 
-<div class="otp" id="no-index">
 
-## On this page
-
- - [Prerequisites](#prerequisites)
- - [Creating a channel](#creating-a-channel)
- - [Specifying the platform](#specifying-the-platform)
- - [Configuring UI sections](#configuring-ui-sections)
- - [Protected UI sections](#protected-ui-sections)
- - [Storefront settings](#storefront-settings)
- - [Currencies settings](#currencies-settings)
- - [Notification settings](#notification-settings)
- - [Related resources](#related-resources)
-
-</div>
 
 This article documents how to use [Channels Toolkit](https://developer.bigcommerce.com/api-docs/channels/guide/channels-toolkit-reference) to install a storefront channel into [Channel Manager](https://support.bigcommerce.com/s/article/Selling-Everywhere-with-Channel-Manager) during a [single-click app's](https://developer.bigcommerce.com/api-docs/apps/guide/types) installation. We'll assume you're an experienced app and headless storefront developer familiar with channels on BigCommerce.
 

--- a/docs/api-docs/channels/channels-toolkit-reference.md
+++ b/docs/api-docs/channels/channels-toolkit-reference.md
@@ -2,17 +2,7 @@
 
 <!-- Dev Center URL: https://developer.bigcommerce.com/api-docs/channels/guide/channels-toolkit-reference -->
 
-<div class="otp" id="no-index">
 
-## On this page
-
- - [Required endpoints](#required-endpoints)
- - [Recommended endpoints](#recommended-endpoints)
- - [Extended functionality endpoints](#extended-functionality-endpoints)
- - [UI components](#ui-components)
- - [Documentation](#documentation)
-
-</div>
 
 This article serves as a comprehensive list of all the tools in Channels Toolkit for quick reference. For a general overview of channels and developing channel apps on BigCommerce, see [Channels Introduction](https://developer.bigcommerce.com/api-docs/channels/overview).
 

--- a/docs/api-docs/customers/current-customer-api.md
+++ b/docs/api-docs/customers/current-customer-api.md
@@ -1,13 +1,6 @@
 # Current customer API
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Identifying logged-in customers securely](#identifying-logged-in-customers-securely)
-- [Example JavaScript](#example-javascript)
-
-</div>
 
 ## Identifying logged-in customers securely
 

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -1,16 +1,6 @@
 # Customer Login API
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Introduction](#introduction)
-- [Overview](#overview)
-- [Prerequisites](#prerequisites)
-- [Enable single sign-on](#enable-single-sign-on)
-- [Troubleshooting](#troubleshooting)
-- [Related resources](#related-resourcess)
-
-</div> 
+ 
 
 ## Introduction
 In this tutorial, you will learn how to enable single sign-on for storefront customers using the Customer Login API and JSON Web Tokens.

--- a/docs/api-docs/customers/customers-subscribers-overview.md
+++ b/docs/api-docs/customers/customers-subscribers-overview.md
@@ -1,22 +1,6 @@
 # Customers and Subscribers
 
-<div class="otp" id="no-index">
-
-### On this page
-- [OAuth scopes](#oauth-scopes)
-- [What is a customer?](#what-is-a-customer)
-- [What is a subscriber?](#what-is-a-subscriber)
-- [Subscribers vs. customers](#subscribers-vs-customers)
-- [What is a guest?](#what-is-a-guest)
-- [Customer Login API](#customer-login-api)
-- [Current Customer API](#current-customer-api)
-- [Customers API](#customers-api)
-- [Differences between V2 and V3 Customers APIs](#differences-between-v2-and-v3-customers-apis)
-- [Subscribers API](#subscribers-api)
-- [FAQ](#faq)
-- [Related resources](#related-resources)
-
-</div> 
+ 
 
 ## OAuth scopes
 

--- a/docs/api-docs/customers/passwordless-login.md
+++ b/docs/api-docs/customers/passwordless-login.md
@@ -1,12 +1,6 @@
 # Passwordless Customer Login
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Logging in customers via email link](#logging-in-customers-via-email-link)
-- [Sending the request](#sending-the-request)
-- [Related resources](#related-resources)
-</div>
 
 ## Logging in customers via email link
 Your application can send shoppers a one-time link via email that will sign them in to their [storefront account](https://support.bigcommerce.com/s/article/Customer-Account-Creation).

--- a/docs/api-docs/developers-guide-headless.md
+++ b/docs/api-docs/developers-guide-headless.md
@@ -1,22 +1,5 @@
 # Developers Guide to Headless Commerce
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Ways to implement headless](#ways-to-implement-headless)
-- [Storefront channels](#storefront-channels)
-- [Multisite](#multisite)
-- [Catalog Management](#catalog-management)
-- [Cart management](#cart-management)
-- [Checkout management](#checkout-management)
-- [Customer login](#customer-login)
-- [Sample integration](#sample-integration)
-- [PCI compliance](#pci-compliance)
-- [Sample API workflows](#sample-api-workflows)
-- [Related resources](#related-resources)
-
-</div>
-
 This article provides a high level guide to using BigCommerce to power headless storefronts; we'll assume you're already familiar with headless commerce as a concept; if you're not, check out our whitepaper, [A New Era of Ecommerce: Headless Commerce](https://www.bigcommerce.com/new-era-headless-caas/) or the Help Center's [Headless Commerce Guide](https://support.bigcommerce.com/s/article/The-Headless-Approach).
 
 ## Ways to implement headless

--- a/docs/api-docs/getting-started/about-our-api.md
+++ b/docs/api-docs/getting-started/about-our-api.md
@@ -1,15 +1,6 @@
 # About Our APIs
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Available APIs](#available-apis)
-- [API environments](#api-environments)
-- [Available store resources](#available-store-resources)
-- [REST API (V2 & V3)](#rest-api-v2--v3)
-- [Support](#support)
-- [Resources](#resources)
-</div>
 
 
 

--- a/docs/api-docs/getting-started/api-status-codes.md
+++ b/docs/api-docs/getting-started/api-status-codes.md
@@ -1,14 +1,5 @@
 # API Status Codes
-<div class="otp" id="no-index">
-	<h3> On This Page </h3>
-	<ul>
-        <li><a href="#api-status-codes_2-success">2xx Success</a></li>
-        <li><a href="#api-status-codes_3-redirection">3xx Redirection</a></li>
-        <li><a href="#api-status-codes_4-client-error">4xx Client Error</a></li>
-        <li><a href="#api-status-codes_5-server-error">5xx Server Error</a></li>
-        <li><a href="#api-status-codes_troubleshooting">Troubleshooting</a></li>
-	</ul>
-</div>
+
 
 The BigCommerce API responds to requests with different HTTP status codes depending on the result from the request. Error responses might also include an error message in the body to assist in resolving the problem.
 

--- a/docs/api-docs/getting-started/authentication.md
+++ b/docs/api-docs/getting-started/authentication.md
@@ -1,14 +1,6 @@
 # Authentication
 
-<div class="otp" id="no-index">
 
-### On this page
-- [REST APIs](#rest-apis)
-- [Storefront API](#storefront-api)
-- [GraphQL Storefront API](#graphql-storefront-api)
-- [Customer Login API](#customer-login-api)
-- [Current Customer API](#current-customer-api)
-</div>
 
 BigCommerce has five different APIs that let you manage store data, log in customers, make client-side queries for product information, and more. Each requires a different authentication method.
 

--- a/docs/api-docs/getting-started/available-apis.md
+++ b/docs/api-docs/getting-started/available-apis.md
@@ -1,23 +1,6 @@
 # API Reference
 
-<div class="otp" id="no-index">
 
-### On this page
-- [BigCommerce APIs at a glance](#bigcommerce-apis-at-a-glance)
-- [V2 REST API](#v2-rest-api)
-- [V3 REST API](#v3-rest-api)
-- [Webhooks](#webhooks)
-- [Payment Processing API](#payment-processing-api)
-- [Storefront API](#storefront-api)
-- [Storefront GraphQL API](#storefront-graphql-api)
-- [Customer Login API](#customer-login-api)
-- [Current Customer API](#current-customer-api)
-- [Provider APIs](#provider-apis)
-- [Add to cart URLs](#add-to-cart-urls)
-- [API spec files](#api-spec-files)
-- [Deprecations and sunsets](#deprecations-and-sunsets)
-
-</div>
 
 ## BigCommerce APIs at a glance
 |API|Server|Description|

--- a/docs/api-docs/getting-started/best-practices.md
+++ b/docs/api-docs/getting-started/best-practices.md
@@ -1,18 +1,6 @@
 # API Best Practices
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Ensure your integration is up-to-date](#ensure-your-integration-is-up-to-date)
-- [Anticipate changes to BigCommerce APIs](#anticipate-changes-to-bigcommerce-apis)
-- [Use webhooks effectively](#use-webhooks-effectively)
-- [Thread API requests](#thread-api-requests)
-- [Marketplace apps](#marketplace-apps)
-- [API rate limits](#api-rate-limits)
-- [Platform limits](#platform-limits)
-- [Resources](#resources)
-
-</div>
 
 ## Ensure your integration is up-to-date
 

--- a/docs/api-docs/getting-started/building-apps-bigcommerce/building-apps.md
+++ b/docs/api-docs/getting-started/building-apps-bigcommerce/building-apps.md
@@ -1,26 +1,6 @@
 # Building an App
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [OAuth Summary](#oauth-summary)
-- [Request Headers](#request-headers)
-- [Managing Users Session Timeouts](#managing-users-session-timeouts)
-- [Installation and Update Sequence](#installation-and-update-sequence)
-- [Receiving the GET Request](#receiving-the-get-request)
-- [Responding to the GET Request](#responding-to-the-get-request)
-- [Making the POST Request](#making-the-post-request)
-- [Receiving the POST Response](#receiving-the-post-response)
-- [Required URIs](#required-uris)
-- [Processing the Signed Payload](#processing-the-signed-payload)
-- [Multi-User Support](#multi-user-support)
-- [External App Installation](#external-app-installation)
-- [Designing the User Interface](#designing-the-user-interface)
-- [Hosting Your App](#hosting-your-app)
-- [FAQ](#faq)
-- [Resources](#resources)
-
-</div>
 
 ## OAuth Summary
 

--- a/docs/api-docs/getting-started/building-apps-bigcommerce/types-of-apps.md
+++ b/docs/api-docs/getting-started/building-apps-bigcommerce/types-of-apps.md
@@ -1,16 +1,6 @@
 # Types of Apps
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Single Click Apps](#single-click-apps)
-- [Connector Apps](#connector-apps)
-- [Unlisted Marketplace Apps](#unlisted-marketplace-apps)
-- [Personal Apps](#personal-apps)
-- [Scripts](#scripts)
-- [Resources](#resources)
-
-</div> 
+ 
 
 The BigCommerce ecosystem facilitates the creation of multiple types of apps. Determining which type of app to create largely depends on the nature and size of the intended user-base. For example, Single Click Apps are listed on the BigCommerce marketplace and can be installed on any BigCommerce store; Personal Apps, on the other hand, are intended for a specific merchant and are not listed on the marketplace. For more information, see the detailed descriptions of each app type below.
 

--- a/docs/api-docs/getting-started/deprecations-and-sunsets.md
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.md
@@ -1,13 +1,6 @@
 # Deprecations and Sunsets
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Deprecations](#deprecations)
-- [Sunsets](#sunsets)
-- [Related resources](#related-resources)
-
-</div>
 
 This article provides a reference for deprecated APIs and exposes BigCommerce's plans to sunset specific API operations and properties. We recommend setting up a feed alert for our [Developer Changelog](https://developer.bigcommerce.com/changelog) to receive the most up-to-date information about API changes.
 

--- a/docs/api-docs/getting-started/filtering.md
+++ b/docs/api-docs/getting-started/filtering.md
@@ -1,13 +1,6 @@
 # Filtering
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Include](#include)
-- [Include and exclude fields](#include-and-exclude-fields)
-- [Pagination and limit](#pagination-and-limit)
-
-</div>
 
 To filter collections down to a particular set of items, you can add filters to your request as URL query parameters.
 

--- a/docs/api-docs/getting-started/making-requests.md
+++ b/docs/api-docs/getting-started/making-requests.md
@@ -1,14 +1,6 @@
 # BigCommerce APIs Quick Start
 
-<div class="otp" id="no-index">
 
-### On this page
-- [REST API](#rest-api)
-- [Storefront API quick start](#storefront-api-quick-start)
-- [GraphQL API](#graphql-api)
-- [Customer Login API](#customer-login-api)
-
-</div>
 
 This quick start guide will take you through making your first requests with BigCommerce's APIs.
 

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -1,17 +1,6 @@
 # Authenticating BigCommerce's REST APIs
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Obtaining store API credentials](#obtaining-store-api-credentials)
-- [Revoking store API credentials](#revoking-store-api-credentials)
-- [Obtaining app API credentials](#obtaining-app-api-credentials)
-- [Use cases by credential type](#use-cases-by-credential-type)
-- [Migrating from legacy to OAuth](#migrating-from-legacy-to-oauth)
-- [OAuth scopes](#oauth-scopes)
-- [Resources](#resources)
-
-</div>
 
 Two types of API credentials are available to developers wishing to make requests against BigCommerce's REST APIs.
 

--- a/docs/api-docs/getting-started/webhooks/about-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/about-webhooks.md
@@ -1,19 +1,6 @@
 # Webhooks Overview
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Creating a webhook](#creating-a-webhook)
-- [Callback payload](#callback-payload)
-- [Handling callbacks](#handling-callbacks)
-- [Callback retry mechanism](#callback-retry-mechanism)
-- [Security](#security)
-- [Troubleshooting](#troubleshooting)
-- [Tools](#tools)
-- [Related resources](#related-resources)
-
-</div>
 
 Webhooks notify applications when specific events occur on a BigCommerce store. For example, when:
 

--- a/docs/api-docs/getting-started/webhooks/setting-up-webhooks.md
+++ b/docs/api-docs/getting-started/webhooks/setting-up-webhooks.md
@@ -1,18 +1,6 @@
 # Webhooks Tutorial
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Create an Express app](#create-an-express-app)
-- [Start the app](#start-the-app)
-- [Create a webhook](#create-a-webhook)
-- [Trigger the webhook event](#trigger-the-webhook-event)
-- [Adding custom headers](#adding-custom-headers)
-- [Troubleshooting](#troubleshooting)
-- [Resources](#resources)
-
-</div>
 
 In this tutorial, we'll create a Node.js Express app that handless webhook callbacks and uses [ngrok](https://ngrok.com/) (ngrok.com) to expose the app to the Internet. Then, we'll create a webhook and observe the callback using the ngrok web interface when the event is triggered.
 

--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -1,25 +1,7 @@
 
 # Webhook Events
 
-<div class="otp" id="no-index">
 
-### On this Page
-
-- [Callback structure](#callback-structure)
-- [Cart](#cart)
-- [Cart line item](#cart-line-item)
-- [Category](#category)
-- [Channel](#channel)
-- [Customer](#customer)
-- [Orders](#orders)
-- [Products](#products)
-- [Shipment](#shipment)
-- [SKU](#sku)
-- [Store](#store)
-- [Subscriber](#subscriber)
-- [Resources](#resources)
-
-</div>
 
 This article contains a complete reference of all BigCommerce webhook events and their callback payloads. For an introduction to webhooks on BigCommerce, see [Webhooks Overview](https://developer.bigcommerce.com/api-docs/store-management/webhooks/overview#callback-payload).
 

--- a/docs/api-docs/headless/carts.md
+++ b/docs/api-docs/headless/carts.md
@@ -1,16 +1,6 @@
 # Managing Carts
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Creating a cart](#creating-a-cart)
-- [Redirecting to checkout](#redirecting-to-checkout)
-- [Deleting a line item](#deleting-a-line-item)
-- [Clearing the cart](#clearing-the-cart)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 In this section, we will explain how to use the Carts API to create and manage carts. Additionally, we will discuss how to redirect shoppers from a headless storefront to the BigCommerce hosted cart and checkout pages.
 

--- a/docs/api-docs/headless/channels.md
+++ b/docs/api-docs/headless/channels.md
@@ -1,13 +1,6 @@
 # Creating Channels
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Creating channels](#creating-channels)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 This section demonstrates how to create a channel and a channel site for a headless storefront.
 

--- a/docs/api-docs/headless/checkout.md
+++ b/docs/api-docs/headless/checkout.md
@@ -1,15 +1,6 @@
 # Creating Checkouts
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Redirecting to the BigCommerce checkout](#redirecting-to-the-bigcommerce-checkout)
-- [Embedding the BigCommerce checkout](#embedding-the-bigcommerce-checkout)
-- [Using the Checkouts API](#using-the-checkouts-api)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 This section covers checkout options available to headless storefronts.
 

--- a/docs/api-docs/headless/customers.md
+++ b/docs/api-docs/headless/customers.md
@@ -1,15 +1,6 @@
 # Managing Customers
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Customer login using GraphQL](#customer-login-using-graphql)
-- [Customer Single Sign-on](#customer-single-sign-on)
-- [Identifying logged-in customers](#identifying-logged-in-customers)
-- [Surfacing customer group pricing](#surfacing-customer-group-pricing)
-- [Next steps](#next-steps)
-
-</div>
 
 This section covers different ways to associate customers to headless carts.
 

--- a/docs/api-docs/headless/orders.md
+++ b/docs/api-docs/headless/orders.md
@@ -1,14 +1,6 @@
 # Handling Orders
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Creating an order from a cart](#creating-an-order-from-a-cart)
-- [Processing payments](#processing-payments)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 This section explains how to create and manage orders for headless storefronts.
 

--- a/docs/api-docs/headless/overview.md
+++ b/docs/api-docs/headless/overview.md
@@ -1,14 +1,6 @@
 # Introduction to Headless Commerce
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Ways to implement headless commerce](#ways-to-implement-headless-commerce)
-- [Sample integration](#sample-integration)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 This is the first article in a comprehensive developer's guide to using BigCommerce as a commerce backend for headless storefronts. If you are not familiar with headless commerce as a concept, start by reviewing our whitepaper, [A New Era of Ecommerce: Headless Commerce](https://www.bigcommerce.com/new-era-headless-caas/), or the Help Center's [Headless Commerce Guide](https://support.bigcommerce.com/s/article/The-Headless-Approach).
 

--- a/docs/api-docs/headless/pci-compliance.md
+++ b/docs/api-docs/headless/pci-compliance.md
@@ -1,13 +1,6 @@
 # PCI Compliance
 
-<div class="otp" id="no-index">
 
-### On this page
-- [What is PCI DSS](#what-is-pci-dss)
-- [Who is responsible](#who-is-responsible)
-- [Resources](#resources)
-
-</div>
 
 This section covers the Payment Card Industry Data Security Standard compliance and your responsibilities as a third-party developer.
 

--- a/docs/api-docs/headless/products.md
+++ b/docs/api-docs/headless/products.md
@@ -1,14 +1,6 @@
 # Working with Products
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Retrieving product data](#retrieving-product-data)
-- [Managing products](#managing-products)
-- [Next steps](#next-steps)
-- [Resources](#resources)
-
-</div>
 
 This section demonstrates how to use BigCommerce's GraphQL Storefront API and REST Products API to query and manage product data for headless storefronts.
 

--- a/docs/api-docs/management-apis/contextual-filters.md
+++ b/docs/api-docs/management-apis/contextual-filters.md
@@ -1,16 +1,6 @@
 # Contextual Filters
 
-<div class="otp" id="no-index">
 
-### On this page
-- [View active storefront filters](#view-active-storefront-filters)
-- [View available storefront filters](#view-available-storefront-filters)
-- [View available category-level filters](#view-available-category-level-filters)
-- [View contextual filters](#view-contextual-filters)
-- [Configure contextual filters](#configure-contextual-filters)
-- [Related resources](#related-resources)
-
-</div>
 
 The [Settings API](https://developer.bigcommerce.com/api-reference/store-management/settings) allows you to manage settings and configurations for BigCommerce-hosted stores and headless storefronts. 
 

--- a/docs/api-docs/management-apis/email-templates/email-template-examples.md
+++ b/docs/api-docs/management-apis/email-templates/email-template-examples.md
@@ -1,15 +1,6 @@
 # Email Templates Code Examples
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Updating text](#updating-text)
-- [Adding a button](#adding-a-button)
-- [Changing logo size](#changing-logo-size)
-- [Changing font size](#changing-font-size)
-
-</div>
 
 This article provides examples of how to customize email templates. The examples are for use in the recently updated templates. You can enable the new version of transactional emails by going to **Marketing > Transactional Emails** and clicking **Try New Experience**. When you are ready to use a template, make sure to **Enable** the template from the respective dropdown. 
 

--- a/docs/api-docs/management-apis/email-templates/overview.md
+++ b/docs/api-docs/management-apis/email-templates/overview.md
@@ -1,15 +1,6 @@
 # Email Templates Overview
 
-<div class="otp" id="no-index">
 
-### On This Page
-
-- [Editing](#editing)
-- [API](#api)
-- [Overrides](#overrides)
-- [Resources](#resources)
-
-</div>
 
 This article provides an overview of BigCommerce's transactional email templates and API.
 

--- a/docs/api-docs/orders/order-refunds.md
+++ b/docs/api-docs/orders/order-refunds.md
@@ -1,20 +1,6 @@
 # Order Refunds
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Single order refund example](#single-order-refund-example)
-- [Creating refund quotes](#creating-refund-quotes)
-- [Creating a refund](#creating-a-refund)
-- [Creating order level refunds](#creating-order-level-refunds)
-- [Refunding shipping and handling](#refunding-shipping-and-handling)
-- [Refunding products and gift wrapping](#refunding-products-and-gift-wrapping)
-- [Offline order refunds](#offline-order-refunds)
-- [FAQ](#faq)
-- [Troubleshooting](#troubleshooting)
-- [Related resources](#related-resources)
-
-</div>
 
 [Order V3](https://developer.bigcommerce.com/api-reference/store-management/order-transactions) exposes endpoints for creating refunds against orders with settled payments. These endpoints are useful when building order management or payment integrations as they make embedding refund functionality directly into the application possible without requiring merchants to return to their BigCommerce control panel.
 

--- a/docs/api-docs/orders/orders-api-overview.md
+++ b/docs/api-docs/orders/orders-api-overview.md
@@ -1,24 +1,6 @@
 # Orders Overview
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Creating an order](#creating-an-order)
-- [Changing order status](#changing-order-status)
-- [Specifying order customer](#specifying-order-customer)
-- [Including shipping addresses](#including-shipping-addresses)
-- [Adding products](#adding-products)
-- [Creating order shipments](#creating-order-shipments)
-- [Shipping to multiple locations](#shipping-to-multiple-locations)
-- [Getting shipping quotes](#getting-shipping-quotes)
-- [Getting order taxes](#getting-order-taxes)
-- [Getting order transactions](#getting-order-transactions)
-- [Handling refunds](#handling-refunds)
-- [Calculating totals](#calculating-totals)
-- [FAQ](#faq)
-- [Related resources](#related-resources)
-
-</div>
 
 This article introduces BigCommerce's [Orders V2](https://developer.bigcommerce.com/api-reference/store-management/orders) and [Orders V3](https://developer.bigcommerce.com/api-reference/store-management/order-transactions) REST API resources. [Orders V2](https://developer.bigcommerce.com/api-reference/store-management/orders) exposes endpoints for [creating](https://developer.bigcommerce.com/api-reference/store-management/orders/orders/createanorder), [reading](https://developer.bigcommerce.com/api-reference/store-management/orders/orders/getallorders), [updating](https://developer.bigcommerce.com/api-reference/store-management/orders/orders/updateanorder), and [deleting](https://developer.bigcommerce.com/api-reference/store-management/orders/orders/deleteallorders) orders; it also includes endpoints for managing [order shipments](https://developer.bigcommerce.com/api-reference/store-management/orders/order-shipments) and [order shipping addresses](https://developer.bigcommerce.com/api-reference/store-management/orders/order-shipping-addresses). [Orders V3](https://developer.bigcommerce.com/api-reference/store-management/order-transactions) surfaces [order transactions](https://developer.bigcommerce.com/api-reference/store-management/order-transactions/transactions/gettransactions) and [order refunds](https://developer.bigcommerce.com/api-reference/store-management/order-transactions/order-refunds/) endpoints. For information on processing order payments via API, see [Payments API Overview](https://developer.bigcommerce.com/api-docs/payments/payments-api-overview).
 

--- a/docs/api-docs/orders/orders-overview.md
+++ b/docs/api-docs/orders/orders-overview.md
@@ -1,18 +1,6 @@
 # Orders
 
-<div class="otp" id="no-index">
 
-### On this page
-- [What is an order?](#what-is-an-order)
-- [Available endpoints](#available-endpoints)
-- [Storefront Orders API](#storefront-orders-api)
-- [Server-to-Server Checkout API](#server-to-server-checkout-api)
-- [Orders API](#orders-api)
-- [Order transactions](#order-transactions)
-- [OAuth scopes](#oauth-scopes)
-- [Related resources](#related-resources)
-
-</div>
 
 ## What is an order?
 An order is a collection of items, customer information, and shipping information of customers that have finalized with a payment or attempted payment.

--- a/docs/api-docs/partner/Resources
+++ b/docs/api-docs/partner/Resources
@@ -1,13 +1,6 @@
 # Resources
 
-<div class="otp" id="no-index">
-
-### On this page
-- [API clients](#api-clients)
-- [Sample apps](#sample-apps)
-- [BigDesign](#bigdesign)
-- [Checkout SDK](#checkout-sdk)
-</div> 
+ 
 
 ## API clients
 Accelerate your app development with BigCommerce API clients. BigCommerce API clients are available for the following languages:

--- a/docs/api-docs/partner/Support
+++ b/docs/api-docs/partner/Support
@@ -1,15 +1,6 @@
 # Support
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Developer community](#developer-community)
-- [Developer blog](#developer-blog)
-- [Developer library](#developer-library)
-- [Dev Slack](#dev-slack)
-- [Changelog](#changelog)
-- [Town Hall](#town-hall)
-</div> 
+ 
 
 ## Developer community
 The [Developer community](https://support.bigcommerce.com/s/group/0F913000000HLjECAW/bigcommerce-developers) is a forum for web developers working with BigCommerce APIs, creating a custom theme, or building a custom app or integration. Find answers, browse topics, and talk to other developers in this group.

--- a/docs/api-docs/partner/app-store-approval-requirements.md
+++ b/docs/api-docs/partner/app-store-approval-requirements.md
@@ -1,23 +1,6 @@
 # App Store Approval Requirements
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Prerequisites](#prerequisites)
-- [General Requirements](#general-requirements)
-- [Functionality](#functionality)
-- [Installation](#installation)
-- [Recommendations](#recommendations)
-- [Dev Tools Walkthrough](#dev-tools-walkthrough)
-- [App Summary](#app-summary)
-- [Details](#details)
-- [Technical](#technical)
-- [Review](#review)
-- [Preview](#preview)
-- [Payment and Submission](#payment-and-submission)
-- [Resources](#resources)
-
-</div> 
+ 
 
 Dev Tools is the BigCommerce workspace for developing single-click apps. Within Dev Tools, you'll create the Client Id and Client Secret to authenticate your apps, submit new apps to the App Marketplace, and manage existing Marketplace listings.
 

--- a/docs/api-docs/partner/becoming-a-partner.md
+++ b/docs/api-docs/partner/becoming-a-partner.md
@@ -1,14 +1,6 @@
 # Becoming a Partner
 
-<div class="otp" id="no-index">
-
-### On this page
-
-- [Applying to the Partner Program](#applying-to-the-partner-program)
-- [Partner Portal training](#partner-portal-training)
-- [Ongoing support](#ongoing-support)
-- [Resources](#resources)
-</div> 
+ 
 
 
 The BigCommerce Partner Program includes access to resources, training, sales enablement, partner support, and a referral network to increase your client base and build better ecommerce experiences.

--- a/docs/api-docs/partner/create-a-sandbox.md
+++ b/docs/api-docs/partner/create-a-sandbox.md
@@ -1,11 +1,6 @@
 # Create a Sandbox Store
 
-<div class="otp" id="no-index"> 
-
-### On this page
-- [Creating a sandbox store](#creating-a-sandbox-store)
-- [Resources](#resources)
-</div> 
+ 
 
 A sandbox store cannot process transactions and is for developing and testing apps without the 15-day time limit of a trial store. 
 

--- a/docs/api-docs/partner/dev-portal-overview.md
+++ b/docs/api-docs/partner/dev-portal-overview.md
@@ -1,11 +1,6 @@
 # Developer Portal Overview
 
-<div class="otp" id="no-index">
-
-### On this page
-- [About the Developer Portal](#about-the-developer-portal)
-- [Resources](#resources)
-</div> 
+ 
 
 ## About the Developer Portal
 

--- a/docs/api-docs/partner/marketing-api-overview.md
+++ b/docs/api-docs/partner/marketing-api-overview.md
@@ -1,15 +1,6 @@
 # Marketing API
 
-<div class="otp" id="no-index">
 
-### On this page
-- [OAuth scopes](#oauth-scopes)
-- [Banners](#banners)
-- [Coupons](#coupons)
-- [Gift certificates](#gift-certificates)
-- [Resources](#resources)
-
-</div>
 
 The Marketing API enables you to generate product discounts, issue gift certificates, and convey marketing information using storefront banners.  
 

--- a/docs/api-docs/partner/resources.md
+++ b/docs/api-docs/partner/resources.md
@@ -1,17 +1,6 @@
 # Resources
 
-<div class="otp" id="no-index">
-
-### On this page
-
-- [API clients](#api-clients)
-- [Sample apps](#sample-apps)
-- [BigDesign](#bigdesign)
-- [Checkout SDK](#checkout-sdk)
-- [Page Builder](#page-builder)
-- [Stencil references](#stencil-references)
-
-</div> 
+ 
 
 ## API clients
 

--- a/docs/api-docs/partner/staying-current.md
+++ b/docs/api-docs/partner/staying-current.md
@@ -1,15 +1,6 @@
 # Staying Current with Platform Changes
 
-<div class="otp" id="no-index">
-
-### On this page
-
-- [General updates](#general-updates)
-- [Cornerstone theme updates](#cornerstone-theme-updates)
-- [API updates](#api-updates)
-- [Checkout SDK updates](#checkout-sdk-updates)
-
-</div> 
+ 
 
 
 At BigCommerce, we strive to offer the best ecommerce experience to our customers. Occasionally, we make updates to our platform to improve performance, add new features, or fix bugs. This article provides general information on how to stay current with the latest changes.

--- a/docs/api-docs/partner/support.md
+++ b/docs/api-docs/partner/support.md
@@ -1,17 +1,6 @@
 # Support
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Developer community](#developer-community)
-- [Developer blog](#developer-blog)
-- [Developer library](#developer-library)
-- [Developer Slack](#developer-slack)
-- [Changelog](#changelog)
-- [BigCommerce Status](#bigcommerce-status)
-- [Town Hall](#town-hall)
-- [Partner Support Team](#partner-support-team)
-</div> 
+ 
 
 As a BigCommerce partner, you have access to a wide variety of support resources. This article outlines the different types of resources available to you.
 

--- a/docs/api-docs/partner/technology-program.md
+++ b/docs/api-docs/partner/technology-program.md
@@ -1,13 +1,6 @@
 # Partner Program
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Program overview](#program-overview)
-- [Application requirements](#application-requirements)
-- [App Marketplace](#app-marketplace)
-- [Resources](#resources)
-</div> 
+ 
 
 ## Program overview
 Join the BigCommerce Partner Program to become an official BigCommerce partner. As an official partner, you will have access to training, sales enablement, and a referral network to get more clients and build better ecommerce experiences.

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -1,20 +1,6 @@
 # Payments API
 
-<div class="otp" id="no-index">
 
-### On this page
-- [PCI compliance](#pci-compliance)
-- [Processing a payment](#processing-a-payment)
-- [Stored cards](#stored-cards)
-- [Credit cards](#credit-cards)
-- [Using the Orders API](#using-the-orders-api)
-- [Technical details](#technical-details)
-- [Sample app diagram](#sample-app-diagram)
-- [Error codes](#error-codes)
-- [FAQ](#faq)
-- [Related resources](#related-resources)
-
-</div>
 
 The Payments API enables you to process payments through the store’s connected payment gateway. Merchants can receive a payment for an order that was created using either the [Server to Server Checkout API Orders](https://developer.bigcommerce.com/api-reference/cart-checkout/server-server-checkout-api) endpoint or the [V2 Orders](https://developer.bigcommerce.com/api-reference/orders/orders-api/orders/createanorder) endpoint.
 

--- a/docs/api-docs/provider-apis/tax/overview.md
+++ b/docs/api-docs/provider-apis/tax/overview.md
@@ -1,22 +1,6 @@
 # Tax Provider API
 
-<div class="otp" id="no-index">
 
-### On this Page
-
-- [Obtaining an app ID](#obtaining-an-app-id)
-- [Sharing provider details with BigCommerce](#sharing-provider-details-with-bigcommerce)
-- [Building the app](#building-the-app)
-- [Installing the app](#installing-the-app)
-- [Establishing a connection](#establishing-a-connection)
-- [Enabling tax providers in the control panel](#enabling-tax-providers-in-the-control-panel)
-- [Tax estimation](#tax-estimation)
-- [Document submission](#document-submission)
-- [Testing](#testing)
-- [Support](#support)
-- [Related resources](#related-resources)
-
-</div>
 
 The [Tax Provider API](https://developer.bigcommerce.com/api-reference/providers/tax-provider-api) allows you to provide business-to-consumer sales tax estimates to shoppers on the storefront and to merchants in the control panel; it can also be used to submit documents for tax reconciliation purposes.
 

--- a/docs/api-docs/store-management/shipping/shipper-hq.md
+++ b/docs/api-docs/store-management/shipping/shipper-hq.md
@@ -1,12 +1,5 @@
 # ShipperHQ Metafields
-<div class="otp" id="no-index">
 
-### On this page
-- [ShipperHQ object properties](#shipper-hq-object-properties)
-- [Control panel behavior](#control-panel-behavior)
-- [Add ShipperHQ metafield](#add-shipperhq-metafield)
-       
-</div>
 
 When you enable ShipperHQ on a store, additional fields become available on the product level:
 * [Shipping Groups](https://support.bigcommerce.com/s/article/ShipperHQ#ship-groups)

--- a/docs/api-docs/store-management/shipping/shipping-overview.md
+++ b/docs/api-docs/store-management/shipping/shipping-overview.md
@@ -1,14 +1,5 @@
 # Shipping
-<div class="otp" id="no-index">
-	
-### On this page 
-- [Checkout APIs](#checkout-apis)
-- [Order shipping addresses](#order-shipping-addresses)
-- [Shipping zone and shipping methods](#shipping-zone-and-shipping-methods)
-- [Real-time carriers](#real-time-carriers)
-- [Related resources](#related-resources)
-    	
-</div>
+
 
 You can create shipments from orders, and it is possible to create multiple shipments from a single order. A [shipment](/api-reference/orders/orders-api/order-shipments/createordershipments) represents a grouping of order line items that you can ship to a customer. 
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -1,24 +1,6 @@
 # Shipping Providers
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Sign-up](#sign-up)
-- [Before development](#before-development)
-- [Developing the app](#developing-the-app)
-- [Control Panel installation workflow](#control-panel-installation-workflow)
-- [Validation credentials](#validation-credentials)
-- [API installation workflow](#api-installation-workflow)
-- [Returning shipping quotes](#returning-shipping-quotes)
-- [Including product metatadata in rate requests](#including-product-metatadata-in-rate-requests)
-- [Submitting the app](#submitting-the-app)
-- [App diagram](#app-diagram)
-- [Definitions](#definitions)
-- [FAQ](#faq)
-- [Related resources](#related-resources)
-
-</div>
 
 Shipping service providers wishing to offer shipping services and rates to BigCommerce merchants and shoppers can implement BigCommerce Shipping Provider endpoints. Once they implement and accept their service into BigCommerce's shipping Carrier Registry, merchants will have access to enable and configure the service through their BigCommerce control panel. Once enabled on a store, BigCommerce will automatically retrieve the service options and rates using the provider's endpoints and display them to merchants in the store's control panel and to shoppers on the storefront.
 

--- a/docs/api-docs/storefront/graphql/graphql-api-examples.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-examples.md
@@ -1,21 +1,6 @@
 # GraphQL Storefront API Example Queries
 
-<div class="otp" id="no-index">
 
-### On this Page
-
-- [Get a customer's details](#get-a-customers-details)
-- [Get first three levels of category tree](#get-first-three-levels-of-category-tree)
-- [Get category and products within by URL](#get-category-and-products-within-by-url)
-- [Look up an object by URL](#look-up-an-object-by-url)
-- [Get product images at different resolutions](#get-product-images-at-different-resolutions)
-- [Get a product](#get-a-product)
-- [Get variant details as a product object](#get-variant-details-as-a-product-object)
-- [Get product option details by product ID](#get-product-option-details-by-product-id)
-- [Get refined product object for given options](#get-refined-product-object-for-given-options)
-- [Get product swatch option values](#get-product-swatch-option-values)
-
-</div>
 
 Below are example GraphQL queries for use with the BigCommerce GraphQL Storefront API. The purpose of these examples is to assist developers in getting familiar with the API. For a general overview of it's usage and capabilities, see [GraphQL Storefront API Overview](https://developer.bigcommerce.com/api-docs/storefront/graphql/graphql-storefront-api-overview).
 

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -1,20 +1,6 @@
 # GraphQL Storefront API Overview
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [See it in action](#see-it-in-action)
-- [Accessing the GraphQL Playground](#accessing-the-graphql-playground)
-- [Using the GraphQL Playground](#using-the-graphql-playground)
-- [Authentication](#authentication)
-- [Querying within a BigCommerce storefront](#querying-within-a-bigcommerce-storefront)
-- [Querying from external systems](#querying-from-external-systems)
-- [Pagination](#pagination)
-- [Complexity limits](#complexity-limits)
-- [Related resources](#related-resources)
-
-</div>
 
 BigCommerce's GraphQL Storefront API makes it possible to query storefront data from within a [Stencil](https://developer.bigcommerce.com/stencil-docs/getting-started/about-stencil) theme or remote site. This means information previously only available on the back-end via [Stencil's template logic](https://developer.bigcommerce.com/stencil-docs/reference-docs/global-objects-and-properties) can now be accessed via front-end JavaScript. For example, with the Storefront API, it is possible to do the following:
 

--- a/docs/api-docs/storefront/scripts-overview.md
+++ b/docs/api-docs/storefront/scripts-overview.md
@@ -1,18 +1,6 @@
 # Scripts API
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Script Manager API partner guidelines](#script-manager-api-partner-guidelines)
-- [Prerequisites](#prerequisites)
-- [Upgrades and installation](#upgrades-and-installation)
-- [Fixing missing scripts](#fixing-missing-scripts)
-- [Notes](#notes)
-- [Script visibility locations](#script-visibility-locations)
-- [Related resources](#related-resources)
-
-</div>
 
 The BigCommerce Scripts API gives developers the ability to inject scripts into a store's template files programmatically. This ability means that apps and integrations can insert scripts into a user’s storefront without requiring the user to paste a snippet of code into their control panel manually. You can insert many types of scripts using this API, including the following:
 

--- a/docs/api-docs/storefront/widgets/global-regions-tutorial.md
+++ b/docs/api-docs/storefront/widgets/global-regions-tutorial.md
@@ -1,13 +1,6 @@
 # Global Regions
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Create a global region](#create-a-global-region)
-- [Place a widget in the global region](#place-a-widget-in-the-global-region)
-- [Related resources](#related-resources)
-
-</div>
 
 [Global regions](https://developer.bigcommerce.com/api-docs/store-management/widgets/overview#global-regions) are special regions you can use to place and manage content sitewide. 
 In this tutorial, we will explore the concept of global regions by creating a global region and placing a widget in it using Page Builder.

--- a/docs/api-docs/storefront/widgets/product-widget-tutorial.md
+++ b/docs/api-docs/storefront/widgets/product-widget-tutorial.md
@@ -1,15 +1,6 @@
 # Create Widgets Powered by GraphQL
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Prerequisites](#prerequisites)
-- [Create the widget template](#create-the-widget-template)
-- [Place the widget using Page Builder](#place-the-widget-using-page-builder)
-- [Place the widget using the API](#place-the-widget-using-the-api)
-- [Related resources](#related-resources)
-
-</div>
 
 Widgets are configurable and reusable components of content that merchants can display on their storefront. Widgets consist of a combination of HTML/CSS, JavaScript, and Handlebars, and are rendered as part of the storefront’s HTML.
 

--- a/docs/api-docs/storefront/widgets/widget-builder.md
+++ b/docs/api-docs/storefront/widgets/widget-builder.md
@@ -1,18 +1,6 @@
 # Widget Builder
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Prerequisites](#prerequisites)
-- [Install Widget Builder](#install-widget-builder)
-- [Configure Widget Builder](#configure-widget-builder)
-- [Reset or create parallel configurations](#reset-or-create-parallel-configurations)
-- [Generate a scaffold with `create`](#generate-a-scaffold-with-create)
-- [Continue development with `start`](#continue-development-with-start)
-- [Publish to store](#publish-to-store)
-- [Resources](#resources)
-
-</div>
 
 Widget Builder is a command-line tool that lets you build, edit, and preview custom storefront widgets in real time, outside the context of your BigCommerce store.
 

--- a/docs/api-docs/storefront/widgets/widget-versioning-tutorial.md
+++ b/docs/api-docs/storefront/widgets/widget-versioning-tutorial.md
@@ -1,14 +1,6 @@
 # Widget Versioning
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Create a widget template](#create-a-widget-template)
-- [Update the widget template](#update-the-widget-template)
-- [Upgrade the widget](#upgrade-the-widget)
-- [Related resources](#related-resources)
-
-</div>
 
 This article documents how to use [widget versioning](https://developer.bigcommerce.com/api-docs/store-management/widgets/overview#widget-versioning) to update a widget template without updating its widgets.
 

--- a/docs/api-docs/storefront/widgets/widgets-code-samples.md
+++ b/docs/api-docs/storefront/widgets/widgets-code-samples.md
@@ -1,16 +1,6 @@
 # Widgets Code Samples
 
-<div class="otp" id="no-index">
 
-### On this page
-- [List](#list)
-- [HTML](#html)
-- [Text with styling](#text-with-styling)
-- [Image slider](#image-slider)
-- [Button](#button)
-- [Related resources](#related-resources)
-
-</div>
 
 Below are widget code samples for developers to use as a starting point.
 

--- a/docs/api-docs/storefront/widgets/widgets-localizing-settings.md
+++ b/docs/api-docs/storefront/widgets/widgets-localizing-settings.md
@@ -1,14 +1,6 @@
 # Localizing Widget Template Settings
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Mapping settings to translations](#mapping-settings-to-translations)
-- [Supported language code schemes](#supported-language-code-schemes)
-- [Resources](#resources)
-  
-</div>
 
 You can localize widget template settings to the provided language translations using the internationalization (**i18n**) system.
 

--- a/docs/api-docs/storefront/widgets/widgets-overview.md
+++ b/docs/api-docs/storefront/widgets/widgets-overview.md
@@ -1,20 +1,7 @@
 # Widgets API
 
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Regions](#regions)
-- [Widget templates](#widget-templates)
-- [Widgets](#widgets)
-- [Widget versioning](#widget-versioning)
-- [Placements](#placements)
-- [Widgets on the storefront](#widgets-on-the-storefront)
-- [Definitions](#definitions)
-- [Related resources](#related-resources)
-
-</div>
 
 The Widgets API allows developers to create units of content and programmatically place them on specific pages of a BigCommerce storefront. The content can consist of HTML, CSS, and JavaScript, and is configurable using [Handlebars](https://handlebarsjs.com/) variables. The Widgets API supports various content types, such as YouTube videos, image sliders, and chat apps. 
 

--- a/docs/api-docs/storefront/widgets/widgets-tutorial.md
+++ b/docs/api-docs/storefront/widgets/widgets-tutorial.md
@@ -1,17 +1,6 @@
 # Create and Place a Widget
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Create a region](#create-a-region)
-- [Create a widget template](#create-a-widget-template)
-- [Create a widget](#create-a-widget)
-- [Create a placement](#create-a-placement)
-- [Create a custom template placement](#create-a-custom-template-placement)
-- [Create a user interface](#create-a-user-interface)
-- [Related resources](#related-resources)
-
-</div>
 
 BigCommerce's [Widgets API](https://developer.bigcommerce.com/api-docs/store-management/widgets/overview) allows you to create, manage, and apply widgets to your storefront. 
 

--- a/docs/bigcommerce-for-wordpress/extending-the-plugin/amp-for-the-plugin.md
+++ b/docs/bigcommerce-for-wordpress/extending-the-plugin/amp-for-the-plugin.md
@@ -3,20 +3,7 @@
 # AMP for the BigCommerce WordPress plugin
 #### Prepared by XWP for BigCommerce
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [What's AMP?](#whats-amp)
-- [AMP real world example](#amp-real-world-example)
-- [How to enable AMP](#how-to-enable-amp)
-- [WordPress AMP plugin support](#wordpress-amp-plugin-support)
-- [Choosing an AMP mode](#choosing-an-amp-mode)
-- [Previewing AMP](#previewing-amp)
-- [AMP Tools](#amp-tools)
-- [AMP for SEO](#amp-for-seo)
-- [Customizing AMP templates](#customizing-amp-templates)
-
-</div> 
+ 
 
 ## What's AMP?
 

--- a/docs/bigcommerce-for-wordpress/extending-the-plugin/code-reference.md
+++ b/docs/bigcommerce-for-wordpress/extending-the-plugin/code-reference.md
@@ -1,13 +1,6 @@
 # Code Reference
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Code reference](#code-reference)
-- [Usage notes](#usage-notes)
-
-
-</div> 
+ 
 
 ## Code reference
 To search the BigCommerce for WordPress (BC4WP) codebase for detailed entries on available hooks, functions, classes, and methods, visit the [BigCommerce Plugin Code Reference](https://bigcommerce.moderntribe.qa/).

--- a/docs/bigcommerce-for-wordpress/extending-the-plugin/customization-guide.html
+++ b/docs/bigcommerce-for-wordpress/extending-the-plugin/customization-guide.html
@@ -23,20 +23,7 @@
     <body>
         <div><h3 class="sub-docs-type" id="bigcommerce-for-wordpress">BigCommerce for Wordpress</h3>
 <h1 id="customization-guide">Customization Guide</h1>
-<div class="otp" id="no-index">
-<h3 id="on-this-page">On This Page</h3>
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#file-structure">File Structure</a></li>
-<li><a href="#template-overrides">Template Overrides</a></li>
-<li><a href="#accessing-bigcommerce-data">Accessing BigCommerce Data</a></li>
-<li><a href="#custom-css">Custom CSS</a></li>
-<li><a href="#hooks">Hooks</a></li>
-<li><a href="#styling-checkout">Styling Checkout</a></li>
-<li><a href="#email-templates">Email Templates</a></li>
-<li><a href="#additional-resources">Additional Resources</a></li>
-</ul>
-</div>
+
 <h2 id="introduction">Introduction</h2>
 <p>BigCommerce for WordPress is compatible out-of-the-box with all standard WordPress themes and includes full support for the Genesis theme framework. The plugin includes templates and stylesheets to render all of the elements and pages you need to merchandise your products and move shoppers through checkout, including:</p>
 <ul>

--- a/docs/bigcommerce-for-wordpress/extending-the-plugin/customization-guide.md
+++ b/docs/bigcommerce-for-wordpress/extending-the-plugin/customization-guide.md
@@ -2,21 +2,7 @@
 
 # Customization Guide
 
-<div class="otp" id="no-index">
 
-### On This Page
-
-- [Overview](#overview)
-- [Styling BC4WP templates](#Styling-BC4WP-templates)
-- [Accessing BigCommerce data](#accessing-bigcommerce-data)
-- [Custom CSS](#custom-css)
-- [Hooks](#hooks)
-- [Localizing strings displayed on the storefront](#localizing-strings-displayed-on-the-storefront)
-- [Styling checkout](#styling-checkout)
-- [Email templates](#email-templates)
-- [Related resources](#related-resources)
-
-</div>
 
 ## Overview
 

--- a/docs/bigcommerce-for-wordpress/extending-the-plugin/multi-channel-capabilities.md
+++ b/docs/bigcommerce-for-wordpress/extending-the-plugin/multi-channel-capabilities.md
@@ -1,19 +1,6 @@
 # Multi-Channel Capabilities
 
-<div class="otp" id="no-index">
 
-### On this Page
-- [Enabling Multiple Channels](#enabling-multiple-channels)
-- [Switching Channels](#switching-channels)
-- [Plugin Example](#plugin-example)
-- [Step 1: Setup Directory Structure](#step-1-setup-directory-structure)
-- [Step 2: Connect Channels](#step-2-connect-channels)
-- [Step 2: Add the Plugin Code](#step-2-add-the-plugin-code)
-- [Developing Further](#developing-further)
-- [FAQ](#faq)
-- [Resources](#resources)
-
-</div>
 
 Since version `3.1.0`, BigCommerce for WordPress is capable of managing multiple channels (and displaying different product listings for each channel) from within a single WordPress site. This makes it possible to have multiple storefronts on a single WordPress instance with BigCommerce serving as headless commerce back-end.
 

--- a/docs/bigcommerce-for-wordpress/extending-the-plugin/proxy-rest-api-endpoints.md
+++ b/docs/bigcommerce-for-wordpress/extending-the-plugin/proxy-rest-api-endpoints.md
@@ -1,12 +1,6 @@
 # Proxy REST API Endpoints
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Caching and Webhooks](#caching-and-webhooks)
-- [Endpoints](#endpoints)
-
-</div>
 
 BigCommerce for WordPress sets up several proxy REST endpoints that map requests to the BigCommerce API. This allows developers to build extensions using client-side requests without having to worry about cross-origin restrictions. This feature is useful for building extensions such as single-page store apps or progressive web apps, and it powers the AMP integration provided when the official AMP plugin for WordPress is active on the same site.
 

--- a/docs/bigcommerce-for-wordpress/getting-started/app-compatibility.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/app-compatibility.md
@@ -3,13 +3,7 @@
 
 # App Compatibility
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Supported Apps](#supported-apps)
-- [Unsupported Apps](#unsupported-apps)
-
-</div> 
+ 
 
 When you use BigCommerce for WordPress, your storefront is rendered by WordPress rather than BigCommerce, so some apps that you use for a BigCommerce-powered storefront may no longer be compatible.
 

--- a/docs/bigcommerce-for-wordpress/getting-started/gutenberg-support.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/gutenberg-support.md
@@ -2,13 +2,7 @@
 
 # Gutenberg Support
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Available BigCommerce Blocks](#available-bigcommerce-blocks)
-- [Creating Your Own Blocks](#creating-your-own-blocks)
-
-</div> 
+ 
 
 The WordPress Gutenberg Visual Editor provides users the ability to easily compose a page by adding and arranging blocks of content. Some blocks come with WordPress by default -- paragraph, image, list, and audio blocks, for example. Additionally, WordPress plugins can extend Gutenberg by adding their own blocks to the Visual Editor's Add Block dropdown. The BigCommerce for Wordpress plugin is packed with custom blocks that put the power of BigCommerce in the hands of WordPress developers.
 

--- a/docs/bigcommerce-for-wordpress/getting-started/install.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/install.md
@@ -2,14 +2,7 @@
 
 # Install
 
-<div class="otp" id="no-index">
 
-### On this page
-- [System requirements](#system-requirements)
-- [Installation](#installation)
-- [Setting your channel name](#setting-your-channel-name)
-
-</div>
 
 
 ## System requirements

--- a/docs/bigcommerce-for-wordpress/getting-started/introduction.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/introduction.md
@@ -2,12 +2,7 @@
 <div><h3 class="sub-docs-type" id="bigcommerce-for-wordpress">BigCommerce for Wordpress</h3>
 
 # Introduction
-<div class="otp" id="no-index">
 
-### On This Page
-- [How It Works](#how-it-works)
-
-</div>
 
 BigCommerce for WordPress allows you to power content-driven WordPress storefronts with the ecommerce functionality of BigCommerce. Product data is pulled into WordPress as a custom post type, giving you the freedom to embed products in posts and pages to create a tailored shopping experience. The plugin utilizes the full suite of BigCommerce APIs, allowing shoppers to seamlessly complete a purchase end-to-end on WordPress.
 

--- a/docs/bigcommerce-for-wordpress/getting-started/site-launch-checklist.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/site-launch-checklist.md
@@ -2,14 +2,7 @@
 
 # Site Launch Checklist
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Required steps](#required-steps)
-- [Optional steps](#optional-steps)
-- [Resources](#resources)
-
-</div>
 
 This document outlines our recommended steps for launching a BigCommerce for WordPress site. It assumes that you have a reasonable understanding of WordPress and BigCommerce and know how to install the BigCommerce for WordPress plugin. For an overview of BigCommerce and the BigCommerce for WordPress plugin, see the following articles:
 

--- a/docs/bigcommerce-for-wordpress/getting-started/supported-features.md
+++ b/docs/bigcommerce-for-wordpress/getting-started/supported-features.md
@@ -2,14 +2,7 @@
 
 # Supported Features
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Supported features](#supported-features)
-- [Unsupported features](#unsupported-features)
-- [General product roadmap](#general-product-roadmap)
-
-</div>
 
 ## Supported features
 

--- a/docs/bigcommerce-for-wordpress/setup/multi-site.md
+++ b/docs/bigcommerce-for-wordpress/setup/multi-site.md
@@ -2,14 +2,7 @@
 
 # Multisite Setup
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Getting your API credentials](#getting-your-api-credentials)
-- [Setting up a WordPress site using API account credentials](#setting-up-a-wordpress-site-using-api-account-credentials)
-- [Additional resources](#additional-resources)
-
-</div>
 
 When connecting more than one WordPress site to your BigCommerce store, you need to use an API account to link them. If you try to connect using the 'connect your store' flow, which uses a BigCommerce app to streamline the connection, your first WordPress site will lose its connection to BigCommerce.
 

--- a/docs/bigcommerce-for-wordpress/setup/plugin-settings.md
+++ b/docs/bigcommerce-for-wordpress/setup/plugin-settings.md
@@ -2,17 +2,7 @@
 
 # Plugin Settings
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Product Sync](#product-sync)
-- [Cart Settings](#cart-settings)
-- [Theme Customizer](#theme-customizer)
-- [Navigation Menus](#navigation-menus)
-- [Reviews](#reviews)
-- [Gift Certificate Settings](#gift-certificate-settings)
-
-</div>
 
 BigCommerce settings for WordPress are found in the left admin menu in WordPress, under the BigCommerce menu item.
 

--- a/docs/bigcommerce-for-wordpress/setup/product-import.md
+++ b/docs/bigcommerce-for-wordpress/setup/product-import.md
@@ -2,12 +2,7 @@
 
 # Product Import
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Product Import](#product-import)
-
-</div> 
+ 
 
 ## Product Import
 

--- a/docs/bigcommerce-for-wordpress/setup/shortcodes.md
+++ b/docs/bigcommerce-for-wordpress/setup/shortcodes.md
@@ -2,14 +2,7 @@
 
 # Shortcodes
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Products Shortcode](#products-shortcode)
-- [Component Shortcodes](#component-shortcodes)
-- [Other Shortcodes](#other-shortcodes)
-
-</div> 
+ 
 
 Most of the plugin's functionality is exposed on the front-end of the site through shortcodes embedded on automatically created pages. The code controlling those shortcodes can be found in the classes in `src/BigCommerce/Shortcodes`.
 

--- a/docs/bigcommerce-for-wordpress/setup/troubleshooting.md
+++ b/docs/bigcommerce-for-wordpress/setup/troubleshooting.md
@@ -2,13 +2,7 @@
 
 # Troubleshooting
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Error on "Add to Cart" button, 404 error](#error-on-%22add-to-cart%22-button-404-error)
-- [PHP getenv() Errors](#php-getenv-errors)
-
-</div> 
+ 
 
 ## Error on "Add to Cart" button, 404 error
 

--- a/docs/legacy/blueprint-themes/anatomy-of-a-theme.md
+++ b/docs/legacy/blueprint-themes/anatomy-of-a-theme.md
@@ -1,16 +1,6 @@
 # Anatomy of a Theme
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Directory Structure](#directory-structure)
-- [Images](#images)
-- [Layouts](#layouts)
-- [Panels](#panels)
-- [Snippets](#snippets)
-- [Styles](#styles)
-
-</div> 
+ 
 
 Themes are built using a powerful template system that enables designers and developers familiar with CSS and HTML to modify the presentation and structure of a BigCommerce store.
 

--- a/docs/legacy/blueprint-themes/blueprint-and-developer-mode.md
+++ b/docs/legacy/blueprint-themes/blueprint-and-developer-mode.md
@@ -1,12 +1,6 @@
 # Blueprint and Developer Mode
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [A Foundation for Creating Themes](#a-foundation-for-creating-themes)
-- [Setting Up Your Environment](#setting-up-your-environment)
-
-</div> 
+ 
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">

--- a/docs/legacy/blueprint-themes/blueprint-email-templates.md
+++ b/docs/legacy/blueprint-themes/blueprint-email-templates.md
@@ -1,15 +1,6 @@
 # Email Templates
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Gift Certificate Email Template](#gift-certificate-email-template)
-- [Abandoned Cart Email Template](#abandoned-cart-email-template)
-- [Invoice Email Template](#invoice-email-template)
-- [Order Status Email Template](#order-status-email-template)
-- [Return Confirmation Email Template](#return-confirmation-email-template)
-
-</div>
 
 The following variables are available within individual BigCommerce email template:
 

--- a/docs/legacy/blueprint-themes/blueprint-template-syntax.md
+++ b/docs/legacy/blueprint-themes/blueprint-template-syntax.md
@@ -1,15 +1,6 @@
 # Template Syntax
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Global-Variables References](#global-variables-references)
-- [Panel References](#panel-references)
-- [Snippet References](#snippet-references)
-- [Referencing Distributed Theme Assets](#referencing-distributed-theme-assets)
-- [File Includes](#file-includes)
-
-</div>
 
 Each of the layout, panel, and snippet files in a theme uses variables (also called placeholders) to show external content or content fetched from the database (such as the name of a product).
 

--- a/docs/legacy/blueprint-themes/blueprint-theme-update-process.md
+++ b/docs/legacy/blueprint-themes/blueprint-theme-update-process.md
@@ -1,13 +1,6 @@
 # Theme Update Process
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Prerequisites](#prerequisites)
-- [Update Process](#update-process)
-- [Other Requirements](#other-requirements)
-
-</div> 
+ 
 
 Here is how BigCommerce and our partners collaborate to integrate a partner's theme changes/updates into the BigCommerce Theme Marketplace (which merchants also know as our "theme store"):
 

--- a/docs/legacy/blueprint-themes/checkout-styling.md
+++ b/docs/legacy/blueprint-themes/checkout-styling.md
@@ -1,15 +1,6 @@
 # Checkout Styling
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Customization Options/Restrictions](#customization-optionsrestrictions)
-- [Configuring the Desktop Viewport](#configuring-the-desktop-viewport)
-- [Deploying Custom CSS](#deploying-custom-css)
-- [Classes Provided](#classes-provided)
-- [CSS Skeleton](#css-skeleton)
-
-</div> 
+ 
 
 To support stores that enable BigCommerce's Optimized One-Page Checkout feature, you can customize the Optimized Checkout page's styling within your theme. You do this by adding custom CSS to the `optimized-checkout-webdav.css` template file that we provide. You can copy the CSS [below](#css-skeleton).
 

--- a/docs/legacy/blueprint-themes/product-filtering-toolkit.md
+++ b/docs/legacy/blueprint-themes/product-filtering-toolkit.md
@@ -1,15 +1,6 @@
 # Product Filtering Toolkit
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Creating a New Theme with Product Filtering](#creating-a-new-theme-with-product-filtering)
-- [Enabling Product Filtering for Your Customized Theme](#enabling-product-filtering-for-your-customized-theme)
-- [Implementing Product Filtering in Your Theme](#implementing-product-filtering-in-your-theme)
-- [Allowing For Filtering On/Off](#allowing-for-filtering-onoff)
-- [Category Filtering Details](#category-filtering-details)
-
-</div> 
+ 
 
 Product filtering (also known as faceted search) enables shoppers to refine product searches based on multiple attributes like price, size, ratings, etc. For a store owner's view of administering this feature, please see <a href="https://forum.bigcommerce.com/s/article/Product-Filtering-Settings" target="_blank">this KB article</a>. 
 

--- a/docs/legacy/blueprint-themes/recaptcha-two.md
+++ b/docs/legacy/blueprint-themes/recaptcha-two.md
@@ -1,13 +1,6 @@
 # ReCaptcha 2
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Better Spam Deterrence](#better-spam-deterrence)
-- [How to Upgrade](#how-to-upgrade)
-- [Supported Browsers](#supported-browsers)
-
-</div> 
+ 
 
 To deter spam submission through storefront forms, BigCommerce now supports Google [reCAPTCHA v2](https://support.google.com/recaptcha/?hl=en#6080933) challenges, to distinguish human customers/visitors from automated bots.
 

--- a/docs/legacy/blueprint-themes/style-editor.md
+++ b/docs/legacy/blueprint-themes/style-editor.md
@@ -1,13 +1,6 @@
 # Style Editor
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [What Is Less.js?](#what-is-lessjs)
-- [Integrating a Theme with the Style Editor](#integrating-a-theme-with-the-style-editor)
-- [Testing Style Editor with Your Theme](#testing-style-editor-with-your-theme)
-
-</div> 
+ 
 
 Style Editor allows users to customize the look and feel of their BigCommerce store, without needing to know HTML or CSS conventions. Using a simple WYSIWYG interface, users can edit colors and fonts, then see the changes simultaneously in a live preview.
 

--- a/docs/legacy/stencil-themes/installing-legacy-theme-modules.md
+++ b/docs/legacy/stencil-themes/installing-legacy-theme-modules.md
@@ -1,16 +1,6 @@
 # Installing Legacy Theme Modules
 
-<div class="otp" id="no-index">
 
-### On This Page
-
-* [Step 1: Install `jspm`](#install-jspm)
-* [Step 2: Register `jspm` Instance](#register-jspm-instance)
-* [Step 3: Install `jspm-git`](#install-jspm-git)
-* [Step 4: Add BitBucket as a `jspm Registry`](#add-bitbucket-as-a-jspm-registry)
-* [Step 5: Install the Modules](#install-the-modules) 
-
-</div>
 
 If a theme’s version number is lower than `1.10.0`, the theme uses `jspm` as its JavaScript build system. Follow the steps outlined on this article to install theme modules via `jspm`.
 

--- a/docs/legacy/stencil-themes/stored-credit-card-management.md
+++ b/docs/legacy/stencil-themes/stored-credit-card-management.md
@@ -1,22 +1,6 @@
 # Stored Credit Card Management
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Prerequisites](#prerequisites)
-- [Adding Stored Credit Card Management](#adding-stored-credit-card-management)
-- [Step 1: Add Payment Methods Page](#step-1-add-payment-methods-page)
-- [Step 2: Add Translations](#step-2-add-translations)
-- [Step 3: Include Credit Card Listing](#step-3-include-credit-card-listing)
-- [Step 4: Add Credit Card Actions](#step-4-add-credit-card-actions)
-- [Step 5: Implement `Delete Payment` Method](#step-5-implement-delete-payment-method)
-- [Step 6: Implement `Edit Payment` Method](#step-6-implement-edit-payment-method)
-- [Step 7: Implement `Add Payment` Method](#step-7-implement-add-payment-method)
-- [Step 8: Add Default Instrument](#step-8-add-default-instrument)
-- [FAQ](#faq)
-- [Resources](#resources)
-
-</div>
 
 Stored Credit Card management gives customer’s the ability to manage their stored credit cards from the My Account page of the storefront. In the Cornerstone theme, shoppers with store accounts will have the ability to add new cards, delete cards, select a default card, and edit the billing details of existing cards from their customer account area of the storefront.
 

--- a/docs/legacy/v2-catalog-products/v2-brands.md
+++ b/docs/legacy/v2-catalog-products/v2-brands.md
@@ -1,18 +1,6 @@
 # Brands
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Brands](#brands)
-- [List Brands](#list-brands)
-- [Get a Brand](#get-a-brand)
-- [Get a Count of Brands](#get-a-count-of-brands)
-- [Create a Brand](#create-a-brand)
-- [Update a Brand](#update-a-brand)
-- [Delete a Brand](#delete-a-brand)
-- [Delete All Brands](#delete-all-brands)
-
-</div> 
+ 
 
 ## Brands 
 

--- a/docs/legacy/v2-catalog-products/v2-bulk-pricing.md
+++ b/docs/legacy/v2-catalog-products/v2-bulk-pricing.md
@@ -1,18 +1,6 @@
 # Bulk Pricing Rules
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Bulk Pricing](#bulk-pricing)
-- [List Bulk Pricing Rules](#list-bulk-pricing-rules)
-- [Get a Product Bulk Pricing Rule](#get-a-product-bulk-pricing-rule)
-- [Get a Count of Bulk Pricing Rules](#get-a-count-of-bulk-pricing-rules)
-- [Create a Product Bulk Pricing Rule](#create-a-product-bulk-pricing-rule)
-- [Update a Product Bulk Pricing Rule](#update-a-product-bulk-pricing-rule)
-- [Delete a Product Bulk Pricing Rule](#delete-a-product-bulk-pricing-rule)
-- [Delete Multiple Product Bulk Pricing Rules](#delete-multiple-product-bulk-pricing-rules)
-
-</div> 
+ 
 
 ##  Bulk Pricing 
 

--- a/docs/legacy/v2-catalog-products/v2-categories.md
+++ b/docs/legacy/v2-catalog-products/v2-categories.md
@@ -1,18 +1,6 @@
 # Categories
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Categories](#categories)
-- [List Categories](#list-categories)
-- [Get a Category](#get-a-category)
-- [Get a Count of Categories](#get-a-count-of-categories)
-- [Create a Category](#create-a-category)
-- [Update a Category](#update-a-category)
-- [Delete a Category](#delete-a-category)
-- [Delete All Categories](#delete-all-categories)
-
-</div>
 
 ## Categories 
 

--- a/docs/legacy/v2-catalog-products/v2-custom-fields.md
+++ b/docs/legacy/v2-catalog-products/v2-custom-fields.md
@@ -1,17 +1,6 @@
 # Custom Fields
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Custom Fields](#custom-fields)
-- [List Custom Fields](#list-custom-fields)
-- [Get a Custom Field](#get-a-custom-field)
-- [Get a Count of Custom Fields](#get-a-count-of-custom-fields)
-- [Create a Custom Field](#create-a-custom-field)
-- [Delete a Custom Field](#delete-a-custom-field)
-- [Delete Multiple Custom Fields](#delete-multiple-custom-fields)
-
-</div> 
+ 
 
 ## Custom Fields 
 

--- a/docs/legacy/v2-catalog-products/v2-option-set-options.md
+++ b/docs/legacy/v2-catalog-products/v2-option-set-options.md
@@ -1,17 +1,6 @@
 # Option Set Options
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Option Set Options](#option-set-options)
-- [List Option Set Options](#list-option-set-options)
-- [Get an Option Set Option](#get-an-option-set-option)
-- [Create an Option Set Option](#create-an-option-set-option)
-- [Update an Option Set Option](#update-an-option-set-option)
-- [Delete an Option Set Option](#delete-an-option-set-option)
-- [Delete Multiple Option Set Options](#delete-multiple-option-set-options)
-
-</div> 
+ 
 
 ##  Option Set Options 
 

--- a/docs/legacy/v2-catalog-products/v2-option-sets.md
+++ b/docs/legacy/v2-catalog-products/v2-option-sets.md
@@ -1,18 +1,6 @@
 # Option Sets
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Option Sets](#option-sets)
-- [List Option Sets](#list-option-sets)
-- [Get an Option Set](#get-an-option-set)
-- [Get a Count of Option Sets](#get-a-count-of-option-sets)
-- [Create an Option Set](#create-an-option-set)
-- [Update an Option Set](#update-an-option-set)
-- [Delete an Option Set](#delete-an-option-set)
-- [Delete All Option Sets](#delete-all-option-sets)
-
-</div> 
+ 
 
 ## Option Sets 
 

--- a/docs/legacy/v2-catalog-products/v2-option-values.md
+++ b/docs/legacy/v2-catalog-products/v2-option-values.md
@@ -1,17 +1,6 @@
 # Option Values
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Option Values](#option-values)
-- [List Option Values](#list-option-values)
-- [Get an Option Value](#get-an-option-value)
-- [Create an Option Value](#create-an-option-value)
-- [Update an Option Value](#update-an-option-value)
-- [Delete an Option Value](#delete-an-option-value)
-- [Delete Multiple Option Values](#delete-multiple-option-values)
-
-</div> 
+ 
 
 ## Option Values 
 

--- a/docs/legacy/v2-catalog-products/v2-options.md
+++ b/docs/legacy/v2-catalog-products/v2-options.md
@@ -1,13 +1,6 @@
 # Product Options
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Options](#options)
-- [List Product Options](#list-product-options)
-- [Get a Product Option](#get-a-product-option)
-
-</div> 
+ 
 
 ## Options 
 

--- a/docs/legacy/v2-catalog-products/v2-product-images.md
+++ b/docs/legacy/v2-catalog-products/v2-product-images.md
@@ -1,17 +1,6 @@
 # Product Images
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Product Images](#product-images)
-- [Get a Product Image](#get-a-product-image)
-- [Get a Count of Product Images](#get-a-count-of-product-images)
-- [Create a Product Image](#create-a-product-image)
-- [Update a Product Image](#update-a-product-image)
-- [Delete a Product Image](#delete-a-product-image)
-- [Delete Multiple Product Images](#delete-multiple-product-images)
-
-</div> 
+ 
 
 ## Product Images 
 

--- a/docs/legacy/v2-catalog-products/v2-product-options.md
+++ b/docs/legacy/v2-catalog-products/v2-product-options.md
@@ -1,13 +1,6 @@
 # Product Options
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Product Options](#product-options)
-- [List Product Options](#list-product-options)
-- [Get a Product Option](#get-a-product-option)
-
-</div> 
+ 
 
 ## Product Options 
 

--- a/docs/legacy/v2-catalog-products/v2-product-reviews.md
+++ b/docs/legacy/v2-catalog-products/v2-product-reviews.md
@@ -1,17 +1,6 @@
 # Product Reviews
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Product Reviews](#product-reviews)
-- [List Product Reviews](#list-product-reviews)
-- [Get a Product Review](#get-a-product-review)
-- [Create a Product Review](#create-a-product-review)
-- [Update a Product Review](#update-a-product-review)
-- [Delete a Product Review](#delete-a-product-review)
-- [Delete All Product Reviews](#delete-all-product-reviews)
-
-</div> 
+ 
 
 ## Product Reviews 
 

--- a/docs/legacy/v2-catalog-products/v2-product-rules.md
+++ b/docs/legacy/v2-catalog-products/v2-product-rules.md
@@ -1,18 +1,6 @@
 # Product Rules
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Product Rules](#product-rules)
-- [List Product Rules](#list-product-rules)
-- [Get a Product Rule](#get-a-product-rule)
-- [Get a Count of Product Rules](#get-a-count-of-product-rules)
-- [Create a Product Rule](#create-a-product-rule)
-- [Update a Product Rule](#update-a-product-rule)
-- [Delete a Product Rule](#delete-a-product-rule)
-- [Delete Multiple Product Rules](#delete-multiple-product-rules)
-
-</div> 
+ 
 
 ## Product Rules 
 

--- a/docs/legacy/v2-catalog-products/v2-product-sku.md
+++ b/docs/legacy/v2-catalog-products/v2-product-sku.md
@@ -1,16 +1,6 @@
 # Product SKU
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [SKUs](#skus)
-- [List Product SKUs](#list-product-skus)
-- [Get a Product SKU](#get-a-product-sku)
-- [Update a Product SKU](#update-a-product-sku)
-- [Delete a Product SKU](#delete-a-product-sku)
-- [Delete Multiple Product SKUs](#delete-multiple-product-skus)
-
-</div> 
+ 
 
 ## SKUs 
 

--- a/docs/legacy/v2-catalog-products/v2-product-videos.md
+++ b/docs/legacy/v2-catalog-products/v2-product-videos.md
@@ -1,18 +1,6 @@
 # Product Videos
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Videos](#videos)
-- [List Product Videos](#list-product-videos)
-- [Get a Product Video](#get-a-product-video)
-- [Get a Count of Product Videos](#get-a-count-of-product-videos)
-- [Create a Product Video](#create-a-product-video)
-- [Update Product Video Metadata](#update-product-video-metadata)
-- [Delete a Product Video](#delete-a-product-video)
-- [Delete All Product Videos](#delete-all-product-videos)
-
-</div> 
+ 
 
 ## Videos 
 

--- a/docs/legacy/v2-catalog-products/v2-products.md
+++ b/docs/legacy/v2-catalog-products/v2-products.md
@@ -1,18 +1,6 @@
 # Products
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Products](#products)
-- [List Products](#list-products)
-- [Get a Product](#get-a-product)
-- [Get a Product Count](#get-a-product-count)
-- [Create a Product](#create-a-product)
-- [Update a Product](#update-a-product)
-- [Delete a Product](#delete-a-product)
-- [Delete All Products](#delete-all-products)
-
-</div> 
+ 
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--error">

--- a/docs/legacy/v2-products/v2-v3.md
+++ b/docs/legacy/v2-products/v2-v3.md
@@ -1,19 +1,6 @@
 # V2 versus V3 API
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Advantages of V3 over V2](#advantages-of-v3-over-v2)
-- [Products in V3](#products-in-v3)
-- [Interoperability between V2 and V3](#interoperability-between-v2-and-v3)
-- [What's not in V3](#whats-not-in-v3)
-- [Recommendations](#recommendations)
-- [V2 and V3 Cheat Sheet](#v2-and-v3-cheat-sheet)
-- [Simple Product](#simple-product)
-- [Complex Products](#complex-products)
-- [Stock Levels](#stock-levels)
-
-</div>
 
 ## Advantages of V3 over V2
 

--- a/docs/partner-apps/bundleb2b/b2b-edition.md
+++ b/docs/partner-apps/bundleb2b/b2b-edition.md
@@ -1,10 +1,4 @@
 # The B2B Edition of BigCommerce
-### On this page
-- [B3 integration with BigCommerce](#b3-integration-with-bigcommerce)
-- [Customizing B3](#customizing-b3)
-- [Overwriting and injecting JavaScript](#overwriting-and-injecting-javascript)
-- [B3 REST API](#b3-rest-api)
-- [Additional BundleB2B resources](#additional-bundleb2b-resources)
 
 BundleB2B (B3) adds business-to-business (B2B) functionality to the BigCommerce platform, allowing businesses to easily facilitate B2B operations online. B3 provides a comprehensive suite of key B2B features to improve the B2B self-service experience for BigCommerce store owners and their customers.
 

--- a/docs/stencil-docs/configure-store-design-ui/defining-global-styles.md
+++ b/docs/stencil-docs/configure-store-design-ui/defining-global-styles.md
@@ -1,18 +1,6 @@
 # Defining Global Styles
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Configuration file](#configuration-file)
-- [Requirements and restrictions](#requirements-and-restrictions)
-- [New products example](#new-products-example)
-- [Changing page layout using local front matter](#changing-page-layout-using-local-front-matter)
-- [Retrieving specific config.json values through Sass](#retrieving-specific-configjson-values-through-sass)
-- [Adding and removing components](#adding-and-removing-components)
-- [Resources](#resources)
-
-</div>
 
 ## Configuration file
 

--- a/docs/stencil-docs/configure-store-design-ui/defining-ui-options.md
+++ b/docs/stencil-docs/configure-store-design-ui/defining-ui-options.md
@@ -1,16 +1,6 @@
 # Defining UI Options
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Enabling Store Design Options](#enabling-store-design-options)
-- [Best Practices](#best-practices)
-- [How .json Entries Govern Store Design's UI](#how-json-entries-govern-store-designs-ui)
-- [Store Design Data Types](#store-design-data-types)
-- [Store Design Data Structure in schema.json](#store-design-data-structure-in-schemajson)
-- [Store Design UI Troubleshooting](#store-design-ui-troubleshooting)
-
-</div> 
+ 
 
 You are free to decide which properties of your theme to make editable in Store Design, and in which order to display them. Store Design can expose any set of properties as long as your <span class="fn">schema.json</span> declares them using the data types that Store Design supports.
 

--- a/docs/stencil-docs/configure-store-design-ui/store-design-overview.md
+++ b/docs/stencil-docs/configure-store-design-ui/store-design-overview.md
@@ -1,15 +1,6 @@
 # Store Design Overview
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Configuration Files](#configuration-files)
-- [Managing Keys between Versions](#managing-keys-between-versions)
-- [Persistent Settings Storage](#persistent-settings-storage)
-- [Theme Upgrades and Settings](#theme-upgrades-and-settings)
-- [Resources](#resources)
-
-</div> 
+ 
 
 [Store Design](https://support.bigcommerce.com/s/article/Store-Design) is a browser-based tool that enables BigCommerce merchants to rapidly modify and customize a storefront's look and feel without writing any code. A merchant using Store Design can customize a storefront theme by modifying characteristics from a variety of menu options such as **Styles, Colors, Typography, Buttons**, and more. 
 

--- a/docs/stencil-docs/customizing-checkout/checkout-confirmation-injection.md
+++ b/docs/stencil-docs/customizing-checkout/checkout-confirmation-injection.md
@@ -1,16 +1,6 @@
 # Checkout/Confirmation Injection Options
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Adding Storewide Styles](#adding-storewide-styles)
-- [Applying Storewide Header](#applying-storewide-header)
-- [Applying Storewide Scripts](#applying-storewide-scripts)
-- [Adding Trust Seals](#adding-trust-seals)
-- [Checkout App Injection](#checkout-app-injection)
-- [Resources](#resources)
-
-</div>
 
 ## Adding Storewide Styles
 

--- a/docs/stencil-docs/customizing-checkout/checkout-sdk-example.md
+++ b/docs/stencil-docs/customizing-checkout/checkout-sdk-example.md
@@ -1,13 +1,6 @@
 # Checkout SDK Tutorial
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Implementing React Checkout in Cornerstone](#implementing-react-checkout-in-cornerstone)
-- [Additional customizations](#additional-customizations)
-- [Additional resources](#additional-resources)
-
-</div>
 
 This tutorial demonstrates how to implement a custom checkout built with React on the Cornerstone theme. The checkout will utilize BigCommerce's Checkout SDK. This tutorial assumes [Cornerstone 3.4.0](https://github.com/bigcommerce/cornerstone/releases/tag/3.4.0) as a starting point.
 

--- a/docs/stencil-docs/customizing-checkout/checkout-sdk-quickstart.md
+++ b/docs/stencil-docs/customizing-checkout/checkout-sdk-quickstart.md
@@ -1,17 +1,6 @@
 # Checkout SDK Quickstart
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Prerequisites](#prerequisites)
-- [Installing the Checkout JS SDK](#installing-the-checkout-js-sdk)
-- [Creating a checkout-loader.js file](#creating-a-checkoutjs-file)
-- [Installing your custom checkout](#installing-custom-checkout)
-- [Logging the Checkout Object](#logging-the-checkout-object)
-- [Resources](#resources)
-- [Related articles](#related-articles)
-
-</div> 
+ 
 
 The Checkout JS SDK is a JavaScript library of methods for performing actions related to checkout. It includes methods for logging in a customer, adding addresses to the checkout object, and surfacing the shipping and payment methods that a merchant has configured. It’s everything you need to build your own custom checkout page on BigCommerce.
 

--- a/docs/stencil-docs/customizing-checkout/optimized-one-page-checkout.md
+++ b/docs/stencil-docs/customizing-checkout/optimized-one-page-checkout.md
@@ -1,17 +1,6 @@
 # Restyle Optimized One-Page Checkout
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Working with the optimized checkout SCSS file](#working-with-the-optimized-checkout-scss-file)
-- [Configuring the desktop viewport](#configuring-the-desktop-viewport)
-- [Classes available for customization](#classes-available-for-customization)
-- [Providing customizable options in Page Builder](#providing-customizable-options-in-page-builder)
-- [Currency conversion options](#currency-conversion-options)
-- [Related resources](#related-resources)
-
-
-</div> 
+ 
 
 ## Working with the optimized checkout SCSS file
 

--- a/docs/stencil-docs/customizing-checkout/paypal-smart-buttons.md
+++ b/docs/stencil-docs/customizing-checkout/paypal-smart-buttons.md
@@ -1,13 +1,6 @@
 # PayPal Smart Buttons
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Enable Smart Buttons on Your Stencil Theme](#enable-smart-buttons-on-your-stencil-theme)
-- [Enabling Smart Buttons Customization via Page Builder](#enabling-smart-buttons-customization-via-page-builder)
-- [Resources](#resources)
-
-</div> 
+ 
 
 PayPal Smart Buttons are available on Cornerstone versions 2.6.0+ for merchants who have **PayPal powered by Braintree** or **PayPal Express Checkout** enabled on their store.
 

--- a/docs/stencil-docs/deploying-a-theme/bundling-and-pushing.md
+++ b/docs/stencil-docs/deploying-a-theme/bundling-and-pushing.md
@@ -1,17 +1,6 @@
 # Bundling and Pushing a Theme
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Confirm dependencies](#confirm-dependencies)
-- [Verify directory and file permissions](#verify-directory-and-file-permissions)
-- [Bundling your theme](#bundling-your-theme)
-- [Pushing your theme](#pushing-your-theme)
-- [Theme quota warning](#theme-quota-warning)
-- [Other bundling or upload errors](#other-bundling-or-upload-errors)
-- [Resources](#resources)
-
-</div> 
+ 
 
 ## Confirm dependencies
 

--- a/docs/stencil-docs/deploying-a-theme/checking-a-themes-size.md
+++ b/docs/stencil-docs/deploying-a-theme/checking-a-themes-size.md
@@ -1,13 +1,6 @@
 # Checking a Theme's Size
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Shrinking a theme](#shrinking-a-theme)
-- [Organizing a theme](#organizing-a-theme)
-- [Resources](#resources)
-
-</div> 
+ 
 
 Ideally, your theme should bundle into an archive of only a few megabytes (MB). BigCommerce imposes a hard limit of 50 MB, but most themes do not approach this limit unless they include many large static assets. If your theme does not exceed 50 MB, follow the steps outlined in [Bundling and Pushing a Theme](https://developer.bigcommerce.com/stencil-docs/deploying-a-theme/bundling-and-pushing) to process and package your theme for upload to BigCommerce.
 

--- a/docs/stencil-docs/deploying-a-theme/naming-your-theme.md
+++ b/docs/stencil-docs/deploying-a-theme/naming-your-theme.md
@@ -1,15 +1,6 @@
 # Naming Your Theme and Theme Variations
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Naming your theme](#naming-your-theme)
-- [Creating and naming a new theme variation](#creating-and-naming-a-new-theme-variation)
-- [Changing a theme variation’s font family](#changing-a-theme-variations-font-family-configjson)
-- [Preparing a variation’s thumbnails](#preparing-a-variations-thumbnails)
-- [Resources](#resources)
-
-</div> 
+ 
 
 ## Naming your theme
 

--- a/docs/stencil-docs/deploying-a-theme/preparing-thumbnail-images.md
+++ b/docs/stencil-docs/deploying-a-theme/preparing-thumbnail-images.md
@@ -1,15 +1,6 @@
 # Preparing Thumbnail Images
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Where merchants see your theme's thumbnail images](#where-merchants-see-your-themes-thumbnail-images)
-- [General image requirements](#general-image-requirements)
-- [Theme-wide composite image](#theme-wide-composite-image)
-- [Variations: desktop and mobile screenshots](#variations-desktop-and-mobile-screenshots)
-- [Resources](#resources)
-
-</div>
 
 ## Displaying theme thumbnail images
 

--- a/docs/stencil-docs/deploying-a-theme/theme-best-practices.md
+++ b/docs/stencil-docs/deploying-a-theme/theme-best-practices.md
@@ -1,14 +1,6 @@
 # Theme Development Best Practices Tutorial
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Importing images](#importing-images)
-- [Injecting variables](#injecting-variables)
-- [Using Lighthouse](#using-lighthouse)
-- [Designing for accessibility](#designing-for-accessibility)
-- [Related resources](#related-resources)
-</div>
 
 In this tutorial, you will learn the correct way to import theme images and inject theme variables. Also, you will learn how to improve theme designs using [Lighthouse](https://developers.google.com/web/tools/lighthouse) and [accessibility best practices](https://developer.bigcommerce.com/stencil-docs/theme-accessibility).
 

--- a/docs/stencil-docs/deploying-a-theme/troubleshooting-theme-uploads.md
+++ b/docs/stencil-docs/deploying-a-theme/troubleshooting-theme-uploads.md
@@ -1,14 +1,6 @@
 # Troubleshooting Theme Uploads
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Restrictions](#restrictions)
-- [Error codes](#error-codes)
-- [Warnings](#warnings)
-- [Workarounds and further info](#workarounds-and-further-info)
-
-</div> 
+ 
 
 ## Restrictions
 

--- a/docs/stencil-docs/developing-further/add-recaptcha-v2.md
+++ b/docs/stencil-docs/developing-further/add-recaptcha-v2.md
@@ -1,12 +1,6 @@
 # Add reCAPTCHA V2
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [How to Upgrade](#how-to-upgrade)
-- [Resources](#resources)
-
-</div> 
+ 
 
 reCAPTCHA v1 was deprecated as of March 31, 2018. To deter spam submission through storefront forms, BigCommerce now supports Google reCAPTCHA v2 challenges, to distinguish human customers/visitors from automated bots. We recommend that all storefront themes take advantage of this upgraded bot detection.
 

--- a/docs/stencil-docs/developing-further/catalog-price-object.md
+++ b/docs/stencil-docs/developing-further/catalog-price-object.md
@@ -1,14 +1,6 @@
 # Catalog Price Object Examples
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Catalog price object examples excluding tax](#catalog-price-object-examples-excluding-tax)
-- [Catalog price object examples including and excluding tax](#catalog-price-object-examples-including-and-excluding-tax)
-- [Control panel quick reference](#control-panel-quick-reference)
-- [Resources](#resources)
-
-</div> 
+ 
 
 As a theme developer, you can use the catalog price object to highlight the savings that a merchant is offering over the MSRP directly on the storefront by referencing the product's `price` object and the correct property for the product.
 

--- a/docs/stencil-docs/developing-further/customizing-emails.md
+++ b/docs/stencil-docs/developing-further/customizing-emails.md
@@ -1,12 +1,6 @@
 # BigCommerce Legacy Email Templates
 
-<div class="otp" id="no-index">
 
-### On this page
-- [BigCommerce Legacy Email Templates](#bigcommerce-legacy-email-templates)
-- [Accessing and Editing Legacy Email Templates](#accessing-and-editing-legacy-email-templates)
-
-</div>
 This article provides information on how to create your own unique email templates using our legacy framework. 
 
 <div class="HubBlock--callout">

--- a/docs/stencil-docs/developing-further/customizing-invoices.md
+++ b/docs/stencil-docs/developing-further/customizing-invoices.md
@@ -1,15 +1,6 @@
 # Customizing Invoices
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Email invoice template](#email-invoice-template)
-- [Merchant printable invoice](#merchant-printable-invoice)
-- [Customizing the customer printable invoice](#customizing-the-customer-printable-invoice)
-- [Customizing the detailed customer printable invoice](#customizing-the-detailed-customer-printable-invoice)
-- [Resources](#resources)
-
-</div>
 
 There are four editable invoices in BigCommerce:
 

--- a/docs/stencil-docs/developing-further/customizing-printable-packing-slips.md
+++ b/docs/stencil-docs/developing-further/customizing-printable-packing-slips.md
@@ -1,12 +1,6 @@
 # Customizing Printable Packing Slips
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Customizing printable packing slips](#customizing-printable-packing-slips)
-- [Resources](#resources)
-
-</div> 
+ 
 
 Developers are commonly asked to modify the default content of packing slips in order to satisfy specific business requirements and industry demands. This article contains instructions on how to edit the HTML file of a printable packing slip.
 

--- a/docs/stencil-docs/developing-further/google-amp.md
+++ b/docs/stencil-docs/developing-further/google-amp.md
@@ -1,14 +1,6 @@
 # Google AMP
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Implementing AMP](#implementing-amp)
-- [Location of AMP Files](#location-of-amp-files)
-- [Local Testing](#local-testing)
-- [Resources](#resources)
-
-</div> 
+ 
 
 Google AMP (Accelerated Mobile Pages) is an open-source project to improve page speed on mobile devices by using a specific framework for a page’s code. The improved performance on mobile devices provides a better browsing experience for shoppers and boosts ranking on Google search. To learn more about the Google AMP project, see [AMP Overview](https://www.ampproject.org/support/faqs/overview) on the Google AMP project site.
 

--- a/docs/stencil-docs/developing-further/google-analytics-enhanced-ecommerce.md
+++ b/docs/stencil-docs/developing-further/google-analytics-enhanced-ecommerce.md
@@ -1,14 +1,6 @@
 # Google Analytics Enhanced ECommerce
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Adding data attributes](#adding-data-attributes)
-- [Data attribute reference](#data-attribute-reference)
-- [Custom dimensions and metrics](#custom-dimensions-and-metrics)
-- [Resources](#resources)
-
-</div>
 
 Google Analytics is a free analytics tool that helps you track visitors and conversions on your store. BigCommerce has updated the Google Analytics integration to support Enhanced Ecommerce.  As apart of the Enhanced ECommerce feature, Stencil themes now support data attributes.
 

--- a/docs/stencil-docs/developing-further/modifying-forms.md
+++ b/docs/stencil-docs/developing-further/modifying-forms.md
@@ -1,9 +1,5 @@
 # Modify the Login Form
-<div class="otp" id="no-index">
 
-### On this page
-- [Modifying the template](#modifying-the-template)
-</div>
 
 ## Modifying the template
 You can customize the login experience by modifying the theme's `templates/pages/auth/login.html` file.

--- a/docs/stencil-docs/developing-further/stored-credit-card-management.md
+++ b/docs/stencil-docs/developing-further/stored-credit-card-management.md
@@ -1,14 +1,6 @@
 # Stored Payment Methods
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Requirements](#requirements)
-- [Adding Stored Credit Cards](#adding-stored-credit-cards)
-- [FAQ](#faq)
-- [Resources](#resources)
-
-</div>
 
 Cornerstone release [`2.6.0`](https://developer.bigcommerce.com/changelog#posts/cornerstone-2-6-0-release) added stored payment method management for saved credit cards to the customer `account.php` page. Cornerstone [`4.4.0`](https://developer.bigcommerce.com/changelog#posts/cornerstone-4-4-0-release) expands this functionality to include saving PayPal accounts via [PayPal powered by Braintree](https://support.bigcommerce.com/s/article/Connecting-with-PayPal-Powered-by-Braintree). This article contains instructions for manually applying the changes made in `4.4.0` to themes version `2.6.0 ` to `4.3.1`. For a full diff of the files to change, see [Pull Request #1603](https://github.com/bigcommerce/cornerstone/pull/1603/files). If you're developing on a theme older than version `2.6.0` you'll first need to apply the changes made in `2.6.0`; to do so, see [Stored Credit Card Management](https://developer.bigcommerce.com/legacy/stencil-themes/stored-credit-card-management). For theme update best practices, see [Theme Updates and Version Control](https://developer.bigcommerce.com/stencil-docs/developing-further/theme-updates-and-version-control).
 

--- a/docs/stencil-docs/developing-further/theme-updates-and-version-control.md
+++ b/docs/stencil-docs/developing-further/theme-updates-and-version-control.md
@@ -1,14 +1,6 @@
 # Theme Updates and Version Control
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Version control](#version-control)
-- [Theme updates](#theme-updates)
-- [Maintaining customizations](#maintaining-customizations)
-- [Resources](#resources)
-
-</div>
 
 When developing BigCommerce themes, there are a few steps you can take to ensure your custom theme stays up to date with BigCommerce theme updates and version releases.
 

--- a/docs/stencil-docs/getting-started/about-stencil.md
+++ b/docs/stencil-docs/getting-started/about-stencil.md
@@ -1,20 +1,6 @@
 # About Stencil
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Cornerstone](#cornerstone)
-- [Stencil CLI](#stencil-cli)
-- [Flexible templates](#flexible-templates)
-- [Powerful CSS stack](#powerful-css-stack)
-- [Front Matter](#front-matter)
-- [JavaScript event hooks](#javascript-event-hooks)
-- [Blueprint (Legacy framework)](#blueprint-legacy-framework)
-
-- [Support](#support)
-- [Resources](#resources)
-
-</div>
 
 Stencil is BigCommerce's theme engine. It incorporates industry best practices in technology, design standards, SEO, and allows developers to build a stunning storefront that engages shoppers and encourages checkouts on any device. Stencil themes are supported on the [following browsers](https://support.bigcommerce.com/s/article/Themes-Supported-Browsers). Stencil is responsible for powering the BigCommerce [Cornerstone theme](#cornerstone).
 

--- a/docs/stencil-docs/getting-started/stencil-technology-stack.md
+++ b/docs/stencil-docs/getting-started/stencil-technology-stack.md
@@ -1,14 +1,6 @@
 # Stencil Technology Stack
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Handlebars overview](#handlebars-overview)
-- [Stencil objects overview](#stencil-objects-overview)
-- [YAML front matter overview](#yaml-front-matter-overview)
-- [Resources](#resources)
-
-</div>
 
 Stencil's use of Handlebars.js, Javascript, and YAML Front Matter on the front end allows developers to create dynamic, templated customizations across a BigCommerce storefront.
 

--- a/docs/stencil-docs/getting-started/transitioning-to-stencil.md
+++ b/docs/stencil-docs/getting-started/transitioning-to-stencil.md
@@ -1,18 +1,6 @@
 # Transitioning to Stencil
 
-<div class="otp" id="no-index">
 
-### On this page
-- [What is Stencil?](#what-is-stencil)
-- [Why transition to Stencil?](#why-transition-to-stencil)
-- [Technical differences](#technical-differences)
-  - [Developing locally on Stencil CLI](#developing-locally-on-stencil-cli)
-  - [Using Handlebars](#using-handlebars)
-  - [Customize Page Builder mode](#customize-page-builder-mode)
-  - [Create custom templates](#create-custom-templates)
-- [Resources](#resources)
-
-</div>
 
 This article outlines the key differences between Blueprint and Stencil for developers, agency partners, and anyone interested in Stencil's enhanced capabilities.
 

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.md
@@ -1,15 +1,6 @@
 # Installing Stencil CLI
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Installing on Mac](#installing-on-mac)
-- [Installing on Windows](#installing-on-windows)
-- [Installing on Linux](#installing-on-linux)
-- [Live previewing a theme](#live-previewing-a-theme)
-- [Resources](#resources)
-
-</div>
 
 Stencil CLI gives developers the power to locally edit and preview themes with no impact to a merchant’s live storefront, and it's built-in [Browsersync](https://github.com/bigcommerce/browser-sync) capabilities make simultaneous testing across desktop, mobile, and tablet devices a breeze. Once work is complete, developers can push themes to BigCommerce storefronts (and set them live) using Stencil CLI's simple, yet powerful commands.
 

--- a/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
+++ b/docs/stencil-docs/installing-stencil-cli/live-previewing-a-theme.md
@@ -1,15 +1,6 @@
 # Live Previewing a Theme
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Obtaining store API credentials](#obtaining-store-api-credentials)
-- [Downloading a theme](#downloading-a-theme)
-- [Installing theme modules](#installing-theme-modules)
-- [Serving a live preview](#serving-a-live-preview)
-- [Resources](#resources)
-
-</div>
 
 Once you've installed the Stencil CLI, the next steps are downloading a theme to edit and previewing live changes using Stencil CLI's powerful Browsersync functionality. This article walks you through the process of downloading a theme for development, installing theme modules, and serving a live preview using Stencil CLI's `stencil start` command.
 

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -1,20 +1,6 @@
 # Stencil CLI Options and Commands
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Commands overview](#commands-overview)
-- [`stencil help`](#stencil-help)
-- [`stencil init`](#stencil-init)
-- [`stencil start`](#stencil-start)
-- [`stencil bundle`](#stencil-bundle)
-- [`stencil pull`](#stencil-pull)
-- [`stencil download`](#stencil-download)
-- [`stencil push`](#stencil-push)
-- [`stencil release`](#stencil-release)
-- [Resources](#resources)
-
-</div>
 
 This article is a comprehensive command reference for Stencil CLI, BigCommerce's powerful theme development and deployment tool. For installation instructions for your OS, see [Installing Stencil CLI](https://developer.bigcommerce.com/stencil-docs/installing-stencil-cli/installing-stencil). For more information on BigCommerce's Stencil Theme Engine, see [About Stencil](https://developer.bigcommerce.com/stencil-docs/getting-started/about-stencil). Continue reading below for detailed information on each Stencil CLI command and option.
 

--- a/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.md
+++ b/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.md
@@ -1,26 +1,6 @@
 # Troubleshooting Your Setup
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Unsupported Node version](#unsupported-node-version)
-- [`npm install` errors](#npm-install-errors)
-- [`npm install` and `stencil init` errors](#npm-install-and-stencil-init-errors)
-- [`stencil init`/`stencil start` errors](#stencil-initstencil-start-errors)
-- [`stencil start` missing module errors](#stencil-start-missing-module-errors)
-- [Mac OS: `Xcode/iOS license...` errors](#mac-os-xcodeios-license-errors)
-- [ETIMEOUT errors on Node > 4.4.0](#etimeout-errors-on-node--440)
-- [`stencil` command not found](#stencil-command-not-found)
-- [`stencil start` errors](#stencil-start-errors)
-- [500 errors](#500-errors)
-- [Lint errors upon bundling](#lint-errors-upon-bundling)
-- [Module not found errors upon bundling](#module-not-found-errors-upon-bundling)
-- [Short undescriptive JavaScript diagnostics](#short-undescriptive-javascript-diagnostics)
-- [TR-300 error upon theme upload](#tr-300-error-upon-theme-upload)
-- [Reinstalling Stencil CLI](#reinstalling-stencil-cli)
-- [Resources](#resources)
-
-</div>
 
 For any unexpected behavior you encounter while developing your Stencil theme, we recommend checking the terminal window where you started Stencil CLI.
 

--- a/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/adding-javascript.md
@@ -1,21 +1,6 @@
 # Adding Javascript to Your Stencil Theme
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Bundling and minification](#bundling-and-minification)
-- [Development options](#development-options)
-- [Using npm](#using-npm)
-- [Page types and Javascript API](#page-types-and-javascript-api)
-- [JavaScript template context injection](#javascript-template-context-injection)
-- [Placing modules in assets/js/](#placing-modules-in-assetsjs)
-- [Theme-specific JavaScript modules](#theme-specific-javascript-modules)
-- [Mapping page types to JavaScript modules](#mapping-page-types-to-javascript-modules)
-- [Mapping custom templates to JavaScript modules](#mapping-custom-templates-to-javascript-modules)
-- [Summary](#summary)
-
-</div>
 
 ## Bundling and minification
 

--- a/docs/stencil-docs/javascript-and-event-hooks/customizing-javascript.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/customizing-javascript.md
@@ -1,14 +1,6 @@
 # Customizing Javascript
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Modifying a page's Javascript](#modifying-a-pages-javascript)
-- [Bringing in Handlebars context](#bringing-in-handlebars-context)
-
-- [Installing libraries](#installing-libraries)
-
-</div>
 
 Most [Cornerstone theme](https://github.com/bigcommerce/cornerstone) page template files located in `templates/pages/` have a corresponding `.js` file in `assets/js/theme/`. These JavaScript files contain event handlers and logic for managing page specific elements and actions.
 

--- a/docs/stencil-docs/javascript-and-event-hooks/dynamic-content-rendering.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/dynamic-content-rendering.md
@@ -1,16 +1,6 @@
 # Dynamic Content Rendering on Stencil Storefronts
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Why Dynamic Content?](#why-dynamic-content)
-- [Dropzones](#dropzones)
-- [Dynamic Tabs](#dynamic-tabs)
-- [Snippets](#snippets)
-- [Snippets HTML](#snippets-html)
-- [Recap](#recap)
-
-</div>
 
 _We're gratefully sharing techniques devised by Ken Utting, Web Developer for BigCommerce client goruck.com_.
 

--- a/docs/stencil-docs/javascript-and-event-hooks/event-hooks.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/event-hooks.md
@@ -1,14 +1,6 @@
 # Event Hooks
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Cookie Notification Example](#cookie-notification-example)
-- [Cart Dialog Example](#cart-dialog-example)
-- [Stencil Data Tags and Event Hooks](#stencil-data-tags-and-event-hooks)
-- [Resources](#resources)
-
-</div>
 
 Stencil themes provide access to remote resources through data tags and event hooks. Developers can use these hooks to trigger defined events. A theme can hook to an event to perform actions or calculations based on shopper behavior.
 

--- a/docs/stencil-docs/javascript-and-event-hooks/npm-tutorials.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/npm-tutorials.md
@@ -1,13 +1,6 @@
 # Adding npm Packages to a Theme
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Installing React and npm packages](#installing-react-and-npm-packages)
-- [Final product](#final-product)
-
-</div>
 
 Stencil's architecture allows for organized customization using npm and React. In production, you can use these tools for stylizing seasonally themed products, temporary promotions, or event tickets. Below is a short tutorial on using npm and React to customize your Stencil theme.
 

--- a/docs/stencil-docs/javascript-and-event-hooks/remote-api-tutorial.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/remote-api-tutorial.md
@@ -1,11 +1,6 @@
 # Remote API Tutorial
 
-<div class="otp" id="no-index">
 
-### On This Page
-- [Remote API Example](#remote-api-example)
-
-</div>
 
 ## Remote API Example
 

--- a/docs/stencil-docs/javascript-and-event-hooks/rendering-html-with-ajax.md
+++ b/docs/stencil-docs/javascript-and-event-hooks/rendering-html-with-ajax.md
@@ -1,11 +1,6 @@
 # Rendering HTML with Ajax
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Rendering HTML with Ajax](#rendering-html-with-ajax)
-
-</div> 
+ 
 
 ## Rendering HTML with Ajax
 

--- a/docs/stencil-docs/localization/localization-tutorial.md
+++ b/docs/stencil-docs/localization/localization-tutorial.md
@@ -1,13 +1,5 @@
 # Localization Tutorial
-<div class="otp" id="no-index">
 
-### On this page
-- [Adding a language file](#adding-a-language-file)
-- [Creating translation keys](#creating-translation-keys)
-- [Updating browser settings](#updating-browser-settings)
-- [Related resources](#related-resources)
-
-</div>
 
 You can localize your Stencil theme for your desired target language. This tutorial describes how to localize a storefront in Spanish. By following this method, you can display a specific language based on the language selected in the viewer's browser. By the end of this tutorial, you will have the tools to localize most areas of your theme.
 

--- a/docs/stencil-docs/localization/localizing-stores.md
+++ b/docs/stencil-docs/localization/localizing-stores.md
@@ -1,14 +1,6 @@
 # Localizing Stores
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Localizing theme files](#localizing-theme-files)
-- [Localizing checkout](#localizing-checkout)
-- [Localizing your storefront content](#localizing-your-storefront-content)
-- [Resources](#resources)
-
-</div>
 
 A BigCommerce storefront can be customized to display in any one language of your choice. To fully localize a store for a language or region, you will need to customize three areas:
 

--- a/docs/stencil-docs/localization/multi-language-checkout.md
+++ b/docs/stencil-docs/localization/multi-language-checkout.md
@@ -1,17 +1,7 @@
 # Multi-Language Checkout
 
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Multi-language setup](#multi-language-setup)
-- [Browsing hidden translation keys](#browsing-hidden-translation-keys)
-- [Adding your own translation values](#adding-your-own-translation-values)
-- [Localized country and state names](#localized-country-and-state-names)
-- [Limits on translation](#limits-on-translation)
-- [Resources](#resources)
-
-</div>
 
 ## Multi-language setup
 

--- a/docs/stencil-docs/localization/translating-regions.md
+++ b/docs/stencil-docs/localization/translating-regions.md
@@ -1,12 +1,6 @@
 # Translating Regions
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Translating regions example](#translating-regions-example)
-- [Resources](#resources)
-
-</div>
 
 Themes now support translations for a specific region, which localizes the region name within Page Builder. Within the region HTML, we can now add a translation field to point to the correct localization from `schema_translations.json`. 
 

--- a/docs/stencil-docs/localization/translation-keys.md
+++ b/docs/stencil-docs/localization/translation-keys.md
@@ -1,18 +1,6 @@
 # Translation Keys
 
-<div class="otp" id="no-index">
-
-### On this page
-
-- [Translating a theme](#translating-a-theme)
-- [Required subdirectory](#required-subdirectory)
-- [The schema](#the-schema)
-- [Localization file structure](#localization-file-structure)
-- [Invoking a translation key](#invoking-a-translation-key)
-- [Localization example](#localization-example)
-- [Resources](#resources)
-
-</div> 
+ 
 
 Translation keys exist in JSON files and are invoked based on the user's browser language. With a Stencil theme, you can define multiple translations for each theme based on a predefined schema.
 

--- a/docs/stencil-docs/page-builder/configuration.md
+++ b/docs/stencil-docs/page-builder/configuration.md
@@ -1,19 +1,6 @@
 # Theme Styles Configuration
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Enabling Page Builder Theme Styles options](#enabling-page-builder-theme-styles-options)
-- [How .json entries govern Page Builder's UI](#how-json-entries-govern-page-builders-ui)
-- [Theme Styles data types](#theme-styles-data-types)
-- [Theme Styles data structure in schema.json](#theme-styles-data-structure-in-schemajson)
-- [Best practices](#best-practices)
-- [Managing keys between versions](#managing-keys-between-versions)
-- [Persistent settings storage](#persistent-settings-storage)
-- [Theme upgrades and settings](#theme-upgrades-and-settings)
-- [Troubleshooting](#troubleshooting)
-
-</div>
 
 ## Enabling Page Builder Theme Styles options
 

--- a/docs/stencil-docs/page-builder/page-builder-overview.md
+++ b/docs/stencil-docs/page-builder/page-builder-overview.md
@@ -1,14 +1,6 @@
 # Page Builder Overview
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Theme Styles](#theme-styles)
-- [Widgets](#widgets)
-- [Layers](#layers)
-- [Related resources](#related-resources)
-
-</div>
 
 Page Builder is a browser-based tool that offers merchants visual editing and content management capabilities to design their stores. The Page Builder interface consists of [Theme Styles](https://support.bigcommerce.com/s/article/Page-Builder#styles), [Widgets](https://support.bigcommerce.com/s/article/Page-Builder#builder), and [Layers](https://support.bigcommerce.com/s/article/Page-Builder#layers).
 

--- a/docs/stencil-docs/page-builder/third-party-widgets.md
+++ b/docs/stencil-docs/page-builder/third-party-widgets.md
@@ -1,15 +1,6 @@
 # Third-Party Widgets
 
-<div class="otp" id="no-index">
 
-### On this page
-
-- [Creating third-party widgets](#creating-third-party-widgets)
-- [Modifying BigCommerce widgets](#modifying-bigcommerce-widgets)
-- [Exposing third-party widget templates](#exposing-third-party-widget-templates)
-- [Resources](#resources)
-
-</div>
 
 A third-party widget is a configurable, reusable component created and maintained by developers outside of BigCommerce. You can use third-party widgets to display custom content in a Stencil storefront. 
 

--- a/docs/stencil-docs/page-builder/widget-ui-schema.md
+++ b/docs/stencil-docs/page-builder/widget-ui-schema.md
@@ -1,15 +1,6 @@
 # Widget UI Schema
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Tabs and sections](#tabs-and-sections)
-- [Array type](#array-type)
-- [Hidden settings](#hidden-settings)
-- [Schema settings fields](#schema-settings-fields)
-- [Resources](#resources)
-
-</div>
 
 This document outlines the different schema settings you can use in your custom widget template. For a tutorial on creating widget templates, see [Widgets Tutorial](https://developer.bigcommerce.com/api-docs/store-management/widgets/tutorial). 
 

--- a/docs/stencil-docs/reference-docs/common-objects.md
+++ b/docs/stencil-docs/reference-docs/common-objects.md
@@ -1,15 +1,6 @@
 # Common Objects
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Catalog Price](#catalog-price)
-- [Price](#price)
-- [Price Range](#price-range)
-- [Stencil Image](#stencil-image)
-- [Common Product Card Model](#common-product-card-model)
-
-</div> 
+ 
 
 Certain Stencil objects can be accessed through multiple other Stencil objects. For example, the image object is exposed through the Category, Product, Product Options, and other objects. Its structure is consistent for all objects/properties that access it.
 

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -1,19 +1,6 @@
 # Front Matter Reference
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Supported templates](#supported-templates)
-- [Global attributes](#global-attributes)
-- [Category attributes](#category-attributes)
-- [Blog attributes](#blog-attributes)
-- [Product attributes](#product-attributes)
-- [Brand attributes](#brand-attributes)
-- [Brand list attributes](#brand-list-attributes)
-- [Search attributes](#search-attributes)
-- [GraphQL attributes](#graphql-attributes)
-  
-</div>
 
 Front matter defines which store resources are available to be rendered within a Stencil template. Front matter is declared at the top of each template and uses [YAML](https://yaml.org/) syntax. For more information, see [Declaring Front Matter Objects](https://developer.bigcommerce.com/stencil-docs/storefront-customization/using-front-matter#declaring-front-matter-objects).
 

--- a/docs/stencil-docs/reference-docs/global-objects-and-properties.md
+++ b/docs/stencil-docs/reference-docs/global-objects-and-properties.md
@@ -1,32 +1,6 @@
 # Global Objects and Properties
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Banner](#banner)
-- [Breadcrumbs](#breadcrumbs)
-- [Carousel](#carousel)
-- [Cart](#cart)
-- [Currency Selector](#currency-selector)
-- [Categories](#categories)
-- [Faceted Search](#faceted-search)
-- [Featured Products](#featured-products)
-- [Footer](#footer)
-- [HTML Head](#html-head)
-- [Is_Ajax](#isajax)
-- [New Products](#new-products)
-- [Page Content](#page-content)
-- [Pages](#pages)
-- [Page Type Property](#page-type-property)
-- [Pagination](#pagination)
-- [Search](#search)
-- [Settings](#settings)
-- [Sitemap](#sitemap)
-- [Social Links](#social-links)
-- [Template Property](#template-property)
-- [Top Sellers](#top-sellers)
-
-</div> 
+ 
 
 Global objects and properties are common components shared across the entire BigCommerce storefront.
 

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -1,14 +1,6 @@
 # Handlebars Helpers Reference
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Custom helpers](#custom-helpers)
-- [Standard helpers](#standard-helpers)
-- [Contributing to helpers](#contributing-to-helpers)
-- [Resources](#resources)
-
-</div>
 
 This article is a reference for [Stencil](https://developer.bigcommerce.com/stencil-docs/getting-started/about-stencil) supported [Handlebars](https://handlebarsjs.com/) helpers. It includes [custom helpers](#custom-helpers) documentation and a list of whitelisted [standard helpers](#standard-helpers).
 

--- a/docs/stencil-docs/reference-docs/other-objects-and-properties-overview.md
+++ b/docs/stencil-docs/reference-docs/other-objects-and-properties-overview.md
@@ -1,43 +1,6 @@
 # Other Objects and Properties Overview
 
-<div class="otp" id="no-index">
-
-### On This Page
-- [Product](#product)
-- [Product Reviews](#product-reviews)
-- [Related Products](#related-products)
-- [Similar Products by Customer Views](#similar-products-by-customer-views)
-- [Product Videos](#product-videos)
-- [Compare](#compare)
-- [Download Item](#download-item)
-- [Product Other Details](#product-other-details)
-- [Category](#category)
-- [Category Products](#category-products)
-- [Category Shop by Price](#category-shop-by-price)
-- [Brand](#brand)
-- [Brand List](#brand-list)
-- [Shop by Brand](#shop-by-brand)
-- [Cart](#cart)
-- [Customer](#customer)
-- [Order Details](#order-details)
-- [Recent Items](#recent-items)
-- [Customer Wishlists](#customer-wishlists)
-- [Wishlist Details](#wishlist-details)
-- [Account Order Shipments](#account-order-shipments)
-- [Account Orders](#account-orders)
-- [Account Returns](#account-returns)
-- [Account New Return](#account-new-return)
-- [Create Account](#create-account)
-- [Shipping Addresses](#shipping-addresses)
-- [Payment Methods](#payment-methods)
-- [Edit Payment Methods](#edit-payment-methods)
-- [Add Payment Methods](#add-payment-methods)
-- [Blog](#blog)
-- [Blog Post](#blog-post)
-- [Forms](#forms)
-- [Order Confirmation Objects](#order-confirmation-objects)
-
-</div> 
+ 
 
 <div class="HubBlock--callout">
 <div class="CalloutBlock--info">

--- a/docs/stencil-docs/reference-docs/stencil-utils-api-reference.md
+++ b/docs/stencil-docs/reference-docs/stencil-utils-api-reference.md
@@ -1,18 +1,6 @@
 # Stencil Utils Reference
 
-<div class="otp" id="no-index">
 
-###  On this Page
-- [Installing](#installing)
-- [api.js](#apijs)
-- [Cart API](#cart-api)
-- [Countries Resource](#countries-resource)
-- [Product Attributes Resource](#product-attributes-resource)
-- [Product Resource](#product-resource)
-- [Search Resource](#search-resource)
-- [Config Object](#config-object)
-- [Resources](#resources)
-</div>
 
 [Stencil Utils](https://github.com/bigcommerce/stencil-utils) is a utility library that contains the BigCommerce Stencil Events system and other functions that make building a theme with the Stencil framework a breeze.
 

--- a/docs/stencil-docs/reference-docs/styles-and-properties.md
+++ b/docs/stencil-docs/reference-docs/styles-and-properties.md
@@ -1,17 +1,5 @@
 # Theme Styles and Properties
-<div class="otp" id="no-index">
-
-### On This Page
-- [Checkbox](#checkbox)
-- [Color](#color)
-- [Font](#font)
-- [Heading](#heading)
-- [imageDimension](#imageDimension)
-- [Reference](#reference)
-- [Select](#select)
-- [Text](#text)
-
-</div> 
+ 
 
 ## Checkbox
 

--- a/docs/stencil-docs/reference-docs/theme-objects.md
+++ b/docs/stencil-docs/reference-docs/theme-objects.md
@@ -1,15 +1,6 @@
 # Theme Objects
 
-<div class="otp" id="no-index">
-
-### On this page
-- [Viewing a page's context](#viewing-a-pages-context)
-- [Using Handlebars](#using-handlebars)
-- [Using PageManager JavaScript](#using-pagemanager-javascript)
-- [Client-side injection](#client-side-injection)
-- [Resources](#resources)
-
-</div> 
+ 
 
 Stencil template objects expose dynamic page data. Not all objects are available on every page; which objects are present depends on page type. Below are instructions on viewing a page’s context while developing locally and how to access that context’s data via Handlebars expressions and JavaScript. For a complete template object reference, see [Models](https://developer.bigcommerce.com/stencil-docs/reference-docs/global-objects-and-properties/models).
 

--- a/docs/stencil-docs/storefront-customization/WCAG-compliance-levels.md
+++ b/docs/stencil-docs/storefront-customization/WCAG-compliance-levels.md
@@ -1,11 +1,5 @@
 # WCAG Compliance Levels
-<div class="otp" id="no-index">
 
-### On this page
-- [Accessibility principles](#accessibility-principles)
-- [Accessibility guidelines](#accessibility-guidelines)
-- [Related resources](#related-resources)
-</div>
 
 This article demonstrates how Cornerstone satisfies [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/WCAG21/#guidelines) across compliance levels. You can perform similar techniques to your site regardless of your compliance level. For detailed implementation information, see [Implementing WCAG Guidelines](https://developer.bigcommerce.com/stencil-docs/accessibility/implementing-WCAG-guidelines).
 

--- a/docs/stencil-docs/storefront-customization/custom-sass-functions.md
+++ b/docs/stencil-docs/storefront-customization/custom-sass-functions.md
@@ -1,12 +1,6 @@
 # Custom Sass Functions
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Custom Sass functions](#custom-sass-functions)
-- [Compiling custom Sass files](#compiling-custom-sass-files)
-
-</div>
 
 ## Custom Sass functions
 

--- a/docs/stencil-docs/storefront-customization/custom-templates.md
+++ b/docs/stencil-docs/storefront-customization/custom-templates.md
@@ -1,17 +1,6 @@
 # Custom Templates
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Authoring a custom template](#authoring-a-custom-template)
-- [Local mapping and testing](#local-mapping-and-testing)
-- [Specifying custom front matter](#specifying-custom-front-matter)
-- [Theme upload](#theme-upload)
-- [Troubleshooting template authoring](#troubleshooting-template-authoring)
-- [Applying custom templates to pages](#applying-custom-templates-to-pages)
-- [Resources](#resources)
-
-</div>
 
 The Stencil framework allows theme developers and merchants to assign custom layout templates to storefront pages of the following types:
 

--- a/docs/stencil-docs/storefront-customization/implementing-WCAG-guidelines.md
+++ b/docs/stencil-docs/storefront-customization/implementing-WCAG-guidelines.md
@@ -1,13 +1,7 @@
 
 # Implementing WCAG Guidelines - Examples
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Bypass blocks](#bypass-blocks)
-- [Location](#location)
-- [Unusual words](#unusual-words)
-</div>
 
 This article provides Cornerstone code snippets which satisfy current WCAG guidelines or code you can add to meet a WCAG requirement.
 

--- a/docs/stencil-docs/storefront-customization/localizing-variation-descriptions.md
+++ b/docs/stencil-docs/storefront-customization/localizing-variation-descriptions.md
@@ -1,13 +1,6 @@
 # Localizing Variation Descriptions
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Adding translations](#adding-translations)
-- [Supported language code schemes](#supported-language-code-schemes)
-- [Resources](#resources)
-
-</div>
 
 Stencil themes support translations for variation descriptions enabling you to customize the display language of your theme.
 

--- a/docs/stencil-docs/storefront-customization/page-composition-and-styling.md
+++ b/docs/stencil-docs/storefront-customization/page-composition-and-styling.md
@@ -1,12 +1,6 @@
 # Page Composition and Styling
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Referencing a CSS stylesheet](#referencing-a-css-stylesheet)
-- [Template composition](#template-composition)
-
-</div>
 
 ## Referencing a CSS stylesheet
 

--- a/docs/stencil-docs/storefront-customization/theme-accessibility.md
+++ b/docs/stencil-docs/storefront-customization/theme-accessibility.md
@@ -1,14 +1,6 @@
 # Developing Accessible Themes 
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Image alt text](#image-alt-text)
-- [Text accessibility](#text-accessibility)
-- [Keyboard accessibility](#keyboard-accessibility)
-- [Customization](#customization)
-- [Related resources](#related-resources)
-</div>
 
 Designing for accessibility means being inclusive to the needs of all users. This article outlines the basic accessibility requirements BigCommerce would recommend for all themes.
 

--- a/docs/stencil-docs/storefront-customization/theme-assets.md
+++ b/docs/stencil-docs/storefront-customization/theme-assets.md
@@ -1,16 +1,6 @@
 # Theme Assets
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Cornerstone assets directory](#cornerstone-assets-directory)
-- [Citadel subdirectory](#citadel-subdirectory)
-- [Components vs utilities](#components-vs-utilities)
-- [Variables and mixins](#variables-and-mixins)
-- [Stencil subdirectory](#stencil-subdirectory)
-- [Resources](#resources)
-
-</div>
 
 Each Stencil theme’s `assets/` directory contains CSS, JavaScript, and image assets that help create the design of storefront pages. A minimal `assets/` directory contains the files and subdirectories that you can view on the [Cornerstone Github Repository](https://github.com/bigcommerce/cornerstone/tree/master/assets).
 

--- a/docs/stencil-docs/storefront-customization/using-custom-fonts-and-icons.md
+++ b/docs/stencil-docs/storefront-customization/using-custom-fonts-and-icons.md
@@ -1,15 +1,5 @@
 # Custom Fonts and Icons
 
-<div class="otp">
-
-### On this page
-- [Applying custom fonts](#applying-custom-fonts)
-- [Sass stylesheet support for theme fonts](#sass-stylesheet-support-for-theme-fonts)
-- [Applying custom icons](#applying-custom-icons)
-- [Resources](#resources)
-
-</div>
-
 <div class="HubBlock--callout">
 <div class="CalloutBlock--warning">
 <div class="HubBlock-content">

--- a/docs/stencil-docs/storefront-customization/using-disqus.md
+++ b/docs/stencil-docs/storefront-customization/using-disqus.md
@@ -1,12 +1,6 @@
 # Using Disqus
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Integrating Disqus with your Stencil blog](#integrating-disqus-with-your-stencil-blog)
-- [Integrating Disqus with your Stencil product pages](#integrating-disqus-with-your-stencil-product-pages)
-
-</div>
 
 Stencil themes have the ability to integrate with Disqus, a third-party commenting system that allows users to leave blog comments on blog posts made with Stencil’s built-in blog. Disqus can also be used on Stencil product pages to allow comment and review threads on individual products.
 

--- a/docs/stencil-docs/storefront-customization/using-front-matter.md
+++ b/docs/stencil-docs/storefront-customization/using-front-matter.md
@@ -1,17 +1,7 @@
 
 # Using Front Matter
 
-<div class="otp" id="no-index">
 
-### On this page
-- [Declaring front matter objects](#declaring-front-matter-objects)
-- [Filtering attributes](#filtering-attributes)
-- [Combining front matter and Handlebars](#combining-front-matter-and-handlebars)
-- [Default vs custom attributes](#default-vs-custom-attributes)
-- [Declaring multiple attributes](#declaring-multiple-attributes)
-- [Resources](#resources)
-
-</div>
 
 ## Declaring front matter objects
 


### PR DESCRIPTION
Removing "on this page" TOC because Stoplight Platform duplicates them as a right-side nav.