### PR TITLE
DEVDOCS-3466-add-note-spec-file-formatting

### DIFF
--- a/docs/api-docs/getting-started/making-requests.md
+++ b/docs/api-docs/getting-started/making-requests.md
@@ -38,10 +38,7 @@ Save and you'll see the **send request** link above `GET`. Click **send request*
 
 ### Import API spec file with Postman
 
-Alternatively, you can import the [Specification File](https://github.com/bigcommerce/api-specs/blob/master/reference/catalog.v3.yml) into [Postman](https://www.getpostman.com/) (or any other tool that can import [Open API Specification](https://swagger.io/specification/) files).
-
-<!-- theme: note -->
->Currently, not all of our API specification file formatting is readily compatible with Postman. 
+You can import many of our API Specification Files into [Postman](https://www.getpostman.com/) (or any other tool that can import [Open API Specification](https://swagger.io/specification/) files) to try out endpoints and view responses.
 
 To view sample JSON request bodies for each REST API resource, see the [API Reference](/api-reference) for that resource.
 

--- a/docs/api-docs/getting-started/making-requests.md
+++ b/docs/api-docs/getting-started/making-requests.md
@@ -40,6 +40,9 @@ Save and you'll see the **send request** link above `GET`. Click **send request*
 
 Alternatively, you can import the [Specification File](https://github.com/bigcommerce/api-specs/blob/master/reference/catalog.v3.yml) into [Postman](https://www.getpostman.com/) (or any other tool that can import [Open API Specification](https://swagger.io/specification/) files).
 
+<!-- theme: note -->
+>Currently, not all of our API specification file formatting is readily compatible with Postman. 
+
 To view sample JSON request bodies for each REST API resource, see the [API Reference](/api-reference) for that resource.
 
 ## Storefront API quick start


### PR DESCRIPTION
# [DEVDOCS-3466](https://jira.bigcommerce.com/browse/DEVDOCS-3466)

## What changed?
Added note because of the current spec file formatting. Once the spec files are updated then we can remove this note.