### PR TITLE
DEVDOCS-3508 find missing pymt methods

### DIFF
--- a/docs/api-docs/partner/app-store-approval-requirements.md
+++ b/docs/api-docs/partner/app-store-approval-requirements.md
@@ -266,7 +266,7 @@ If you want to receive a callback when the store owner uninstalls your app, you 
 ![Dev Tool OAuth Scopes](https://s3.amazonaws.com/user-content.stoplight.io/6012/1536260600336)
 
 ### OAuth Scopes
-If you know the [OAuth scopes](/api-docs/getting-started/authentication#authentication_oauth-scopes) that your app requires, you should select these. If you do not yet know the scopes that you need, you can just request minimal permissions (such as Information: Read-Only) to get started. However, once you determine the scopes you need, you must:
+If you know the [OAuth scopes](/api-docs/getting-started/authentication/rest-api-authentication#oauth-scopes) that your app requires, you should select these. If you do not yet know the scopes that you need, you can just request minimal permissions (such as Information: Read-Only) to get started. However, once you determine the scopes you need, you must:
 - Modify the scopes of your app in My Apps and save the changes.
 - Obtain the new OAuth token during the [App Installation or Update flow](/api/#app-installation-and-update-sequence).
 - Retest your app to make sure it still functions properly with the new token.

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -6,9 +6,11 @@ Process payments using a sequence of requests to two API hosts:
 * Create the payment token:  `https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens`
 * Process the payment:  `https://payments.bigcommerce.com/stores/{{store_hash}}/payments`
 
-### Required [OAuth Scopes](/api-docs/getting-started/authentication/rest-api-authentication#oauth-scopes)
-* `Create Payments`
-* `Get Payment Methods`
+<!-- theme: success -->
+> #### Required OAuth scopes
+> * `Create Payments`
+> * `Get Payment Methods`
+> Learn more about BigCommerce API [OAuth scopes](/api-docs/getting-started/authentication/rest-api-authentication#oauth-scopes).
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/38daa68bda00ba9d4734)
 

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -34,21 +34,12 @@ Merchants or shoppers' personal identifiable information (PII) collected by recu
 
 ## Processing a payment
 
-You can process payments using cards stored with the BigCommerce Stored Credit Cards feature or by providing a credit card number.
+You can process payments charged to either of two main forms of payment: newly-entered credit cards, or stored cards. For a list of supported payment gateways and their feature sets, see [All Available Payment Gateways](https://support.bigcommerce.com/s/article/Available-Payment-Gateways#all-available). 
 
-Attempting to process a payment through the API using the full credit card information may fail if the provider requires 3DS authentication. The card must be saved through a shopper-initiated transaction before it can be charged through the Payments API. For a list of payment gateways that support 3DS, see [All Available Payment Gateways](https://support.bigcommerce.com/s/article/Available-Payment-Gateways#all-available).
-
-<div class="HubBlock--callout">
-<div class="CalloutBlock--info">
-<div class="HubBlock-content">
-
-<!-- theme:  -->
-### Hosted providers
-> The API flow does not currently support hosted/offsite providers, such as PayPal, and wallet type payments, such as Amazon Pay.
-
-</div>
-</div>
-</div>
+<!-- theme: info -->
+> #### Notes
+> * Attempting to process a payment through the API using the full credit card information may fail if the provider requires 3DS authentication. The card must be saved through a shopper-initiated transaction before it can be charged through the Payments API. 
+> * The API flow does not currently support hosted, offsite, or wallet-type providers, such as PayPal and Amazon Pay.
 
 ## Stored cards
 There are three steps to using a stored card to make a payment.

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -1,14 +1,12 @@
 # Payments API
 
-
-
-The Payments API enables you to process payments through the store’s connected payment gateway. Merchants can receive a payment for an order that was created using either the [Server to Server Checkout API Orders](/api-reference/cart-checkout/server-server-checkout-api) endpoint or the [V2 Orders](/api-reference/orders/orders-api/orders/createanorder) endpoint.
+The Payments API enables you to process payments through the store’s connected payment gateway. Merchants can receive a payment for an order that was created using either the [Server to Server Checkout API Orders](/api-reference/store-management/checkouts) endpoint or the [V2 Orders](/api-reference/store-management/orders/orders/createanorder) endpoint.
 
 Process payments using a sequence of requests to two API hosts:
 * Create the payment token:  `https://api.bigcommerce.com/stores/{store_hash}/v3/payments/access_tokens`
 * Process the payment:  `https://payments.bigcommerce.com/stores/{store_hash}/payments`
 
-### Required [OAuth Scopes](/api-docs/getting-started/authentication#authentication_oauth-scopes)
+### Required [OAuth Scopes](/api-docs/getting-started/authentication/rest-api-authentication#oauth-scopes)
 * `Create Payments`
 * `Get Payment Methods`
 

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -21,8 +21,7 @@ Merchants or shoppers' personal identifiable information (PII) collected by recu
 
 <!-- theme: warning -->
 > #### PCI compliance
-> If your application handles credit card data, you will need to be PCI compliant. SAQs (self-assessment questionnaires) can be submitted to
-<a href="mailto:compliance@bigcommerce.com">compliance@bigcommerce.com</a>.
+> If your application handles credit card data, you will need to be PCI compliant. SAQs (self-assessment questionnaires) can be submitted to <a href="mailto:compliance@bigcommerce.com">compliance@bigcommerce.com</a>.
 
 ## Processing a payment
 
@@ -53,15 +52,13 @@ To use stored cards with the Payments API or the Checkout SDK, make sure you ena
 
 This token is the same as `payment_instrument_token` from [Get Transactions](/api-reference/store-management/order-transactions).
 
-```http title="Get payment methods" subtitle="Example request" lineNumbers
+```http title="Example request: Get payment methods" lineNumbers
 GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?order_id={{order_id}}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Accept: application/json
 ```
-```http title="Get payment methods" subtitle="Example response" lineNumbers
-GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?order_id={{order_id}}
-Content-Type: application/json
-
+&nbsp;
+```json title="Example response: Get payment methods" lineNumbers
 {
   "data": [
     {
@@ -122,7 +119,7 @@ Make a note of the `token` for the target payment method to use as part of proce
 
 2. Make a request to [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
 
-```http title="Create payment access token" subtitle="Example request" lineNumbers
+```http title="Example request: Create payment access token" lineNumbers
 POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -134,10 +131,8 @@ Accept: application/json
   }
 }
 ```
-```http title="Create payment access token" subtitle="Example response" lineNumbers
-POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
-Content-Type: application/json
-
+&nbsp;
+```json title="Example response: Create payment access token" lineNumbers
 {
   "data": {
     "id": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NTEzOTQxNDIsIm5iZiI6MTU1MTM5MDU0MiwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoianJhaDZnbW4iLCJqdGkiOiI3Nzg3ZmU1Zi01OWJmLTQ3ZWMtYTFmZC00ZDQ3ZTkwNjFlNWMiLCJpYXd4gJ8uHDk3kDhhuyefsrtr45mRhdGEiOnsic3RvcmVfaWQiOjEwMjU2NDYsIm9yZGVyX2lkIjoyMTUsImFtb3VudCI6OTgwMCwiY3VycmVuY3kiOiJVU0QifX0.WbR90d8m4gn8wK7kPMDEoVq8B0hHC5Ul5H4Hpqq6Yvo"
@@ -151,9 +146,9 @@ Content-Type: application/json
 <!-- theme: info -->
 > #### Authorization header
 > The `pat_token` is the `data.id` value returned in preceding step.
-> To be valid, the header value string should contain a space between "PAT" and the {{pat_token}}.
+> To be valid, the header value string should contain a space between "PAT" and the `{{pat_token}}`.
 
-```http title="Process payment with a stored card" subtitle="Example request" lineNumbers
+```http title="Example request: Process payment with a stored card" lineNumbers
 POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
 Accept: application/vnd.bc.v1+json
 Authorization: PAT {{pat_token}}
@@ -170,10 +165,8 @@ Content-Type: application/json
   }
 }
 ```
-```http title="Process payment with a stored card" subtitle="Example response" lineNumbers
-POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
-Content-Type: application/vnd.bc.v1+json
-
+&nbsp;
+```json title="Example response: Process payment with a stored card" lineNumbers
 {
   "data": {
     "id": "693bb4cd-3f20-444a-8315-6369f582c68a",
@@ -195,7 +188,7 @@ There are two steps to using a credit card to make a payment.
 ### Create access token
 1. Make a request to [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
 
-```http title="Create payment access token" subtitle="Example request" lineNumbers
+```http title="Example request: Create payment access token" lineNumbers
 POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -207,10 +200,8 @@ Accept: application/json
   }
 }
 ```
-```http title="Create payment access token" subtitle="Example response" lineNumbers
-POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
-Content-Type: application/json
-
+&nbsp;
+```json title="Example response: Create payment access token" lineNumbers
 {
   "data": {
     "id": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NTEzOTQxNDIsIm5iZiI6MTU1MTM5MDU0MiwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoianJhaDZnbW4iLCJqdGkiOiI3Nzg3ZmU1Zi01OWJmLTQ3ZWMtYTFmZC00ZDQ3ZTkwNjFlNWMiLCJpYXd4gJ8uHDk3kDhhuyefsrtr45mRhdGEiOnsic3RvcmVfaWQiOjEwMjU2NDYsIm9yZGVyX2lkIjoyMTUsImFtb3VudCI6OTgwMCwiY3VycmVuY3kiOiJVU0QifX0.WbR90d8m4gn8wK7kPMDEoVq8B0hHC5Ul5H4Hpqq6Yvo"
@@ -226,10 +217,10 @@ Content-Type: application/json
 <!-- theme: info -->
 > #### Authorization header
 > The `pat_token` is the `data.id` value returned in preceding step.
-> To be valid, the header value string should contain a space between "PAT" and the {{pat_token}}.
+> To be valid, the header value string should contain a space between "PAT" and the `{{pat_token}}`.
 
 
-```http title="Process payment with a credit card" subtitle="Example request" lineNumbers
+```http title="Example request: Process payment with a credit card" lineNumbers
 POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
 Accept: application/vnd.bc.v1+json
 Authorization: PAT {{pat_token}}
@@ -249,10 +240,8 @@ Content-Type: application/json
   }
 }
 ```
-```http title="Process payment with a credit card" subtitle="Example response" lineNumbers
-POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
-Content-Type: application/vnd.bc.v1+json
-
+&nbsp;
+```json title="Example response: Process payment with a credit card" lineNumbers
 {
   "data": {
     "id": "693bb4cd-3f20-444a-8315-6369f582c68a",
@@ -270,7 +259,7 @@ The payments API allows developers to store a credit card while processing a cre
 
 When processing a credit payment, set `save_instrument: true`. The shopper can also store credit cards during checkout. If you are using the [Checkout SDK](/stencil-docs/customizing-checkout/checkout-sdk), it can store the credit card as part of the checkout.
 
-```http title="Process payment and save credit card" subtitle="Example request" lineNumbers
+```http title="Example request: Process payment and save credit card" lineNumbers
 POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
 Accept: application/vnd.bc.v1+json
 Authorization: PAT {{pat_token}}
@@ -297,7 +286,7 @@ Content-Type: application/json
 It is possible to take payment for an order created using the [Orders API](/api-docs/store-management/orders). When creating the order using the Orders API make sure the `status_id:0`. If you do not create an order with order status set to `0` or `Incomplete`, the Payments API will return an [error](#error-codes). Ensure customers enter their billing address and line items when creating the order. The customer can create the order as a guest order by either setting the `customer_id:0` or leaving it blank. After the order is created, then follow the steps for either a [credit card](#credit-cards) or a [stored card](#stored-cards).
 
 
-```http title="Create an order" subtitle="Example request" lineNumbers
+```http title="Example request: Create an order" lineNumbers
 POST https://api.bigcommerce.com/stores/{{store_hash}}/v2/orders
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -3,8 +3,8 @@
 The Payments API enables you to process payments through the store’s connected payment gateway. Merchants can receive a payment for an order that was created using either the [Server to Server Checkout API Orders](/api-reference/store-management/checkouts) endpoint or the [V2 Orders](/api-reference/store-management/orders/orders/createanorder) endpoint.
 
 Process payments using a sequence of requests to two API hosts:
-* Create the payment token:  `https://api.bigcommerce.com/stores/{store_hash}/v3/payments/access_tokens`
-* Process the payment:  `https://payments.bigcommerce.com/stores/{store_hash}/payments`
+* Create the payment token:  `https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens`
+* Process the payment:  `https://payments.bigcommerce.com/stores/{{store_hash}}/payments`
 
 ### Required [OAuth Scopes](/api-docs/getting-started/authentication/rest-api-authentication#oauth-scopes)
 * `Create Payments`
@@ -14,23 +14,15 @@ Process payments using a sequence of requests to two API hosts:
 
 ## PCI compliance
 
-BigCommerce is only responsible for the security of credit cards to the extent that secure handling is maintained while the payment is en route from payment request to payment processors. As a third-party developer, you are responsible for developing the storefronts or recurring billing apps in a PCI compliant manner. You will also need to maintain a PCI compliance certification for third-party service providers certified by an external Qualified Security Assessor (QSA).
+BigCommerce is only responsible for the security of credit cards to the extent that secure handling is maintained while the payment is en route from payment request to payment processors. As a third-party developer, you are responsible for developing the storefronts or recurring billing apps in a PCI-compliant manner. You will also need to maintain a PCI compliance certification for third-party service providers certified by an external Qualified Security Assessor (QSA).
 
 Merchants or shoppers' personal identifiable information (PII) collected by recurring billing apps that consume the BigCommerce Payments API must have its own Privacy Policy sufficient to the requirements of the European Union General Data Protection Requirements (GDPR). The GDPR must be available and displayed to the general public.
 
 
-<div class="HubBlock--callout">
-<div class="CalloutBlock--warning">
-<div class="HubBlock-content">
-
 <!-- theme: warning -->
-### PCI compliance
+> #### PCI compliance
 > If your application handles credit card data, you will need to be PCI compliant. SAQs (self-assessment questionnaires) can be submitted to
 <a href="mailto:compliance@bigcommerce.com">compliance@bigcommerce.com</a>.
-
-</div>
-</div>
-</div>
 
 ## Processing a payment
 
@@ -50,28 +42,26 @@ There are three steps to using a stored card to make a payment.
 
 To use stored cards with the Payments API or the Checkout SDK, make sure you enable stored cards in the store's control panel. To enable stored credit cards on your storefront, navigate to **Store Setup › Payments**, and click the tab for your payment gateway. Toggle the switch to enable Stored Credit Cards and click **Save**. For more on enabling stored cards, see [Enabling Stored Credit Cards](https://support.bigcommerce.com/s/article/Enabling-Stored-Credit-Cards).
 
-**Requirements for stored cards**
+<!-- theme: info -->
+> #### Requirements for stored cards
+> * Your store must be on a Plus plan or higher.
+> * Your store needs to be using Optimized One-Page Checkout.
+> * Your store needs to be using a compatible payment gateway.
 
-* Your store must be on a Plus plan or higher.
-* Your store needs to be using Optimized One-Page Checkout.
-* Your store needs to be using a compatible payment gateway.
 
 1. Make a call to [Get Payment Methods](/api-reference/store-management/payment-processing/accepted-methods/paymentsmethodsget) for the `stored_instruments > token` to pay with a stored card. The `order_id` passes in as a query parameter.
 
 This token is the same as `payment_instrument_token` from [Get Transactions](/api-reference/store-management/order-transactions).
 
-<br>
+```http title="Get payment methods" subtitle="Example request" lineNumbers
+GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?order_id={{order_id}}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Accept: application/json
+```
+```http title="Get payment methods" subtitle="Example response" lineNumbers
+GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?order_id={{order_id}}
+Content-Type: application/json
 
-<!--
-title: "Sample Response"
-subtitle: "Get Payment Methods"
-lineNumbers: true
--->
-
-**Example response get payment methods**
-`/GET https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/methods?order_id={{order_id}}`
-
-```json
 {
   "data": [
     {
@@ -127,36 +117,27 @@ lineNumbers: true
 }
 ```
 
-Make a note of the `token` to use as part of processing the payment in the request body.
+Make a note of the `token` for the target payment method to use as part of processing the payment in the request body.
 
-### Create access token
 
 2. Make a request to [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
-title: "Sample Request"
-subtitle: "Create Payment Access Token"
-lineNumbers: true
--->
 
-**Example request create payment access token**
-`/POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens`
+```http title="Create payment access token" subtitle="Example request" lineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
 
-```json
 {
   "order": {
     "id": 215
   }
 }
 ```
+```http title="Create payment access token" subtitle="Example response" lineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
+Content-Type: application/json
 
-<!--
-title: "Sample Response"
-subtitle: "Create Payment Access Token"
-lineNumbers: true
--->
-
-**Example response create payment access token**
-
-```json
 {
   "data": {
     "id": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NTEzOTQxNDIsIm5iZiI6MTU1MTM5MDU0MiwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoianJhaDZnbW4iLCJqdGkiOiI3Nzg3ZmU1Zi01OWJmLTQ3ZWMtYTFmZC00ZDQ3ZTkwNjFlNWMiLCJpYXd4gJ8uHDk3kDhhuyefsrtr45mRhdGEiOnsic3RvcmVfaWQiOjEwMjU2NDYsIm9yZGVyX2lkIjoyMTUsImFtb3VudCI6OTgwMCwiY3VycmVuY3kiOiJVU0QifX0.WbR90d8m4gn8wK7kPMDEoVq8B0hHC5Ul5H4Hpqq6Yvo"
@@ -165,72 +146,34 @@ lineNumbers: true
 }
 ```
 
-### Process the payment
-3. To process the payment, send a POST to [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost). You will need the following information from [Get Payment Methods](/api-reference/payments/payments-create-payment-token-api/payment-methods/paymentsmethodsget) in step one.
+3. To process the payment, send a POST to [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost). You will need several values retrieved with the [Get Payment Methods](/api-reference/store-management/payment-processing/accepted-methods/paymentsmethodsget) request you made in the preceding step. Additionally, this request contains different headers than a typical BigCommerce API request.  Consult the following for more information:
 
-**Get payment methods = process payment**
-* type = type
-* token = token
-* last_four = verification_value
-* id = payment_method_id
+<!-- theme: info -->
+> #### Authorization header
+> The `pat_token` is the `data.id` value returned in preceding step.
+> To be valid, the header value string should contain a space between "PAT" and the {{pat_token}}.
 
-The headers to process a payment are different than the headers you normally send with a BigCommerce API. The authorization token is the ID returned in Get Payment Access Token (step two).
+```http title="Process payment with a stored card" subtitle="Example request" lineNumbers
+POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
+Accept: application/vnd.bc.v1+json
+Authorization: PAT {{pat_token}}
+Content-Type: application/json
 
-**Headers**
-* Accept: application/vnd.bc.v1+json
-* Authorization: PAT {your-access-token}
-* Content-Type: application/json
-
-<div class="HubBlock--callout">
-<div class="CalloutBlock--warning">
-<div class="HubBlock-content">
-
-<!-- theme: warning -->
-
-### PAT
-> There is a space between PAT {your-access-token}.
-
-</div>
-</div>
-</div>
-
-<!--
-title: "Sample Request"
-subtitle: "Process Payment"
-lineNumbers: true
--->
-
-**Example request process payment**
-`/POST https://payments.bigcommerce.com/stores/{store_hash}/payments`
-
-```curl
-curl -X POST \
-  https://payments.bigcommerce.com/stores/{store_hash}/payments \
-  -H 'Accept: application/vnd.bc.v1+json' \
-  -H 'Authorization: PAT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NTEzOTQxNDIsIm5iZiI6MTU1MTM5MDU0MiwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoianJhaDZnbW4iLCJqdGkiOiI3Nzg3ZmU1Zi01OWJmLTQ3ZWMtYTFmZC00ZDQ3ZTkwNjFlNWMiLCJpYXQiOjE1NTEzOTA1NDIsImRhdGEiOnsic3RvcmVfaWQiOjEwMjU2NDYsIm9yZGVyX2lkIjoyMTUsImFtb3VudCI6OTgwMCwiY3VycmVuY3kiOiJVU0QifX0.WbR90d8m4gn8wK7kPMDEoVq8B0hHC5Ul5H4Hpqq6Yvo' \
-  -H 'Content-Type: application/json' \
-  -d '{
+{
   "payment": {
     "instrument": {
-      "type": "stored_card",
-      "token": "050a1e5c982e5905288ec5ec33f292772762033a0704f46fccb16bf1940b51ef", // from Get Payment Methods
-      "verification_value": "4242"
+      "type": "stored_card", // type from Get Payment Methods
+      "token": "050a1e5c982e5905288ec5ec33f292772762033a0704f46fccb16bf1940b51ef", // token from Get Payment Methods
+      "verification_value": "4242" // last_four from Get Payment Methods
     },
-    "payment_method_id": "stripe.card"
+    "payment_method_id": "stripe.card" // id from Get Payment Methods
   }
-}'
-
+}
 ```
+```http title="Process payment with a stored card" subtitle="Example response" lineNumbers
+POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
+Content-Type: application/vnd.bc.v1+json
 
-<!--
-title: "Sample Response"
-subtitle: "Process Payment"
-lineNumbers: true
--->
-
-**Example response process payment**
-
-```json
 {
   "data": {
     "id": "693bb4cd-3f20-444a-8315-6369f582c68a",
@@ -240,7 +183,7 @@ lineNumbers: true
 }
 ```
 
-If the purchase was successful, it would return a status of success. The order is then automatically moved to an Awaiting Fulfillment status. If you get a different response, see [Error Codes](#error-codes) for troubleshooting.
+If the purchase was successful, the response returns a status of success. The order is then automatically moved to an Awaiting Fulfillment status. If you get a different response, see [Error codes](#error-codes) for troubleshooting.
 
 ## Credit cards
 
@@ -252,32 +195,22 @@ There are two steps to using a credit card to make a payment.
 ### Create access token
 1. Make a request to [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
 
-<!--
-title: "Sample Request"
-subtitle: "Create Payment Access Token"
-lineNumbers: true
--->
+```http title="Create payment access token" subtitle="Example request" lineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
 
-**Example request create payment access token**
-`/POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens`
-
-```json
 {
   "order": {
     "id": 215
   }
 }
 ```
+```http title="Create payment access token" subtitle="Example response" lineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/payments/access_tokens
+Content-Type: application/json
 
-<!--
-title: "Sample Response"
-subtitle: "Create Payment Access Token"
-lineNumbers: true
--->
-
-**Example response create payment access token**
-
-```json
 {
   "data": {
     "id": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NTEzOTQxNDIsIm5iZiI6MTU1MTM5MDU0MiwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoianJhaDZnbW4iLCJqdGkiOiI3Nzg3ZmU1Zi01OWJmLTQ3ZWMtYTFmZC00ZDQ3ZTkwNjFlNWMiLCJpYXd4gJ8uHDk3kDhhuyefsrtr45mRhdGEiOnsic3RvcmVfaWQiOjEwMjU2NDYsIm9yZGVyX2lkIjoyMTUsImFtb3VudCI6OTgwMCwiY3VycmVuY3kiOiJVU0QifX0.WbR90d8m4gn8wK7kPMDEoVq8B0hHC5Ul5H4Hpqq6Yvo"
@@ -288,58 +221,24 @@ lineNumbers: true
 
 ### Process the payment
 
-2. To process the payment, send a `POST` request to [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost).
+2. To process the payment, send a POST request to [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost). You will need several values from the customer's credit card. All the example request body values are required.  If any of these values are incorrect, you may be unable to process the payment. Additionally, this request contains different headers than a typical BigCommerce API request.  Consult the following for more information:
 
-The headers to process a payment are different than the headers you normally send with a BigCommerce API. The Authorization token is the ID returned in Get Payment Access Token(step two).
+<!-- theme: info -->
+> #### Authorization header
+> The `pat_token` is the `data.id` value returned in preceding step.
+> To be valid, the header value string should contain a space between "PAT" and the {{pat_token}}.
 
-**Headers**
-* Accept: application/vnd.bc.v1+json
-* Authorization: PAT {your-access-token}
-* Content-Type: application/json
 
-Send the request with the following fields from the credit card:
-* type -- Will always be card
-* payment_method_id -- The name of the card in the format `payment-provider.card`
-* number
-* cardholder_name
-* expiry_month
-* expiry_year
-* verification_value
+```http title="Process payment with a credit card" subtitle="Example request" lineNumbers
+POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
+Accept: application/vnd.bc.v1+json
+Authorization: PAT {{pat_token}}
+Content-Type: application/json
 
-If any of these fields are incorrect, you may be unable to process the payment.
-
-<div class="HubBlock--callout">
-<div class="CalloutBlock--warning">
-<div class="HubBlock-content">
-
-<!-- theme: warning -->
-
-### PAT
-> There is a space between PAT {your-access-token}.
-
-</div>
-</div>
-</div>
-
-<!--
-title: "Sample Request"
-subtitle: "Process Payment"
-lineNumbers: true
--->
-
-**Example request process payment**
-`/POST https://payments.bigcommerce.com/stores/{store_hash}/payments`
-
-```curl
-curl -X POST \
-  https://payments.bigcommerce.com/stores/{store_hash}/payments \
-  -H 'Accept: application/vnd.bc.v1+json' \
-  -H 'Authorization: PAT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1NTEzOTQxNDIsIm5iZiI6MTU1MTM5MDU0MiwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoianJhaDZnbW4iLCJqdGkiOiI3Nzgadskfjua451OWJmLTQ3ZWMtYTFmZC00ZDQ3ZTkwNjFlNWMiLCJpYXQiOjE1NTEzOTr4gk78dhshehdGEiOnsic3RvcmVfaWQiOjEwMjU2NDYsIm9yZGVyX2lkIjoyMTUsImFtb3VudCI6OTgwMCwiY3VycmVuY3kiOiJVU0QifX0.WbR90d8m4gn8wK7kPMDEoVq8B0hHC5Ul5H4Hpqq6Yvo' \
-  -H 'Content-Type: application/json' \
-  -d '{
+{
   "payment": {
     "instrument": {
-      "type": "card",
+      "type": "card", // will always be card
       "number": "4242424242424242",
       "cardholder_name": "Jane Doe",
       "expiry_month": 12,
@@ -348,18 +247,12 @@ curl -X POST \
     },
     "payment_method_id": "stripe.card"
   }
-}'
+}
 ```
+```http title="Process payment with a credit card" subtitle="Example response" lineNumbers
+POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
+Content-Type: application/vnd.bc.v1+json
 
-<!--
-title: "Sample Response"
-subtitle: "Process Payment"
-lineNumbers: true
--->
-
-**Example response process payment**
-
-```json
 {
   "data": {
     "id": "693bb4cd-3f20-444a-8315-6369f582c68a",
@@ -369,7 +262,7 @@ lineNumbers: true
 }
 ```
 
-If the purchase was successful it will return a status of success. The order is then automatically moved to an Awaiting Fulfillment status. If you get a different response, see [Error Codes](#error-codes) for troubleshooting.
+If the purchase was successful, the response returns a status of success. The order is then automatically moved to an Awaiting Fulfillment status. If you get a different response, see [Error codes](#error-codes) for troubleshooting.
 
 ### Storing credit cards
 
@@ -377,11 +270,12 @@ The payments API allows developers to store a credit card while processing a cre
 
 When processing a credit payment, set `save_instrument: true`. The shopper can also store credit cards during checkout. If you are using the [Checkout SDK](/stencil-docs/customizing-checkout/checkout-sdk), it can store the credit card as part of the checkout.
 
-*`POST`* `https://payments.bigcommerce.com/stores/{store_hash}/payments`
+```http title="Process payment and save credit card" subtitle="Example request" lineNumbers
+POST https://payments.bigcommerce.com/stores/{{store_hash}}/payments
+Accept: application/vnd.bc.v1+json
+Authorization: PAT {{pat_token}}
+Content-Type: application/json
 
-**Process payment example POST**
-
-```json
 {
   "payment": {
     "instrument": {
@@ -397,70 +291,64 @@ When processing a credit payment, set `save_instrument: true`. The shopper can a
   }
 }
 ```
----
-
-<a href='#payments_orders-api' aria-hidden='true' class='block-anchor'  id='payments_orders-api'><i aria-hidden='true' class='linkify icon'></i></a>
 
 ## Using the Orders API
 
 It is possible to take payment for an order created using the [Orders API](/api-docs/store-management/orders). When creating the order using the Orders API make sure the `status_id:0`. If you do not create an order with order status set to `0` or `Incomplete`, the Payments API will return an [error](#error-codes). Ensure customers enter their billing address and line items when creating the order. The customer can create the order as a guest order by either setting the `customer_id:0` or leaving it blank. After the order is created, then follow the steps for either a [credit card](#credit-cards) or a [stored card](#stored-cards).
 
-<!--
-title: "Example Create Order"
-subtitle: ""
-lineNumbers: true
--->
 
-**Example create an order**
-`/POST https://api.bigcommerce.com/stores/{store_hash}/v2/orders`
+```http title="Create an order" subtitle="Example request" lineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v2/orders
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
 
-```json
 {
-    "status_id": 0,
-    "customer_id": 11,
-    "billing_address": {
-        "first_name": "Jane",
-        "last_name": "Does",
-        "company": "",
-        "street_1": "123 Main Street",
-        "street_2": "",
-        "city": "Austin",
-        "state": "Texas",
-        "zip": "78751",
-        "country": "United States",
-        "country_iso2": "US",
-        "email": "janedoe@email.com"
+  "status_id": 0,
+  "customer_id": 11,
+  "billing_address": {
+    "first_name": "Jane",
+    "last_name": "Does",
+    "company": "",
+    "street_1": "123 Main Street",
+    "street_2": "",
+    "city": "Austin",
+    "state": "Texas",
+    "zip": "78751",
+    "country": "United States",
+    "country_iso2": "US",
+    "email": "janedoe@email.com"
+  },
+  "shipping_addresses": [
+    {
+      "first_name": "Trishy",
+      "last_name": "Test",
+      "company": "Acme Pty Ltd",
+      "street_1": "666 Sussex St",
+      "street_2": "",
+      "city": "Anywhere",
+      "state": "Some State",
+      "zip": "12345",
+      "country": "United States",
+      "country_iso2": "US",
+      "phone": "",
+      "email": "janedoe@email.com"
+    }
+  ],
+  "products": [
+    {
+      "name": "BigCommerce Poster",
+      "quantity": 1,
+      "price_inc_tax": 10.98,
+      "price_ex_tax": 10
     },
-    "shipping_addresses": [
-        {
-            "first_name": "Trishy",
-            "last_name": "Test",
-            "company": "Acme Pty Ltd",
-            "street_1": "666 Sussex St",
-            "street_2": "",
-            "city": "Anywhere",
-            "state": "Some State",
-            "zip": "12345",
-            "country": "United States",
-            "country_iso2": "US",
-            "phone": "",
-            "email": "janedoe@email.com"
-        }
-    ],
-    "products": [
-        {
-            "name": "BigCommerce Poster",
-            "quantity": 1,
-            "price_inc_tax": 10.98,
-            "price_ex_tax": 10
-        },
-        {
-            "name": "BigCommerce Poster II",
-            "quantity": 1,
-            "price_inc_tax": 50,
-            "price_ex_tax": 45
-        }
-    ]
+    {
+      "name": "BigCommerce Poster II",
+      "quantity": 1,
+      "price_inc_tax": 50,
+      "price_ex_tax": 45
+    }
+  ]
 }
 ```
 
@@ -500,15 +388,7 @@ The following diagram shows how the `payment_access_token` interacts with BigCom
 
 You can create orders using the [Server to Server API Endpoints](/api-reference/store-management/checkouts/checkout-orders/createanorder) or [Orders API](/api-reference/store-management/orders).
 
-<!--
-    title: Sample App Diagram
-
-    data: https://storage.googleapis.com/bigcommerce-production-dev-center/images/Payments%20API%20sequence%20diagram.png
--->
-
-#### Sample app diagram
-![Sample App Diagram
-](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Payments%20API%20sequence%20diagram.png "Sample App Diagram")
+![Sample App Diagram](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Payments%20API%20sequence%20diagram.png "Sample App Diagram")
 
 ## Error codes
 
@@ -583,6 +463,6 @@ Payment gateways that use 3D Secure meet the EU's Strong Customer Authentication
 * [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost)
 
 ### Webhooks
-- [Cart](/api-docs/store-management/webhooks/webhook-events#cart)
-- [Customer Payment Instrument](/api-docs/store-management/webhooks/webhook-events#customer)
-- [Orders](/api-docs/store-management/webhooks/webhook-events#orders)
+* [Cart](/api-docs/store-management/webhooks/webhook-events#cart)
+* [Customer Payment Instrument](/api-docs/store-management/webhooks/webhook-events#customer)
+* [Orders](/api-docs/store-management/webhooks/webhook-events#orders)

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -130,9 +130,8 @@ lineNumbers: true
 Make a note of the `token` to use as part of processing the payment in the request body.
 
 ### Create access token
-2. Make a request to [Create Access Token](/api-reference/payments/payments-create-payment-token-api/payment-access-token/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
 
-<!--
+2. Make a request to [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
 title: "Sample Request"
 subtitle: "Create Payment Access Token"
 lineNumbers: true
@@ -247,11 +246,11 @@ If the purchase was successful, it would return a status of success. The order i
 
 There are two steps to using a credit card to make a payment.
 
-1. [Create Access Token](/api-reference/payments/payments-create-payment-token-api/payment-access-token/paymentsaccesstokenspost)
+1. [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost)
 2. [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost)
 
 ### Create access token
-1. Make a request to [Create Access Token](/api-reference/payments/payments-create-payment-token-api/payment-access-token/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
+1. Make a request to [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost) to get the authorization token that needs to be passed in the header when processing the payment. The ID of the order needs to be part of the request body.
 
 <!--
 title: "Sample Request"
@@ -579,8 +578,8 @@ Payment gateways that use 3D Secure meet the EU's Strong Customer Authentication
 
 
 ### Endpoints
-* [Create Access Token](/api-reference/payments/payments-create-payment-token-api/payment-access-token/paymentsaccesstokenspost)
-* [Get Payment Methods](/api-reference/payments/payments-create-payment-token-api/payment-methods/paymentsmethodsget)
+* [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost)
+* [Get Payment Methods](/api-reference/store-management/payment-processing/accepted-methods/paymentsmethodsget)
 * [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost)
 
 ### Webhooks

--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -55,9 +55,9 @@ Attempting to process a payment through the API using the full credit card infor
 ## Stored cards
 There are three steps to using a stored card to make a payment.
 
-1. [Get Payment Methods](/api-reference/payments/payments-create-payment-token-api/payment-methods/paymentsmethodsget)
-2. [Create Access Token](/api-reference/payments/payments-create-payment-token-api/payment-access-token/paymentsaccesstokenspost)
-3. [Process Payment](/api-reference/payments/payments-process-payments/payment/paymentspost)
+1. [Get Payment Methods](/api-reference/store-management/payment-processing/accepted-methods/paymentsmethodsget)
+2. [Create Access Token](/api-reference/store-management/payment-processing/access-tokens/paymentsaccesstokenspost)
+3. [Process Payment](/api-reference/store-management/payment-processing/process-payment/paymentspost)
 
 To use stored cards with the Payments API or the Checkout SDK, make sure you enable stored cards in the store's control panel. To enable stored credit cards on your storefront, navigate to **Store Setup › Payments**, and click the tab for your payment gateway. Toggle the switch to enable Stored Credit Cards and click **Save**. For more on enabling stored cards, see [Enabling Stored Credit Cards](https://support.bigcommerce.com/s/article/Enabling-Stored-Credit-Cards).
 
@@ -67,9 +67,9 @@ To use stored cards with the Payments API or the Checkout SDK, make sure you ena
 * Your store needs to be using Optimized One-Page Checkout.
 * Your store needs to be using a compatible payment gateway.
 
-1. Make a call to [Get Payment Methods](/api-reference/payments/payments-create-payment-token-api/payment-methods/paymentsmethodsget) for the `stored_instruments > token` to pay with a stored card. The `order_id` passes in as a query parameter.
+1. Make a call to [Get Payment Methods](/api-reference/store-management/payment-processing/accepted-methods/paymentsmethodsget) for the `stored_instruments > token` to pay with a stored card. The `order_id` passes in as a query parameter.
 
-This token is the same as `payment_instrument_token` from [Get Transactions](/api-reference/orders/orders-transactions-api).
+This token is the same as `payment_instrument_token` from [Get Transactions](/api-reference/store-management/order-transactions).
 
 <br>
 
@@ -387,7 +387,7 @@ If the purchase was successful it will return a status of success. The order is 
 
 The payments API allows developers to store a credit card while processing a credit card payment.
 
-When processing a credit payment, set `save_instrument: true`. The shopper can also store credit cards during checkout. If you are using the [Checkout SDK](/api-docs/cart-and-checkout/checkout-sdk), it can store the credit card as part of the checkout.
+When processing a credit payment, set `save_instrument: true`. The shopper can also store credit cards during checkout. If you are using the [Checkout SDK](/stencil-docs/customizing-checkout/checkout-sdk), it can store the credit card as part of the checkout.
 
 *`POST`* `https://payments.bigcommerce.com/stores/{store_hash}/payments`
 
@@ -415,9 +415,7 @@ When processing a credit payment, set `save_instrument: true`. The shopper can a
 
 ## Using the Orders API
 
-It is possible to take payment for an order created using the [Orders API](/api-docs/orders/orders-api-overview). When creating the order using the Orders API make sure the `status_id:0`. If you do not create an order with order status set to `0` or `Incomplete`, the Payments API will return an [error](#error-codes).
-Ensure customers enter their billing address and line items when creating the order. The customer can create the order as a guest order by either setting the
-`customer_id:0`or leaving it blank. After the order is created, then follow the steps for either a [credit card](#payments_credit-cards) or a [stored card](#payments_stored-cards).
+It is possible to take payment for an order created using the [Orders API](/api-docs/store-management/orders). When creating the order using the Orders API make sure the `status_id:0`. If you do not create an order with order status set to `0` or `Incomplete`, the Payments API will return an [error](#error-codes). Ensure customers enter their billing address and line items when creating the order. The customer can create the order as a guest order by either setting the `customer_id:0` or leaving it blank. After the order is created, then follow the steps for either a [credit card](#credit-cards) or a [stored card](#stored-cards).
 
 <!--
 title: "Example Create Order"
@@ -512,7 +510,7 @@ The Payments API rate limit is 50 payment requests per 4 seconds.  Some payment 
 
 The following diagram shows how the `payment_access_token` interacts with BigCommerce API and BigCommerce payments.
 
-You can create orders using the [Server to Server API Endpoints](/api-reference/cart-checkout/server-server-checkout-api/checkout-orders/createanorder) or [Orders API](/api-reference/orders/orders-api).
+You can create orders using the [Server to Server API Endpoints](/api-reference/store-management/checkouts/checkout-orders/createanorder) or [Orders API](/api-reference/store-management/orders).
 
 <!--
     title: Sample App Diagram
@@ -533,10 +531,10 @@ You can create orders using the [Server to Server API Endpoints](/api-reference/
 | `30000` | Merchant payment configuration could not be found. | * The payment provider has not been configured in the store. | Check the [payment gateways](https://support.bigcommerce.com/s/article/Online-Payment-Methods#setup) settings in your BigCommerce store. |
 | `30001` | Merchant payment configuration is not configured correctly. | The payment gateway rejects the payment configuration. | Check the [payment gateways](https://support.bigcommerce.com/s/article/Online-Payment-Methods#setup) settings in your BigCommerce store. <br> Reach out to the payment gateway to check that the information is correct. |
 | `30002` | Vaulting service is currently not available. |  The vaulting feature is not enabled on this store. | Reach out to the store owner to enable [Stored Credit Cards](https://support.bigcommerce.com/s/article/Enabling-Stored-Credit-Cards) |
-| `30003` | Order could not be found. | The order does not exist. <br> The order ID is not correct. |  Check the current orders in the store using [Get All Orders](/api-reference/orders/orders-api/orders/getanorder) |
+| `30003` | Order could not be found. | The order does not exist. <br> The order ID is not correct. |  Check the current orders in the store using [Get All Orders](/api-reference/store-management/orders/orders/getallorders) |
 | `30004` | The validation on line item and grand total does not match. | N/A| Recreate the payment access token <br> Recreate the order <br> Ensure the store settings for taxes and discounts are setup correctly|
 | `30050` | Payment instrument could not be saved. | Credit card information is incorrect. | Check that the card information is correct.<br> * `expiry_month` is two digits<br>* `expiry_year` is four digits |
-| `30051` | That stored payment instrument could not be found. Please try a different payment option. |  The card requested for payment is not associated to the shopper.| Use [Get Payment Methods](/api-reference/payments/payments-create-payment-token-api/payment-methods/paymentsmethodsget) to see available vaulted cards |
+| `30051` | That stored payment instrument could not be found. Please try a different payment option. |  The card requested for payment is not associated to the shopper.| Use [Get Payment Methods](/api-reference/store-management/payment-processing/accepted-methods/paymentsmethodsget) to see available vaulted cards |
 | `30100` | Payment access token could not be created. | N/A|N/A|
 | `30101` | Order is invalid. | The order is in the wrong status. | Orders must be in Incomplete Status with a `status_id:0`. <br>  The order must be created by the Checkout SDK, Checkout API, or V2 Orders API. Orders created in the control panel and set to an incomplete status will return this error. |
 | `30102` | Your card details could not be verified. Please double check them and try again. | The card information provided was incorrect.<br>The token provided was incorrect. | Check that the shopper information provided is correct.<br>Make sure the token in the authorization header field is correct. |


### PR DESCRIPTION
# [DEVDOCS-3508](https://jira.bigcommerce.com/browse/DEVDOCS-3508)


## What changed?
* Investigate change from that @traci707 found missing on migration review (from [DEVDOCS-3405](https://jira.bigcommerce.com/browse/DEVDOCS-3405))
* Locate cause: intentionally removed in [DEVDOCS-3207](https://jira.bigcommerce.com/browse/DEVDOCS-3207)
* Revise to make more prominent linked support article indicated by 3207.
* Revise more to experiment with SMD callout and code block syntax. 