### PR TITLE
Staging to Master

### DIFF
--- a/docs/api-docs/channels/channels-quick-start.md
+++ b/docs/api-docs/channels/channels-quick-start.md
@@ -44,61 +44,39 @@ Accept: application/json
 }
 ```
 
-<!-- [![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](/api-reference/store-management/channels/channels/createchannel#requestrunner) -->
-
 <!-- theme: info -->
-> #### Note
+> **Note**
 > - For a list of accepted `type` and `platform` values, see [Channels API Reference](/api-reference/store-management/channels#platform).
 > - For instructions on finding your app's ID, see [Find and App's ID](/api-docs/apps/tutorials/id).
+
 ## Create a channel with navigation
 
 We recommend that apps also create navigation sections to better integrate the app's interface within the BigCommerce control panel.
 
 ![Channel Settings Overview Tab](https://storage.googleapis.com/bigcommerce-production-dev-center/images/channels/channels-channel-overview.png "Channel Settings Overview Tab")
 
-To create a channel with navigation, include a `config_meta` object in the [create a channel](/api-reference/store-management/channels/channels/createchannel) request.
+To create a channel with navigation, use the [Channel Menus API](/api-reference/store-management/channels/channels/postChannelMenus) after creating a channel record.
 
 ```http
-POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/channels
+POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/channels/{{CHANNEL_ID}}/channel-menus
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
 Accept: application/json
 
 {
-  "name": "Solution Name",
-  "type": "storefront",
-  "platform": "drupal",
-  "external_id": "",
-  "status": "connected",
-  "is_listable_from_ui": true,
-  "is_visible": true,
-  "config_meta": {
-    "app": {
-      "id": 24483,
-      "sections": [
-        {
-          "title": "Overview",
-          "query_path": "overview"
-        },
-        {
-          "title": "Import",
-          "query_path": "import"
-        },
-        {
-          "title": "Settings",
-          "query_path": "settings"
-        }
-      ]
-    }
-  }
+    "bigcommerce_protected_app_sections": [
+      "domains",
+      "currencies",
+      "storefront_settings"
+    ],
+    "custom_app_sections": [
+      {
+        "title": "Overview",
+        "query_path": "overview"
+      }
+    ]  
 }
 ```
-
-<!-- [![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](/api-reference/store-management/channels/channels/createchannel#requestrunner) -->
-
-<!-- theme: info -->
-> #### Note
-> For additional information on [channel](/api-reference/store-management/channels/channels) `config_meta` properties, see the [create a channel request body schema](/api-reference/store-management/channels/channels/createchannel#request-body).
 
 ## Related resources
 

--- a/docs/api-docs/channels/channels-storefront-tutorial.md
+++ b/docs/api-docs/channels/channels-storefront-tutorial.md
@@ -33,29 +33,7 @@ Accept: application/json
   "is_visible": true,
   "config_meta": {
     "app": {
-      "id": 112233,
-      "sections": [
-        {
-          "title": "Overview",
-          "query_path": "overview"
-        },
-        {
-          "title": "Storefront Settings",
-          "query_path": "storefront_settings"
-        },
-        {
-          "title": "Domains",
-          "query_path": "domains"
-        },
-        {
-          "title": "Notifications",
-          "query_path": "notifications"
-        },
-        {
-          "title": "Currencies",
-          "query_path": "currencies"
-        }
-      ]
+      "id": 112233
     }
   }
 }
@@ -98,85 +76,55 @@ Accept: application/json
 
 ## Configuring UI sections
 
-Define and configure the channel's UI tabs displayed in the control panel by passing in a `config_meta` object.
+Define and configure the navigation menu items displayed in the control panel for the channel by creating channel menus using the [Channel Menus API](/api-reference/store-management/channels/channels/postChannelMenus).
 
 ```http
-POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/channels
+POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/channels/{{CHANNEL_ID}}/channel-menus
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
 Accept: application/json
 
 {
-  "name": "Deity Falcon PWA Storefront",
-  ...
-  "config_meta": {
-    "app": {
-      "id": 112233,
-      "sections": [
-        {
-          "title": "Overview",
-          "query_path": "overview"
-        }
-          ...
-      ]
-    }
-  }
+   "bigcommerce_protected_app_sections":[],
+   "custom_app_sections":[
+      {
+         "title":"Overview",
+         "query_path":"overview"
+      }
+   ]
 }
 ```
 
-<!-- theme: info -->
- 
 <!-- theme:info -->
 > #### Note
-> You can [find an app's ID](/api-docs/apps/tutorials/id) in the URL when editing the app in the [Developer Portal](/api-docs/apps/guide/developer-portal).
-
-
+> These UI sections were previously managed via `config_meta`. As of March 29, 2022, changes to UI sections via `config_meta` are dual written to the new API when `config_meta.app.sections` exists in the payload.
 
 ## Protected UI sections
 
-The following protected sections are provided by BigCommerce.
+The following protected sections are provided by BigCommerce:
 
 | Title               | Query                 | Description                                    |
 | ------------------- | --------------------- | ---------------------------------------------- |
-| [`Storefront Settings`](#storefront-settings) | `storefront_settings` | Renders channel specific storefront settings   |
+|`Storefront Settings` | `storefront_settings` | Renders channel specific storefront settings   |
 | `Domains`             | `domains`             | Renders channel specific domain settings       |
 | `Notifications`       | `notifications`       | Renders channel specific notification settings |
-| [`Currencies`](#currencies-settings)          | `currencies`          | Renders channel specific currency settings     |
+| `Currencies`          | `currencies`          | Renders channel specific currency settings     |
 
-Include protected sections in the [create channel request](/api-reference/store-management/channels/channels/createchannel) to display BigCommerce provided channel specific settings.
+Include protected sections in the [create channel menus request](/api-reference/store-management/channels/channels/postChannelMenus) to display BigCommerce-provided channel-specific settings pages.
 
 ```http
-POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/channels
+POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/channels/{{CHANNEL_ID}}/channel-menus
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
 Accept: application/json
 
 {
-  "name": "Dog US",
-  ...
-  "config_meta": {
-    "app": {
-      "id": 112233,
-      "sections": [
-        {
-          "title": "Storefront Settings",
-          "query_path": "storefront_settings"
-        },
-        {
-          "title": "Domains",
-          "query_path": "domains"
-        },
-        {
-          "title": "Notifications",
-          "query_path": "notifications"
-        },
-        {
-          "title": "Currencies",
-          "query_path": "currencies"
-        }
-      ]
-    }
-  }
+   "bigcommerce_protected_app_sections":[
+      "storefront_settings",
+      "currencies",
+      "domains"
+   ],
+   "custom_app_sections":[]
 }
 ```
 
@@ -184,14 +132,9 @@ Included protected sections display above custom sections.
 
 ![Protected Sections](https://storage.googleapis.com/bigcommerce-production-dev-center/images/channels/channels-sf-protected-custom-settings.png "Protected Sections")
 
-<!-- theme: warning -->
-> #### Note
-> Any content an app attempts to render to the control panel iFrame for a protected section will be overridden by the BigCommerce provided content.
-
-
 ## Storefront settings
 
-Include the `Storefront Settings` [protected section](#protected-ui-sections) in the channel's `config_meta` object to render the BigCommerce provided **Storefront Settings** tab on the channel's settings page.
+Include the `storefront_settings` [protected section](#protected-ui-sections) in the Channel Menus' `bigcommerce_protected_app_sections` array to render the BigCommerce-provided **Storefront Settings** menu item in the channel's navigation and corresponding settings page.
 
 ![Channel Storefront Settings](https://storage.googleapis.com/bigcommerce-production-dev-center/images/channels/channels-sf-storefront-settings.png "Channel Storefront Settings")
 
@@ -224,16 +167,15 @@ Accept: application/json
 
 ## Currencies settings
 
-Include the `Currencies` [protected section](#protected-ui-sections) in the channel's `config_meta` object to render the BigCommerce provided **Currencies** tab on the channel's settings page.
+Include the `currencies` [protected section](#protected-ui-sections) in the Channel Menus' `bigcommerce_protected_app_sections` array to render the BigCommerce-provided **Currencies** menu item in the channel's navigation and corresponding settings page.
 
 ![Channel Currency Settings](https://storage.googleapis.com/bigcommerce-production-dev-center/images/channels/channels-sf-currencies.png "Channel Currency Settings")
 
-You can manage channel specific currency settings using the Channel API [Currency Assignments](/api-reference/store-management/channels/channel-currency-assignments) endpoints. For example, To [get a channel's currency assignments](/api-reference/store-management/channels/channel-currency-assignments/get-channels-channel-id-currency-assignments), send a `GET` request to `/v3/channels/{channel_id}/currency-assignments`.
+You can manage channel specific currency settings using the Channel API [Currency Assignments](/api-reference/store-management/channels/channel-currency-assignments) endpoints. For example, To [get a channel's currency assignments](/api-reference/store-management/channels/channel-currency-assignments/get-channels-channel-id-currency-assignments), send a `GET` request to `/v3/channels/{{CHANNEL_ID}}/currency-assignments`.
 
 ```http
-GET https://api.bigcommerce.com/stores/{{STORE_HASH}}}/v3/channels/{channel_id}/currency-assignments
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}}/v3/channels/{{CHANNEL_ID}}/currency-assignments
 X-Auth-Token: {{ACCESS_TOKEN}}
-X-Auth-Client: {{CLIENT_ID}}
 Content-Type: application/json
 Accept: application/json
 ```
@@ -257,7 +199,7 @@ Accept: application/json
 
 ## Notification settings
 
-Include the `Notifications` [protected section](#protected-ui-sections) in the channel's `config_meta` object to render the BigCommerce provided **Notifications** tab on the channel's settings page.
+Include the `notifications` [protected section](#protected-ui-sections) in the Channel Menus' `bigcommerce_protected_app_sections` array to render the BigCommerce-provided **Notifications** menu item in the channel's navigation and corresponding settings page.
 
 ![Channel Notification Settings](https://storage.googleapis.com/bigcommerce-production-dev-center/images/channels/channels-sf-notifications-small.png "Channel Notification Settings")
 


### PR DESCRIPTION
* Update Dev Docs so they no longer reference the deprecated `config_meta.app.sections` for management of UI Sections.  Those references have been replaced with references to the new Channel Menus API. CHP-7375

* Updated with Ashley's changes

* Modified 2 files

Co-authored-by: Sarah Riehl <sarah.riehl@bigcommerce.com>
Co-authored-by: Preston Huth <preston.huth@bigcommerce.com>

# [DEVDOCS-](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-)

## What changed?
* thing_that_changed
