### PR TITLE
DEVDOCS-3808: broken link to gql-playground

### DIFF
--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -298,7 +298,8 @@ The following is the complete list of available variables:
 * `contact-us.html`: `$pageId`
 * `blog-post.html`: `$blogPostId`
   
-You can also query data without using variables. The following query returns the product category tree as a JSON object.
+You can also query data without using variables. The following query returns the product category tree as a JSON object:
+
   
  ```yaml lineNumbers
 gql: "query CategoryTree3LevelsDeep {

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -258,7 +258,7 @@ product:
   "
   ```
   
-We suggest testing GraphQL queries using the [storefront API playground](/api-reference/storefront/graphql#graphql-playground) to refine them before adding them to your template. You can launch the playground in the context of your store by clicking the **Storefront API Playground** link under the **Advanced Settings** menu in your store's control panel.
+We suggest testing GraphQL queries using the [storefront API playground](https://developer.bigcommerce.com/graphql-playground) to refine them before adding them to your template. You can launch the playground in the context of your store by clicking the **Storefront API Playground** link under the **Advanced Settings** menu in your store's control panel.
   
 Once you have added a query to your template's front matter block, execution happens automatically when the page loads. The data returned by the query will be returned in the page's context and made available to the handlebars under the `gql` key. For example, you can retrieve the variant data from the above query in `product.html` like this:
 ```handlebars

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -27,8 +27,8 @@ customer:
   recently_viewed_products: true    # display recently viewed products
 ```
 ​
-|  Property | Description |
-| --- | --- |
+| Property | Description |
+|:---------|:------------|
 |  `customer` | Customer attributes are always included and are available when an active shopper logs in. |
 |  `returns` | Boolean indicating whether to retrieve product return requests for this customer. No filtering available.true: Retrieve requests. null or false: Do not retrieve requests. |
 |  `wishlists` | If `null`, wishlists are displayed. If `limit` is not specified, it retrieves an unlimited number of wishlists. |
@@ -46,8 +46,8 @@ products:
     limit: 5   # limits the number of top sellers to 5
 ```    
 
-|  Property | Description |
-| --- | --- |
+| Property | Description |
+|:---------|:------------|
 | `products` | When filtering/limiting, products' default sorting is by order id, from lowest to highest.|
 | `featured` | null: No featured products displayed. If not set, defaults to 4 products.|
 |`new`| null: No new products displayed. The maximum allowable value is 25. If not defined, defaults to 8 products.|
@@ -56,8 +56,8 @@ products:
 ```yaml 
 carousel: true    # displays carousel on the storefront unless set to null
 ```
-|  Property | Description |
-| --- | --- |
+| Property | Description |
+|:---------|:------------|
 |`carousel`|Boolean indicating whether to display a carousel on a storefront. No filtering available.|
 
 ```yaml
@@ -67,8 +67,8 @@ blog:
   summary: 100  # displays 100 character summary of blog post
 ```
 
-|  Property | Description |
-| --- | --- |
+| Property | Description |
+|:---------|:------------|
 |`blog`| Default sorting is by published_date, from most recent to earliest. This sorting does not work on the blog page. See [Blog Attributes](/stencil-docs/reference-docs/front-matter-reference#blog-attributes).|
 |`recent_posts`| null: No recent blog posts displayed. If not defined, defaults to the maximum of 20 blog posts.|
 |`summary`|Sets the number of characters to display in each blog post summary. If not defined, it displays 100 characters.|
@@ -76,8 +76,8 @@ blog:
 ```yaml 
 cart: true    # show cart data
 ```
-|  Property | Description |
-| --- | --- |
+| Property | Description |
+|:---------|:------------|
 |`cart`|Boolean indicating whether to retrieve cart data. false: Do not return cart data.|
 
 ```yaml
@@ -85,8 +85,8 @@ categories: true      # displays category tree
   description: true   # displays category description
 ```
 
-|  Property | Description |
-| --- | --- |
+| Property | Description |
+|:---------|:------------|
 |`categories`|Boolean indicating whether to retrieve the category tree during an AJAX request. false: Do not retrieve the category tree.|
 |`description`|Boolean indicating whether to retrieve category descriptions dynamically from the database. Set to true for themes that must display category descriptions when pages render.|
 
@@ -95,8 +95,8 @@ shop_by_brand: true   # displays brand list
   limit: 10           # limits brands to 10 
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`shop_by_brand`|Typically used in a footer or sidebar. null: Do not display this brand list. If not defined, it returns 10 brands, ordered by the number of products per brand.|
 
 ## Category attributes
@@ -109,8 +109,8 @@ category:
     limit:  10          # limits products per page for this category to 10
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`shop_by_price`|Boolean indicating whether to display Shop-by-Price controls.|
 |`products`|Defines the number of products displayed per page for this category. The range of possible values is 1–100 products.|
 
@@ -125,8 +125,8 @@ blog:
     summary: 250    # displays 250 character summary of blog post
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`posts`|Default sorting is by `published_date`, from most recent to earliest.|
 |`limit`|null: No blog posts displayed. The maximum is 20 blog posts per page.|
 |`pages`|null: No pagination. If not defined, defaults to five pages.|
@@ -149,8 +149,8 @@ product:
       limit: 10        # limits similar products by views to 10
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`product`|When filtering/limiting, products' default sorting is by order id, from lowest to highest.|
 |`videos`|If `product.videos` is not defined, you will not return videos. If you define `product.videos`, the default behavior is to return all videos. If you define `product.videos.limit`, this sets the maximum number of videos returned.|
 |`images`|If `product.images` is not defined, you will not return images. If `product.images` is defined, you must also define `product.images.limit`, which throttles the number of images returned. The maximum allowable value for this parameter is five images.|
@@ -160,7 +160,7 @@ product:
   
 Sample GraphQL query for product reviews over the limit.
   
-  ```yaml
+```graphql lineNumbers
 # Fetch product reviews for a product
 query reviewsByProductId(
   $productId: Int!
@@ -197,8 +197,8 @@ brand:
     limit: 50   # limits products displayed for this brand to 50
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`products`|`limit` defines the number of products displayed per page for this brand. The range of possible values is 1–50 products.|
 
 ## Brand list attributes
@@ -208,8 +208,8 @@ brands:
   limit: 50   # limits number of brands displayed in the list to 50
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`brands`|When retrieving a collection of brands, the default sorting is by brand id, from lowest to highest. `limit` sets the number of brands displayed in the list. If `limit` is not defined, returns all brands, up to a maximum of 50.|
 
 
@@ -221,25 +221,24 @@ search:
     limit: 16   # limits product results to 16
 ```
 
-|Property|Description|
-|---|---|
+| Property | Description |
+|:---------|:------------|
 |`product_results`|`limit` defines the number of product search results displayed per page. The range of possible values is 1–100 products.|
   
 ## GraphQL attributes
 You can add [GraphQL Storefront API](/api-docs/storefront/graphql/graphql-storefront-api-overview) queries to your theme via the front matter block in a template file. For example, you can request a product's variants by augmenting the existing [product.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/product.html):
   
- ```handlebars
- ---
+ ```yaml lineNumbers
 product:
-    videos:
-        limit: {{theme_settings.productpage_videos_count}}
-    reviews:
-        limit: {{theme_settings.productpage_reviews_count}}
-    related_products:
-        limit: {{theme_settings.productpage_related_products_count}}
-    similar_by_views:
-        limit: {{theme_settings.productpage_similar_by_views_count}}
- gql: "query productById($productId: Int!) {
+  videos:
+      limit: {{theme_settings.productpage_videos_count}}
+  reviews:
+      limit: {{theme_settings.productpage_reviews_count}}
+  related_products:
+      limit: {{theme_settings.productpage_related_products_count}}
+  similar_by_views:
+      limit: {{theme_settings.productpage_similar_by_views_count}}
+gql: "query productById($productId: Int!) {
   site {
     product(entityId: $productId) {
       variants(first: 25) {
@@ -248,30 +247,30 @@ product:
             sku
             defaultImage {
               url(width: 1000)
+            }
+          }
         }
-       }
       }
-     }
     }
-   }
   }
-  "
-  ```
+}"
+```
   
 We suggest testing GraphQL queries using the [storefront API playground](https://developer.bigcommerce.com/graphql-playground) to refine them before adding them to your template. You can launch the playground in the context of your store by clicking the **Storefront API Playground** link under the **Advanced Settings** menu in your store's control panel.
   
 Once you have added a query to your template's front matter block, execution happens automatically when the page loads. The data returned by the query will be returned in the page's context and made available to the handlebars under the `gql` key. For example, you can retrieve the variant data from the above query in `product.html` like this:
-```handlebars
- {{#if gql.data.site.product}}
- {{#each gql.data.site.product.variants.edges}}
-    {{#with node}}
-      {{sku}} {{! - - sku code from each variant from GQL response}}
-    {{/with}}
- {{/each}}
- {{/if}}
-  ```
+
+```handlebars lineNumbers
+{{#if gql.data.site.product}}
+{{#each gql.data.site.product.variants.edges}}
+  {{#with node}}
+    {{sku}} {{! - - sku code from each variant from GQL response}}
+  {{/with}}
+{{/each}}
+{{/if}}
+```
 If the GraphQL query is invalid, Stencil returns an `errors` object with `locations` and `message` properties similar to the following example:
-```html
+```json lineNumbers
 {
   "gql": {
     "errors": [
@@ -301,7 +300,7 @@ The following is the complete list of available variables:
   
 You can also query data without using variables. The following query returns the product category tree as a JSON object.
   
- ```yaml
+ ```yaml lineNumbers
 gql: "query CategoryTree3LevelsDeep {
   site {
     categoryTree {
@@ -326,7 +325,7 @@ fragment CategoryFields on CategoryTreeItem {
   
 The example query returns the following JSON object:
 
-```json
+```json lineNumbers
 {
   "data": {
     "site": {


### PR DESCRIPTION
# [DEVDOCS-3808](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3808)

## What changed?
* correct link per ticket
* table & code block formatting