### PR TITLE
Removed duplicate gateway

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -37,9 +37,8 @@ The following table lists the payment gateways that are compatible with our publ
 | Barclaycard Fuse  | &times; | &times; |
 | Bolt              | &times; | &times; |
 | CardConnect       |       | &times; |
-| Chase Integrated Payments  |       | &times; |
-| Chase Merchant Services    | &times; |       |
-| Chase Merchant Services (Orbital) |       | &times; |
+| Chase Integrated Payments |         | &times; |
+| Chase Merchant Services   | &times; |  &times;|
 | Checkout.com      | &times; | &times; |
 | Cybersource       | &times; | &times; |
 | Eway Rapid        |       | &times; |


### PR DESCRIPTION
Kyle N. said the following:
This is a single gateway called 'Chase Merchant Services'.  And it supports both Stored Instruments and New Instruments.
So we just need one row for that gateway.

# [DEVDOCS-3702](https://jira.bigcommerce.com/browse/DEVDOCS-3702)

