### PR TITLE
DEVDOCS-3719 Add channel_id to the payload fields reference

### DIFF
--- a/docs/api-docs/cart-and-checkout/embedded-checkout-tutorial.md
+++ b/docs/api-docs/cart-and-checkout/embedded-checkout-tutorial.md
@@ -162,7 +162,7 @@ Next, generate cart redirect URLs by sending a `POST` request to `/carts/{{cart_
 
 For some use cases, you may want your customer to log in before they can begin the checkout process.
 
-Customers can log in using the [Customer Login API](/api-docs/storefront/customer-login-api#logging-in-a-customer).
+Customers can log in using the [Customer Login API](/api-docs/storefront/customer-login-api).
 
 You will first need to use JSON Web Token Standard to create a new token. Use a [JWT library](https://jwt.io/#libraries-io) to accomplish this. For more information, see [Create JWT Using the Debugger Tool](/api-docs/storefront/customer-login-api#create-jwt-using-the-debugger-tool).
 

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -32,6 +32,7 @@ You are required to include the `channel_id` when using the login JWTs to embed 
 | `jti` | string | A unique request ID (ex. uuid).|
 | `operation` | string | Must contain the string `"customer_login"`.|
 | `store_hash` | string | Store hash identifying the store you are logging into.|
+| `channel_id` | integer | Optional field containing the `channel_id` corresponding to a headless storefront. |
 | `customer_id` | integer | ID of the customer you are logging in.|
 | `redirect_to` | string | Optional field containing a relative path for the shopper's destination after login. Will default to `/account.php`. |
 | `request_ip` | string | Optional field containing the expected IP address for the request. If provided, BigCommerce will check that it matches the browser trying to log in.|

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -19,9 +19,9 @@ You can use the Customer Login API in the following use cases:
 
 Storefront customers are logged in using the access point URL `/login/token/{token}`. The `{token}` must be a JSON Web Token (JWT) containing parameters for the customer login request signed by your application’s OAuth client secret. For more information on the OAuth protocol, see [OAuth](https://oauth.net/2/). 
 
-JWT is an industry-standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) for securely transmitting information between two parties. A JWT represents a sequence of base64url-encoded sections separated by dots (` . `).  The sections include the header, payload, and signature. For more details, see [Introduction to JSON Web Tokens](https://jwt.io/introduction/). 
+JWT is an industry standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) for securely transmitting information between two parties. A JWT is a sequence of base64url-encoded strings separated by dots (` . `).  The sections include the header, payload, and signature. For more details, see [Introduction to JSON Web Tokens](https://jwt.io/introduction/). 
 
-You are required to include the `channel_id` when using the login JWTs to embed checkout for headless storefronts. Default value = 1
+You are required to include the `channel_id` when using the login JWTs to embed checkout for headless storefronts. The default `channel_id` value is `1`.
 
 ### Customer Login JWT payload reference
 

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -32,7 +32,7 @@ You are required to include the `channel_id` when using the login JWTs to embed 
 | `jti` | string | A unique request ID (ex. uuid).|
 | `operation` | string | Must contain the string `"customer_login"`.|
 | `store_hash` | string | The store hash identifying the store the shopper is signing in to.|
-| `channel_id` | integer | Optional field containing the `channel_id` corresponding to the headless storefront the shopper is signing in to. |
+| `channel_id` | integer | Optional field containing the `channel_id` corresponding to the storefront or other sales channel the shopper is signing in to. |
 | `customer_id` | integer | The ID of the shopper who is signing in.|
 | `redirect_to` | string | Optional field containing a relative path for the shopper's destination after sign-in. Defaults to `/account.php`. |
 | `request_ip` | string | Optional field containing the expected IP address for the request. If provided, BigCommerce will check that it matches the browser trying to log in.|

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -32,7 +32,7 @@ You are required to include the `channel_id` when using the login JWTs to embed 
 | `jti` | string | A unique request ID (ex. uuid).|
 | `operation` | string | Must contain the string `"customer_login"`.|
 | `store_hash` | string | Store hash identifying the store you are logging into.|
-| `channel_id` | integer | Optional field containing the `channel_id` corresponding to a headless storefront. |
+| `channel_id` | integer | Optional field containing the `channel_id` corresponding to the headless storefront the shopper is signing in to. |
 | `customer_id` | integer | ID of the customer you are logging in.|
 | `redirect_to` | string | Optional field containing a relative path for the shopper's destination after login. Will default to `/account.php`. |
 | `request_ip` | string | Optional field containing the expected IP address for the request. If provided, BigCommerce will check that it matches the browser trying to log in.|

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -32,7 +32,7 @@ You are required to include the `channel_id` when using the login JWTs to embed 
 | `jti` | string | A unique request ID (ex. uuid).|
 | `operation` | string | Must contain the string `"customer_login"`.|
 | `store_hash` | string | The store hash identifying the store the shopper is signing in to.|
-| `channel_id` | integer | Optional field containing the `channel_id` corresponding to the storefront or other sales channel the shopper is signing in to. |
+| `channel_id` | integer | Optional field containing the `channel_id` corresponding to the storefront the shopper is signing in to. |
 | `customer_id` | integer | The ID of the shopper who is signing in.|
 | `redirect_to` | string | Optional field containing a relative path for the shopper's destination after sign-in. Defaults to `/account.php`. |
 | `request_ip` | string | Optional field containing the expected IP address for the request. If provided, BigCommerce will check that it matches the browser trying to log in.|

--- a/docs/api-docs/customers/customer-login-api.md
+++ b/docs/api-docs/customers/customer-login-api.md
@@ -23,18 +23,18 @@ JWT is an industry-standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) fo
 
 You are required to include the `channel_id` when using the login JWTs to embed checkout for headless storefronts. Default value = 1
 
-**Payload fields reference**
+### Customer Login JWT payload reference
 
 | Field Name | Type | Description |
-|-|-|-|
-| `iss` | string | Indicates the token's issuer. This is your application's Client ID.|
-| `iat` | integer| Time when the token was generated. This is a numeric value indicating the number of seconds since the [Unix epoch](http://en.wikipedia.org/wiki/Unix_time).|
+|:-----------|:-----|:------------|
+| `iss` | string | Indicates the token's issuer. This is your API account's client ID.|
+| `iat` | integer| The time when the token was generated. This is a numeric value indicating the number of seconds since the [Unix epoch](http://en.wikipedia.org/wiki/Unix_time).|
 | `jti` | string | A unique request ID (ex. uuid).|
 | `operation` | string | Must contain the string `"customer_login"`.|
-| `store_hash` | string | Store hash identifying the store you are logging into.|
+| `store_hash` | string | The store hash identifying the store the shopper is signing in to.|
 | `channel_id` | integer | Optional field containing the `channel_id` corresponding to the headless storefront the shopper is signing in to. |
-| `customer_id` | integer | ID of the customer you are logging in.|
-| `redirect_to` | string | Optional field containing a relative path for the shopper's destination after login. Will default to `/account.php`. |
+| `customer_id` | integer | The ID of the shopper who is signing in.|
+| `redirect_to` | string | Optional field containing a relative path for the shopper's destination after sign-in. Defaults to `/account.php`. |
 | `request_ip` | string | Optional field containing the expected IP address for the request. If provided, BigCommerce will check that it matches the browser trying to log in.|
 
 ## Prerequisites


### PR DESCRIPTION
# [DEVDOCS-3719](https://jira.bigcommerce.com/browse/DEVDOCS-3719)

## What changed?
Add "channel_id" to the Payload Fields reference on this page: 
Used the following description: "Optional field containing the channel_id corresponding to a headless storefront."
