### PR TITLE
DEVDOCS-3665: additional change

### DIFF
--- a/docs/legacy/v2-products/v2-v3.md
+++ b/docs/legacy/v2-products/v2-v3.md
@@ -46,7 +46,7 @@ Creating Products and Variants on V3:
 
 Variants can be included with a GET request to lower the number of API calls being made using `?include=variants`.
 
-V3 includes endpoints for working with catalog trees. Stores that have multi-storefront enabled can have more than one tree. See the catagories section of the [Multi-Storefront API Guide](/api-docs/multi-storefront/api-guide#categories).
+V3 includes endpoints for working with catalog trees. Stores that have multi-storefront enabled can have more than one tree. See the catagories section of the [Multi-Storefront API Guide](/api-docs/multi-storefront/api-guide#categories). Stores that are not MSF-enabled can use the same endponts. 
 
 ## Interoperability between V2 and V3
 

--- a/docs/legacy/v2-products/v2-v3.md
+++ b/docs/legacy/v2-products/v2-v3.md
@@ -46,7 +46,7 @@ Creating Products and Variants on V3:
 
 Variants can be included with a GET request to lower the number of API calls being made using `?include=variants`.
 
-V3 includes endpoints for working with catalog trees. Stores that have multi-storefront enabled can have more than one tree. See the catagories section of the [Multi-Storefront API Guide](/api-docs/multi-storefront/api-guide#categories). Stores that do not have multi-storefront enabled ...
+V3 includes endpoints for working with catalog trees. Stores that have multi-storefront enabled can have more than one tree. See the catagories section of the [Multi-Storefront API Guide](/api-docs/multi-storefront/api-guide#categories).
 
 ## Interoperability between V2 and V3
 


### PR DESCRIPTION
# [DEVDOCS-3665](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3665)

One additional change for DEVDOCS-3665 (a continuation of [PR 1434](https://github.com/bigcommerce/dev-docs/pull/1434))
