### PR TITLE
DEVDOCS-3567: [update] Add category examples to Stencil frontmatter's GraphQL reference

### DIFF
--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -301,7 +301,8 @@ type: tab
 title: Product
 -->
 
-```handlebars title="Handlebar in product.html template" lineNumbers
+```handlebars title="Example gql Handlebars object in product.html template" lineNumbers
+
 {{#if gql.data.site.product}}
 {{#each gql.data.site.product.variants.edges}}
   {{#with node}}

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -313,7 +313,8 @@ type: tab
 title: Category
 -->
 
-```handlebars title="Handlebar in category.html template" lineNumbers
+```handlebars title="Example gql Handlebars object in category.html template" lineNumbers
+
 {{#if gql.data.site.category}}
 {{#each gql.data.site.category.product.edges}}
   {{#with node}}

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -226,9 +226,15 @@ search:
 |`product_results`|`limit` defines the number of product search results displayed per page. The range of possible values is 1–100 products.|
   
 ## GraphQL attributes
-You can add [GraphQL Storefront API](/api-docs/storefront/graphql/graphql-storefront-api-overview) queries to your theme via the front matter block in a template file. For example, you can request a product's variants by augmenting the existing [product.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/product.html):
-  
- ```yaml lineNumbers
+You can add [GraphQL Storefront API](/api-docs/storefront/graphql/graphql-storefront-api-overview) queries to your theme via the front matter block in a template file. For example, you can request a product's variants by augmenting the existing [product.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/product.html), as well as a category's products by augmenting the existing [category.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/category.html): 
+
+
+<!--
+type: tab
+title: Product
+-->
+
+ ```yaml title="Front matter block in product.html template" lineNumbers
 product:
   videos:
       limit: {{theme_settings.productpage_videos_count}}
@@ -255,12 +261,44 @@ gql: "query productById($productId: Int!) {
   }
 }"
 ```
-  
+
+<!--
+type: tab
+title: Category
+-->
+
+ ```yaml title="Front matter block in category.html template" lineNumbers
+category:
+    shop_by_price: true
+    products:
+        limit: {{theme_settings.categorypage_products_per_page}}
+gql: "query categoryById ($categoryId: Int!){
+	site {
+    category(entityId: $categoryId) {
+      products {
+        edges {
+          node {
+            sku
+          }
+        }
+      }
+    }
+  }
+}"
+```
+
+<!-- type: tab-end -->
+
 We suggest testing GraphQL queries using the [storefront API playground](https://developer.bigcommerce.com/graphql-playground) to refine them before adding them to your template. You can launch the playground in the context of your store by clicking the **Storefront API Playground** link under the **Advanced Settings** menu in your store's control panel.
   
-Once you have added a query to your template's front matter block, execution happens automatically when the page loads. The data returned by the query will be returned in the page's context and made available to the handlebars under the `gql` key. For example, you can retrieve the variant data from the above query in `product.html` like this:
+Once you have added a query to your template's front matter block, execution happens automatically when the page loads. The data returned by the query will be returned in the page's context and made available to the handlebars under the `gql` key. The following examples illustrate how you can retrieve the variant data from the above query in `product.html`, as well as a category's product data from the above query in `category.html`:
 
-```handlebars lineNumbers
+<!--
+type: tab
+title: Product
+-->
+
+```handlebars title="Handlebar in product.html template" lineNumbers
 {{#if gql.data.site.product}}
 {{#each gql.data.site.product.variants.edges}}
   {{#with node}}
@@ -269,6 +307,24 @@ Once you have added a query to your template's front matter block, execution hap
 {{/each}}
 {{/if}}
 ```
+
+<!--
+type: tab
+title: Category
+-->
+
+```handlebars title="Handlebar in category.html template" lineNumbers
+{{#if gql.data.site.category}}
+{{#each gql.data.site.category.product.edges}}
+  {{#with node}}
+    {{sku}} {{! - - sku code from each product from GQL response}}
+  {{/with}}
+{{/each}}
+{{/if}}
+```
+
+<!-- type: tab-end -->
+
 If the GraphQL query is invalid, Stencil returns an `errors` object with `locations` and `message` properties similar to the following example:
 ```json lineNumbers
 {

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -226,7 +226,8 @@ search:
 |`product_results`|`limit` defines the number of product search results displayed per page. The range of possible values is 1–100 products.|
   
 ## GraphQL attributes
-You can add [GraphQL Storefront API](/api-docs/storefront/graphql/graphql-storefront-api-overview) queries to your theme via the front matter block in a template file. For example, you can request a product's variants by augmenting the existing [product.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/product.html), as well as a category's products by augmenting the existing [category.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/category.html): 
+You can add [GraphQL Storefront API](/api-docs/storefront/graphql/graphql-storefront-api-overview) queries to your theme using the front matter block in a template file. For example, you can request a product's variants by augmenting the existing [product.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/product.html), or a category's products by augmenting the existing [category.html template](https://github.com/bigcommerce/cornerstone/blob/master/templates/pages/category.html): 
+
 
 
 <!--

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -290,7 +290,8 @@ gql: "query categoryById ($categoryId: Int!){
 
 <!-- type: tab-end -->
 
-We suggest testing GraphQL queries using the [storefront API playground](https://developer.bigcommerce.com/graphql-playground) to refine them before adding them to your template. You can launch the playground in the context of your store by clicking the **Storefront API Playground** link under the **Advanced Settings** menu in your store's control panel.
+We suggest testing and refining GraphQL queries before adding them to your template. You can use the [GraphQL Storefront API playground](https://developer.bigcommerce.com/graphql-playground). To launch the playground in the context of your store, navigate to the **Advanced Settings** menu in your store control panel and click the **Storefront API Playground** link.
+
   
 Once you have added a query to your template's front matter block, execution happens automatically when the page loads. The data returned by the query will be returned in the page's context and made available to the handlebars under the `gql` key. The following examples illustrate how you can retrieve the variant data from the above query in `product.html`, as well as a category's product data from the above query in `category.html`:
 

--- a/docs/stencil-docs/reference-docs/front-matter-reference.md
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.md
@@ -293,7 +293,8 @@ gql: "query categoryById ($categoryId: Int!){
 We suggest testing and refining GraphQL queries before adding them to your template. You can use the [GraphQL Storefront API playground](https://developer.bigcommerce.com/graphql-playground). To launch the playground in the context of your store, navigate to the **Advanced Settings** menu in your store control panel and click the **Storefront API Playground** link.
 
   
-Once you have added a query to your template's front matter block, execution happens automatically when the page loads. The data returned by the query will be returned in the page's context and made available to the handlebars under the `gql` key. The following examples illustrate how you can retrieve the variant data from the above query in `product.html`, as well as a category's product data from the above query in `category.html`:
+Queries defined in template front matter automatically execute on page load. You can access the returned data using the `gql` Handlebars object in the page's context. The following examples illustrate how to access `gql` object data using results from the previously-defined front matter queries:
+
 
 <!--
 type: tab


### PR DESCRIPTION
# [DEVDOCS-3567](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3567)

Added example for category on stencil doc's graphql section



[DEVDOCS-3567]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ