### PR TITLE
DEVDOCS-3876 Update app guide with MSF app profile options

### DIFF
--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -132,6 +132,7 @@ To learn about mitigating the risks of deleting an app and its API account, see 
 * [Implementing App OAuth](/api-docs/apps/guide/auth)
 * [App Approval Requirements](/api-docs/apps/guide/requirements)
 * [Publishing an App](/api-docs/apps/guide/publishing)
+* [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication).
 
 ### Other resources
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -26,7 +26,7 @@ To create an app, sign in to or create an account with the [Developer Portal](ht
 
 <!-- theme: info -->
 > #### Information optional
-> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval.
+> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval. To learn more about completing an app profile for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
 
 6. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
 7. You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -1,63 +1,35 @@
 # Managing Apps in the Developer Portal
 
+Create, edit, and submit apps for approval using the [Developer Portal](https://devtools.bigcommerce.com/). In [Beginning App Development](/api-docs/apps/guide/development) we briefly touched on how to create a draft app. In this article, we'll go over how to perform other common app management tasks. To get started, sign in or create an account in the [Developer Portal](https://devtools.bigcommerce.com/).  
 
-
-App developers create, edit, and submit apps for approval using the [Developer Portal](https://devtools.bigcommerce.com/). In [Beginning App Development](/api-docs/apps/guide/development) we briefly touched on how to create a draft app. In this article, we'll go over how to perform other common app management tasks in the [Developer Portal](https://devtools.bigcommerce.com/). For detailed instructions on submitting apps for approval, see [Publishing Apps](/api-docs/apps/guide/publishing).
-
-## Signing in
-
-Sign in or create a [Developer Portal](https://devtools.bigcommerce.com) account at [devtools.bigcommerce.com](https://devtools.bigcommerce.com).
 
 <!-- theme: info -->
 > #### Note
-> * `DRAFT` apps can only be installed on stores owned by the same email address as the developer portal account's email address.
+> `DRAFT` apps can only be installed on stores owned by the same email address as the developer portal account's email address.
 
+## Create an app
 
+To create an app, sign in to [Developer Portal](https://devtools.bigcommerce.com), then follow the instructions to [obtain app API credentials](/api-docs/getting-started/authentication/rest-api-authentication#obtaining-app-api-credentials).
 
-## Creating apps
+## Edit the app
 
-To create an app, do the following:
-
-1. Navigate to **[My Apps](https://devtools.bigcommerce.com/my/apps)**.
-2. Click **Create an app**.
-3. Give the app a name.
-4. Click **Create**.
+Edit an app by clicking the **Edit App** pencil icon to the right of the app you want to edit.
 
 ![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
 
-[Learn more about completing registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
-
 <!-- theme: info -->
-> #### Note
-> * The app's name is only visible in the developer portal.
+> #### Marketplace delay
+> Edits can take up to 24 hours to appear in the [App Marketplace](https://www.bigcommerce.com/apps/), but changes are immediately effective and visible in your existing users' store control panels.
+
+## Edit technical details
+
+Click **Edit App**, then navigate to the technical tab to edit enabled features, callback URLs, and OAuth scopes. After saving, edits to enabled features, callbacks URLs, and OAuth scopes are effective immediately for all app users.
+
+![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical Details")
+
+![OAuth Scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "OAuth Scopes")
 
 
-
-## Editing apps
-
-Edit an app by clicking **Edit App**.
-
-![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
-
-[Learn more about completing registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
-
-<!-- theme: info -->
-> #### Note
-> * After saving, edits are effective immediately in the control panel; however, edits can take up to 24 hours to appear in the [Apps Marketplace](https://www.bigcommerce.com/apps/).
-
-
-
-## Editing technical details
-
-Click **Edit App**, then navigate to the technical tab to edit enabled features, callback URLs, and OAuth scopes.
-
-![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-04.png "Technical Details")
-
-[Learn more about completing registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
-
-<!-- theme: warning -->
-> #### Note
-> * After saving, edits to enabled features, callbacks URLs, and OAuth scopes are effective immediately for all app users.
 
 
 
@@ -70,8 +42,8 @@ Click **View Client ID** to view an app's API credentials.
 [Learn how to use app credentials in the app OAuth flow](/api-docs/apps/guide/auth).
 
 <!-- theme: info -->
-> #### Note
-> * [OAuth Client ID is no longer required to authenticate requests to api.bigcommerce.com](/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com).
+> #### The X-Auth-Client header is deprecated
+> Your API account's client ID is [no longer a required header value](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com).
 
 
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -28,9 +28,11 @@ To create an app, sign in or create an account with the [Developer Portal](https
 > #### Information optional
 > No app profile fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval. To learn more about preparing an app for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
 
-1. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
-2. You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).
-3. To learn about deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully)
+6. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+
+You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).
+
+To learn about the risks of deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully)
 
 ## View credentials
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -11,6 +11,45 @@ Create, edit, and submit apps for approval using the [Developer Portal](https://
 
 To create an app, sign in to [Developer Portal](https://devtools.bigcommerce.com), then follow the instructions to [obtain app API credentials](/api-docs/getting-started/authentication/rest-api-authentication#obtaining-app-api-credentials).
 
+To get app API credentials, you need a BigCommerce [Developer Portal](https://devtools.bigcommerce.com) account. Once you have an account, sign in and perform the following steps:
+
+1. Click the **Create an app** button on the right side of the landing page.
+
+![Create an App](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537389767940 "Create an App")
+
+2. Give your app a name. This name is only visible to you.
+3. Click **Create**.
+4. At the top of the modal that opens next, click **Step 2 - Technical**. Scroll down to assign your app the desired OAuth scopes. 
+
+![Step 2 - Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Step 2 - Technical")
+
+![Assign OAuth scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "Assign OAuth scopes")
+
+5. Click **Update & Close** at the lower right-hand corner of the modal.
+
+<!-- theme: info -->
+> #### Information optional
+> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [App Marketplace](https://bigcommerce.com/apps) approval.
+
+6. A new modal will appear, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+7. Back on the Developer Portal landing page, find your app listed under the **Create an app** button. To view your client ID and client secret, click **View Client ID** next to the relevant app. You can access your API account credentials until you delete the app.
+
+![View Client ID](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537390078741 "View Client ID")
+
+![Client ID and client secret](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537390135692 "Client ID and client secret")
+
+## View credentials
+
+Click **View Client ID** to view an app's API credentials.
+
+![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
+
+[Learn how to use app credentials in the app OAuth flow](/api-docs/apps/guide/auth).
+
+<!-- theme: info -->
+> #### The X-Auth-Client header is deprecated
+> Your API account's client ID is [no longer a required header value](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com).
+
 ## Edit the app
 
 Edit an app by clicking the **Edit App** pencil icon to the right of the app you want to edit.
@@ -23,37 +62,26 @@ Edit an app by clicking the **Edit App** pencil icon to the right of the app you
 
 ## Edit technical details
 
-Click **Edit App**, then navigate to the technical tab to edit enabled features, callback URLs, and OAuth scopes. After saving, edits to enabled features, callbacks URLs, and OAuth scopes are effective immediately for all app users.
+Click **Edit App**, then navigate to the **Technical** tab to edit enabled features, callback URLs, and OAuth scopes. After saving, edits to enabled features, callbacks URLs, and OAuth scopes are effective immediately for all app users.
 
 ![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical Details")
 
 ![OAuth Scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "OAuth Scopes")
 
+## Enable multi-storefront functionality
 
+Click **Edit App**, then navigate to the **App Supported Features** tab to indicate whether your app supports stores that sell through multiple storefronts or sales channels. You can toggle multi-storefront on or off, then click the **Update & Close** button at the lower right of the dialog to save your change.
 
+To learn more about modifying your app to support multi-storefront, see [Multi-Storefront App Compatibility and Optimization](/api-docs/apps/multi-storefront)
 
-
-## Viewing credentials
-
-Click **View Client ID** to view an app's API credentials.
-
-![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
-
-[Learn how to use app credentials in the app OAuth flow](/api-docs/apps/guide/auth).
-
-<!-- theme: info -->
-> #### The X-Auth-Client header is deprecated
-> Your API account's client ID is [no longer a required header value](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com).
-
-
+![MSF Toggle](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-msf.png "Toggle MSF on the App Supported Features tab")
 
 ## Submitting apps
 
-Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by clicking **Submit**.
+Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) in the Developer Portal, then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. [Learn more about completing app registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
 
 ![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
 
-[Learn more about completing app registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
 
 ## Next steps
 * [Implement the OAuth flow](/api-docs/apps/guide/auth).

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -46,9 +46,7 @@ Click **View Client ID** to view an app's API credentials.
 
 [Learn how to use app credentials in the app OAuth flow](/api-docs/apps/guide/auth).
 
-<!-- theme: info -->
-> #### The X-Auth-Client header is deprecated
-> Your API account's client ID is [no longer a required header value](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com).
+To edit an app, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **Edit App** pencil icon to the right of the app you want to edit.
 
 ## Edit the app
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -1,6 +1,6 @@
 # Managing Apps in the Developer Portal
 
-Create, edit, and submit apps for approval using the [Developer Portal](https://devtools.bigcommerce.com/). In [Beginning App Development](/api-docs/apps/guide/development) we briefly touched on how to create a draft app. In this article, we'll go over how to perform other common app management tasks. To get started, sign in or create an account in the [Developer Portal](https://devtools.bigcommerce.com/).  
+Create, edit, and submit apps for approval using the [Developer Portal](https://devtools.bigcommerce.com/). In [Beginning App Development](/api-docs/apps/guide/development), we briefly touched on how to create a draft app. In this article, we'll go over how to perform other common app management tasks. To get started, sign in or create an account in the [Developer Portal](https://devtools.bigcommerce.com/).
 
 <!-- theme: info -->
 > #### Store email address constraint
@@ -8,7 +8,7 @@ Create, edit, and submit apps for approval using the [Developer Portal](https://
 
 ## Create an app
 
-To create an app, sign in to or create an account with the [Developer Portal](https://devtools.bigcommerce.com). Creating an app also creates an app API account. To learn more about app API accounts, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts).
+To create an app, sign in or create an account with the [Developer Portal](https://devtools.bigcommerce.com). Creating an app also creates an app API account. To learn more about app API accounts, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts).
 
 1. Click the **Create an app** button on the right side of the landing page.
 
@@ -26,11 +26,11 @@ To create an app, sign in to or create an account with the [Developer Portal](ht
 
 <!-- theme: info -->
 > #### Information optional
-> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval. To learn more about completing an app profile for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
+> No app profile fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval. To learn more about preparing an app for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
 
-6. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
-7. You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).
-8. To learn about deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully)
+1. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+2. You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).
+3. To learn about deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully)
 
 ## View credentials
 
@@ -68,7 +68,7 @@ To learn more about modifying your app to support multi-storefront, see [Multi-S
 
 ## Submit an app for approval
 
-Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. If you've left any required fields incomplete, the Dev Portal will prompt you to complete the app's profile. [Learn more about completing app registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
+Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. If you've left any required fields incomplete, the Dev Portal will prompt you to complete the app's profile. To learn more about completing app registration fields and submitting apps for approval, consult our [App Publishing Guide](/api-docs/apps/guide/publishing).
 
 ![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -120,8 +120,8 @@ To learn about mitigating the risks of deleting an app and its API account, see 
 ![Delete App Dialog](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-delete-app-confirm.png "Delete App Dialog")
 
 ## Next steps
-* [Implement the OAuth flow](/api-docs/apps/guide/auth).
-* [Handle app callbacks](/api-docs/apps/guide/callbacks).
+* [Implement the OAuth flow](/api-docs/apps/guide/auth)
+* [Handle app callbacks](/api-docs/apps/guide/callbacks)
 
 ## Resources
 
@@ -132,7 +132,7 @@ To learn about mitigating the risks of deleting an app and its API account, see 
 * [Implementing App OAuth](/api-docs/apps/guide/auth)
 * [App Approval Requirements](/api-docs/apps/guide/requirements)
 * [Publishing an App](/api-docs/apps/guide/publishing)
-* [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication).
+* [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication)
 
 ### Other resources
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -140,4 +140,3 @@ To learn about mitigating the risks of deleting an app and its API account, see 
 * [Partner Portal](https://partners.bigcommerce.com/English/) (partners.bigcommerce.com)
 * [Technology Partner Program](https://partners.bigcommerce.com/English/register_email.aspx) (partners.bigcommerce.com)
 * [BigCommerce Apps Marketplace](https://www.bigcommerce.com/apps/) (bigcommerce.com)
-* [Media Kit](https://www.bigcommerce.com/press/media-kit/) (bigcommerce.com)

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -8,43 +8,58 @@ Create, edit, and submit apps for approval using the [Developer Portal](https://
 
 ## Create an app
 
-To create an app, sign in or create an account with the [Developer Portal](https://devtools.bigcommerce.com). Creating an app also creates an app API account. To learn more about app API accounts, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts).
-
-1. Click the **Create an app** button on the right side of the landing page.
-
-![Create an App](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Create an App")
-
-2. Give your app a name. This name is only visible to you.
-3. Click **Create**.
-4. At the top of the dialog that opens next, click the **Technical** tab. Scroll down to assign your app the desired OAuth scopes. 
-
-![Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical")
-
-![Assign OAuth scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "Assign OAuth scopes")
-
-5. Click the **Update & Close** button on the dialog's lower right.
+Creating an app also creates an app API account. To learn more about app API accounts, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts). To create an app, do the following:
 
 <!-- theme: info -->
 > #### Information optional
 > No app profile fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval. To learn more about preparing an app for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
 
-6. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+1. Sign in or create an account with the [Developer Portal](https://devtools.bigcommerce.com).
+
+2. Click the **Create an app** button on the right side of the landing page.
+
+![Create an App](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-create-app.png "Create an App")
+
+3. Give your app a name in the **What would you like to call your app?** dialog. This name is only visible to you. Once complete, click the **Create** button.
+
+![Name the app](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-name-app-dialog.png "Name the App")
+
+4. The **app registration dialog** appears; click the **Technical** tab at the top.
+
+![Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical")
+
+5. Scroll down to the **OAuth scopes** section and toggle the necessary OAuth scopes for your app.
+
+![Assign OAuth scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes-tight.png "Assign OAuth scopes")
+
+6. Click the **Update & Close** button on the registration dialog's lower right corner.
+
+7. A new dialog opens, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+
+![Confirm OAuth changes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes-confirm.png "Confirm OAuth changes")
 
 You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).
 
-To learn about the risks of deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully)
-
 ## View credentials
 
-To view an app API account's credentials, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **View Client ID** padlock icon to the right of the relevant app's listing. The dialog box that opens will reveal your API account credentials. To learn more about using an app API account to generate store-specific access tokens, see [Implementing the OAuth Flow](/api-docs/apps/guide/auth).
+1. To view an app API account's credentials, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **View Client ID** padlock icon to the right of the relevant app's listing. 
 
-![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
+![Menu - view client ID](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-app-menu-client-id.png "View Client ID")
+
+2. A dialog box opens to reveal your API account credentials.
+
+To learn more about using an app API account to generate store-specific access tokens, see [Implementing the OAuth Flow](/api-docs/apps/guide/auth).
 
 ## Edit an app
 
-To edit an app, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **Edit App** pencil icon to the right of the app you want to edit.
+1. To edit an app, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **Edit App** pencil icon to the right of the app you want to edit.
 
-![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
+![Menu - edit app](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-app-menu-edit-app.png "Edit an App")
+
+2. The ***edit app dialog** opens. It is identical to the app registration dialog.
+
+![Edit app dialog](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-edit-dialog-landing.png "Edit App / App Registration Dialog Landing View")
+
 
 <!-- theme: info -->
 > #### Marketplace delay
@@ -52,28 +67,57 @@ To edit an app, navigate to the Dev Portal's [My Apps dashboard](https://devtool
 
 ### Edit technical details
 
-Once you enter the **Edit App** dialog, click the **Technical** tab to edit enabled features, callback URLs, and OAuth scopes. To save your change, click the **Update & Close** button on the dialog's lower right. After saving, edits are effective immediately for all app users.
+1. Once you [enter the app dialog](#edit-an-app), click the **Technical** tab at the top to edit enabled features, callback URLs, and OAuth scopes. 
 
 ![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical Details")
 
 ![OAuth Scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "OAuth Scopes")
+   
+2. To save your change, click the **Update & Close** button on the edit dialog's lower right corner. 
+
+3. A new dialog opens, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+
+![Confirm OAuth changes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes-confirm.png "Confirm OAuth changes")
+
+4. After saving, edits are effective immediately for all app users.
 
 ### Enable multi-storefront functionality
 
 If your app supports stores that sell through multiple storefronts or sales channels, add that information to the app's profile.
 
-Once you enter the **Edit App** dialog, click the **App Supported Features** tab. Select either **Single Storefront** or **Multi Storefront**, then save your change by clicking the **Update & Close** button on the dialog's lower right.
-
-To learn more about modifying your app to support multi-storefront, see [Multi-Storefront App Compatibility and Optimization](/api-docs/apps/multi-storefront)
+1. Once you [enter the edit app dialog](#edit-an-app), click the **App Supported Features** tab at the top. 
 
 ![MSF Toggle](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-msf.png "Toggle MSF on the App Supported Features tab")
 
+2. Select either **Single Storefront** or **Multi Storefront**. 
+
+3. To save your change, click the **Update & Close** button on the edit dialog's lower right corner. 
+
+To learn more about modifying your app to support multi-storefront, see [Multi-Storefront App Compatibility and Optimization](/api-docs/apps/multi-storefront)
+
 ## Submit an app for approval
 
-Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. If you've left any required fields incomplete, the Dev Portal will prompt you to complete the app's profile. To learn more about completing app registration fields and submitting apps for approval, consult our [App Publishing Guide](/api-docs/apps/guide/publishing).
+1. Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. 
 
-![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
+![Menu - submit](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-app-menu-submit.png "Submit an App")
 
+2. The registration dialog opens; complete the app's profile. 
+ 
+To learn more about completing app registration fields and submitting apps for approval, consult our [App Publishing Guide](/api-docs/apps/guide/publishing).
+
+## Deleting apps
+
+Deleting an app also deletes its API account. This is a destructive action that you should not take lightly, particularly if your app is in production. It may have far-reaching negative impacts on your users' stores.
+
+To learn about the risks of deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully).
+
+1. To delete an app, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **Delete App** trash can icon to the right of the app you want to edit. 
+
+![Menu - delete app](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-app-menu-delete.png "Delete an App")
+
+2. The **delete app dialog** opens to verify whether you truly want to delete the app. Click **Delete**.
+
+![Delete App Dialog](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-delete-app-confirm.png "Delete App Dialog")
 
 ## Next steps
 * [Implement the OAuth flow](/api-docs/apps/guide/auth).

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -56,7 +56,7 @@ To learn more about using an app API account to generate store-specific access t
 
 ![Menu - edit app](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-app-menu-edit-app.png "Edit an App")
 
-2. The ***edit app dialog** opens. It is identical to the app registration dialog.
+2. The **edit app dialog** opens. It is identical to the app registration dialog.
 
 ![Edit app dialog](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-edit-dialog-landing.png "Edit App / App Registration Dialog Landing View")
 
@@ -71,7 +71,7 @@ To learn more about using an app API account to generate store-specific access t
 
 ![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical Details")
 
-![OAuth Scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "OAuth Scopes")
+![Assign OAuth scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes-tight.png "Assign OAuth scopes")
    
 2. To save your change, click the **Update & Close** button on the edit dialog's lower right corner. 
 
@@ -107,9 +107,9 @@ To learn more about completing app registration fields and submitting apps for a
 
 ## Deleting apps
 
-Deleting an app also deletes its API account. This is a destructive action that you should not take lightly, particularly if your app is in production. It may have far-reaching negative impacts on your users' stores.
+Deleting an app also deletes its API account. This is a destructive action; you can't recover the app or its API account. Do not delete an app without serious consideration, particularly if it is in production. It is likely to have far-reaching negative impacts on your users' stores.
 
-To learn about the risks of deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully).
+To learn about mitigating the risks of deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully).
 
 1. To delete an app, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **Delete App** trash can icon to the right of the app you want to edit. 
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -50,19 +50,19 @@ To edit an app, navigate to the Dev Portal's [My Apps dashboard](https://devtool
 > #### Marketplace delay
 > Edits can take up to 24 hours to appear in the [App Marketplace](https://www.bigcommerce.com/apps/), but changes are immediately effective and visible in your existing users' store control panels.
 
-## Edit technical details
+### Edit technical details
 
-In the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), click the **Edit App** pencil icon to the right of the app you want to edit. At the top of the dialog that opens, click the **Technical** tab to edit enabled features, callback URLs, and OAuth scopes. To save your change, click the **Update & Close** button on the dialog's lower right. After saving, edits are effective immediately for all app users.
+Once you enter the **Edit App** dialog, click the **Technical** tab to edit enabled features, callback URLs, and OAuth scopes. To save your change, click the **Update & Close** button on the dialog's lower right. After saving, edits are effective immediately for all app users.
 
 ![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical Details")
 
 ![OAuth Scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "OAuth Scopes")
 
-## Enable multi-storefront functionality
+### Enable multi-storefront functionality
 
 If your app supports stores that sell through multiple storefronts or sales channels, add that information to the app's profile.
 
-In the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), click the **Edit App** pencil icon to the right of the app you want to edit. At the top of the dialog that opens, click the **App Supported Features** tab. Select either **Single Storefront** or **Multi Storefront**, then save your change by clicking the **Update & Close** button on the dialog's lower right.
+Once you enter the **Edit App** dialog, click the **App Supported Features** tab. Select either **Single Storefront** or **Multi Storefront**, then save your change by clicking the **Update & Close** button on the dialog's lower right.
 
 To learn more about modifying your app to support multi-storefront, see [Multi-Storefront App Compatibility and Optimization](/api-docs/apps/multi-storefront)
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -2,55 +2,45 @@
 
 Create, edit, and submit apps for approval using the [Developer Portal](https://devtools.bigcommerce.com/). In [Beginning App Development](/api-docs/apps/guide/development) we briefly touched on how to create a draft app. In this article, we'll go over how to perform other common app management tasks. To get started, sign in or create an account in the [Developer Portal](https://devtools.bigcommerce.com/).  
 
-
 <!-- theme: info -->
-> #### Note
-> `DRAFT` apps can only be installed on stores owned by the same email address as the developer portal account's email address.
+> #### Store email address constraint
+> Apps that aren't approved for distribution through the [Apps Marketplace](https://bigcommerce.com/apps) can only be installed on stores owned by the same email address as the developer portal account's email address.
 
 ## Create an app
 
-To create an app, sign in to [Developer Portal](https://devtools.bigcommerce.com), then follow the instructions to [obtain app API credentials](/api-docs/getting-started/authentication/rest-api-authentication#obtaining-app-api-credentials).
-
-To get app API credentials, you need a BigCommerce [Developer Portal](https://devtools.bigcommerce.com) account. Once you have an account, sign in and perform the following steps:
+To create an app, sign in to or create an account with the [Developer Portal](https://devtools.bigcommerce.com). Creating an app also creates an app API account. To learn more about app API accounts, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts).
 
 1. Click the **Create an app** button on the right side of the landing page.
 
-![Create an App](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537389767940 "Create an App")
+![Create an App](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Create an App")
 
 2. Give your app a name. This name is only visible to you.
 3. Click **Create**.
-4. At the top of the modal that opens next, click **Step 2 - Technical**. Scroll down to assign your app the desired OAuth scopes. 
+4. At the top of the dialog that opens next, click the **Technical** tab. Scroll down to assign your app the desired OAuth scopes. 
 
-![Step 2 - Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Step 2 - Technical")
+![Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical")
 
 ![Assign OAuth scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "Assign OAuth scopes")
 
-5. Click **Update & Close** at the lower right-hand corner of the modal.
+5. Click the **Update & Close** button on the dialog's lower right.
 
 <!-- theme: info -->
 > #### Information optional
-> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [App Marketplace](https://bigcommerce.com/apps) approval.
+> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval.
 
-6. A new modal will appear, asking if you want to add new OAuth scopes. Click **Confirm Update**.
-7. Back on the Developer Portal landing page, find your app listed under the **Create an app** button. To view your client ID and client secret, click **View Client ID** next to the relevant app. You can access your API account credentials until you delete the app.
-
-![View Client ID](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537390078741 "View Client ID")
-
-![Client ID and client secret](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537390135692 "Client ID and client secret")
+6. A new dialog box will open, asking if you want to add new OAuth scopes. Click **Confirm Update**.
+7. You can view the client ID and client secret any time; see the following section on [viewing credentials](#view-credentials).
+8. To learn about deleting an app and its API account, see the [Guide to API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#delete-apps-carefully)
 
 ## View credentials
 
-Click **View Client ID** to view an app's API credentials.
+To view an app API account's credentials, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **View Client ID** padlock icon to the right of the relevant app's listing. The dialog box that opens will reveal your API account credentials. To learn more about using an app API account to generate store-specific access tokens, see [Implementing the OAuth Flow](/api-docs/apps/guide/auth).
 
 ![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
 
-[Learn how to use app credentials in the app OAuth flow](/api-docs/apps/guide/auth).
+## Edit an app
 
 To edit an app, navigate to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) and click the **Edit App** pencil icon to the right of the app you want to edit.
-
-## Edit the app
-
-Edit an app by clicking the **Edit App** pencil icon to the right of the app you want to edit.
 
 ![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
 
@@ -60,7 +50,7 @@ Edit an app by clicking the **Edit App** pencil icon to the right of the app you
 
 ## Edit technical details
 
-Click **Edit App**, then navigate to the **Technical** tab to edit enabled features, callback URLs, and OAuth scopes. After saving, edits to enabled features, callbacks URLs, and OAuth scopes are effective immediately for all app users.
+In the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), click the **Edit App** pencil icon to the right of the app you want to edit. At the top of the dialog that opens, click the **Technical** tab to edit enabled features, callback URLs, and OAuth scopes. To save your change, click the **Update & Close** button on the dialog's lower right. After saving, edits are effective immediately for all app users.
 
 ![Technical Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Technical Details")
 
@@ -68,15 +58,17 @@ Click **Edit App**, then navigate to the **Technical** tab to edit enabled featu
 
 ## Enable multi-storefront functionality
 
-Click **Edit App**, then navigate to the **App Supported Features** tab to indicate whether your app supports stores that sell through multiple storefronts or sales channels. You can toggle multi-storefront on or off, then click the **Update & Close** button at the lower right of the dialog to save your change.
+If your app supports stores that sell through multiple storefronts or sales channels, add that information to the app's profile.
+
+In the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), click the **Edit App** pencil icon to the right of the app you want to edit. At the top of the dialog that opens, click the **App Supported Features** tab. Select either **Single Storefront** or **Multi Storefront**, then save your change by clicking the **Update & Close** button on the dialog's lower right.
 
 To learn more about modifying your app to support multi-storefront, see [Multi-Storefront App Compatibility and Optimization](/api-docs/apps/multi-storefront)
 
 ![MSF Toggle](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-msf.png "Toggle MSF on the App Supported Features tab")
 
-## Submitting apps
+## Submit an app for approval
 
-Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the [My Apps dashboard](https://devtools.bigcommerce.com/my/apps) in the Developer Portal, then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. [Learn more about completing app registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
+Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. If you've left any required fields incomplete, the Dev Portal will prompt you to complete the app's profile. [Learn more about completing app registration fields and submitting apps for approval](/api-docs/apps/guide/publishing).
 
 ![Developer Portal](https://storage.googleapis.com/bigcommerce-production-dev-center/images/apps-04-developer-portal-01.png "Developer Portal")
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -26,7 +26,7 @@ To begin the app certification process, we'll need some basic information about 
 ![App Summary](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-summary.png  "App Summary")
 
 | Field           | Description                                                                                            |
-| --------------- | ------------------------------------------------------------------------------------------------------ |
+|:----------------|:-------------------------------------------------------------------------------------------------------|
 | Contact Name    | Email address created when applying for your Partner ID                                                |
 | Partner Name    | Name of your company​; attributed on the detail page                                                    |
 | Partner Website | URL to your homepage                                                                                   |
@@ -47,7 +47,7 @@ Specify app type, multiple users support, callback URLs, and OAuth scopes; and, 
 ![Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png  "Technical")
 
 | Field                  | Description                                                                |
-| ---------------------- | -------------------------------------------------------------------------- |
+|:-----------------------|:---------------------------------------------------------------------------|
 | Multiple Users         | Optionally allow your app to be accessible to store users other than owner |
 | App Type               | Type of app; single-click recommended                                      |
 | Auth Callback URL      | Requested when `install` clicked                                           |
@@ -62,17 +62,17 @@ Provide a helpful description with screenshots and a video to promote your app. 
 
 ![Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-details.png  "Details")
 
-| Field                      | Description                                                                                                                               |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| App Details                | Value proposition; avoid fluff or buzzwords; not be indexed for search; 200 words max                                                     |
-| Videos                     | Videos highlighting purpose and value of your app                                                                                         |
+| Field | Description |
+|:------|:------------|
+| App Details | Value proposition; avoid fluff or buzzwords; not be indexed for search; 200 words max |
+| Videos | Videos highlighting purpose and value of your app |
 | Case Studies | Case studies demonstrating how merchants have benefited from using your app. 4 max |
-| Features                   | App's major features; include title and description for each; title is search indexed; rich text accepted; 5 max                          |
-| Legal Termals & Privacy    | App privacy policy and ToS links; legally required                                                                                        |
-| International Optimization | Countries app optimized for and countries app does not support                                                                            |
-| Help Guides                | Links to app's user and installation guides; highly recommended                                                                           |
+| Features | App's major features; include title and description for each; title is search indexed; rich text accepted; 5 max |
+| Legal Terms & Privacy | App privacy policy and ToS links; legally required |
+| International Optimization | Countries app optimized for and countries app does not support |
+| Help Guides | Links to app's user and installation guides; highly recommended |
 | App Screenshot | Screenshots of app UI in a BigCommerce store's control panel |
-| Alternate Logo             | Used if app featured in Marketplace carousel; should be 259 x 158px (or larger at ratio); dark background and light branding; no taglines |
+| Alternate Logo | Used if app featured in Marketplace carousel; should be 259 x 158px (or larger at ratio); dark background and light branding; no taglines |
 
 ## Add supported features
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -5,7 +5,7 @@ After completing development, verifying best practices, and checking approval re
 ## Before you begin
 
 Your listing on the [Apps Marketplace](https://www.bigcommerce.com/apps/) plays a major role in your app's success. A good listing accomplishes three goals:
-*  Shows users how your platform or solution differs from competitive offerings
+   Shows users how your platform or solution differs from competitive offerings
 * Includes keywords so prospective users can find your listing in searches
 * Sets up clear and accurate user expectations as to your solution's features and functionality
 
@@ -74,7 +74,7 @@ Provide a helpful description with screenshots and a video to promote your app. 
 | App Screenshot             | Screenshots of app UI inside BigCommerce                                                                                                  |
 | Alternate Logo             | Used if app featured in Marketplace carousel; should be 259 x 158px (or larger at ratio); dark background and light branding; no taglines |
 
-## App Supported Features
+## Add supported features
 
 Indicate whether your app supports multi-storefront functionality.
 
@@ -88,7 +88,7 @@ Review the information added before submitting the app.
 
 ## Submit your app for approval
 
-Ensure all information is complete, then click **Submit for Review** to pay the review and listing fee and submit the app. Test the app before submitting to avoid pay additional review fees.
+Ensure all information is complete, then click **Submit for Review** to pay the review and listing fee and submit the app. Test the app before submitting it to avoid paying additional review fees.
 
 ![Payment & Submission](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-submit.png "Payment & Submission")
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -1,7 +1,5 @@
 # Publishing an App
 
-
-
 After completing development, verifying best practices, and checking approval requirements, you may submit your app for Marketplace approval in the [Developer Portal](https://devtools.bigcommerce.com/). This article takes you step-by-step through the submission form and provides descriptions for each field.
 
 ## Before you begin
@@ -25,7 +23,7 @@ We also recommend giving special attention to the following search indexed field
 
 To begin the app certification process, we'll need some basic information about you.
 
-![DevTools 01](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/devtools-tutorial-01.png  "DevTools 01")
+![App Summary](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-summary.png  "App Summary")
 
 | Field           | Description                                                                                            |
 | --------------- | ------------------------------------------------------------------------------------------------------ |
@@ -46,7 +44,7 @@ To begin the app certification process, we'll need some basic information about 
 
 Specify app type, multiple users support, callback URLs, and OAuth scopes; and, provide detailed testing instructions.
 
-![DevTools 02](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/devtools-tutorial-02.png  "DevTools 02")
+![Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png  "Technical")
 
 | Field                  | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
@@ -62,7 +60,7 @@ Specify app type, multiple users support, callback URLs, and OAuth scopes; and, 
 
 Provide a helpful description with screenshots and a video to promote your app. We recommend bullet points followed by short paragraphs with headers. Aim for 200 words in total.
 
-![DevTools 03](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/devtools-tutorial-03.png  "DevTools 03")
+![Details](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-details.png  "Details")
 
 | Field                      | Description                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,19 +74,25 @@ Provide a helpful description with screenshots and a video to promote your app. 
 | App Screenshot             | Screenshots of app UI inside BigCommerce                                                                                                  |
 | Alternate Logo             | Used if app featured in Marketplace carousel; should be 259 x 158px (or larger at ratio); dark background and light branding; no taglines |
 
+## App Supported Features
+
+Indicate whether your app supports multi-storefront functionality.
+
+![App Supported Features](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-msf.png "App Supported Features")
+
 ## Review submission
 
 Review the information added before submitting the app.
 
-![DevTools 04](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/devtools-tutorial-04.png  "DevTools 04")
+![Review](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-review.png "Review")
 
 ## Submit your app for approval
 
-Ensure all information is complete; test the app before submitting for review.
+Ensure all information is complete, then click **Submit for Review** to pay the review and listing fee and submit the app. Test the app before submitting to avoid pay additional review fees.
 
-![DevTools 05](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/devtools-tutorial-05.png "DevTools 05")
+![Payment & Submission](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-submit.png "Payment & Submission")
 
-If you have any questions about your submission, email [appstore@bigcommerce.com](mailto:appstore@bigcommerce.com).
+If you have any questions about your submission, email [AppStore@bigcommerce.com](mailto:appstore@bigcommerce.com).
 
 ## FAQ
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -120,7 +120,7 @@ The changes will be effective immediately in your control panel app card, but th
 can take up to 24 hours to appear on the Apps Marketplace. Feel free to use this as a grace period to make edits as needed.
 
 ## Next steps
-[Review the Apps Marketplace listing guide (PDF)](https://grow.bigcommerce.com/rs/695-JJT-333/images/Updated_List_of_App_Fields_for_Tech_Partners.pdf).
+[Review the Apps Marketplace listing guide (PDF)](https://grow.bigcommerce.com/rs/695-JJT-333/images/Updated_List_of_App_Fields_for_Tech_Partners.pdf)
 
 ## Resources
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -5,7 +5,7 @@ After completing development, verifying best practices, and checking approval re
 ## Before you begin
 
 Your listing on the [Apps Marketplace](https://www.bigcommerce.com/apps/) plays a major role in your app's success. A good listing accomplishes three goals:
-   Shows users how your platform or solution differs from competitive offerings
+* Shows users how your platform or solution differs from competitive offerings
 * Includes keywords so prospective users can find your listing in searches
 * Sets up clear and accurate user expectations as to your solution's features and functionality
 
@@ -49,7 +49,7 @@ Specify app type, multiple users support, callback URLs, and OAuth scopes; and, 
 | Field                  | Description                                                                |
 | ---------------------- | -------------------------------------------------------------------------- |
 | Multiple Users         | Optionally allow your app to be accessible to store users other than owner |
-| App Type               | Type of app; single-Click recommended                                      |
+| App Type               | Type of app; single-click recommended                                      |
 | Auth Callback URL      | Requested when `install` clicked                                           |
 | Load Callback URL      | Requested when user launches app                                           |
 | Uninstall Callback URL | Requested when store owner clicks uninstall                                |
@@ -66,12 +66,12 @@ Provide a helpful description with screenshots and a video to promote your app. 
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | App Details                | Value proposition; avoid fluff or buzzwords; not be indexed for search; 200 words max                                                     |
 | Videos                     | Videos highlighting purpose and value of your app                                                                                         |
-| Case Studies               | case studies demonstrating how merchants have benefited from using your app. 4 max                                                        |
+| Case Studies | Case studies demonstrating how merchants have benefited from using your app. 4 max |
 | Features                   | App's major features; include title and description for each; title is search indexed; rich text accepted; 5 max                          |
 | Legal Termals & Privacy    | App privacy policy and ToS links; legally required                                                                                        |
 | International Optimization | Countries app optimized for and countries app does not support                                                                            |
 | Help Guides                | Links to app's user and installation guides; highly recommended                                                                           |
-| App Screenshot             | Screenshots of app UI inside BigCommerce                                                                                                  |
+| App Screenshot | Screenshots of app UI in a BigCommerce store's control panel |
 | Alternate Logo             | Used if app featured in Marketplace carousel; should be 259 x 158px (or larger at ratio); dark background and light branding; no taglines |
 
 ## Add supported features

--- a/docs/api-docs/getting-started/authentication.md
+++ b/docs/api-docs/getting-started/authentication.md
@@ -24,6 +24,10 @@ Most of our REST endpoints use the `X-Auth-Token` header to authenticate to BigC
 
 The `X-Auth-Token` header uses access tokens to authenticate requests. [Create an OAuth API account](/api-docs/getting-started/authentication/rest-api-authentication#api-accounts) to generate access tokens. Pass the access token as the value of the `X-Auth-Token` header of the request you want to authenticate.
 
+<!-- theme: info -->
+> #### The X-Auth-Client header is deprecated
+> Your API account's client ID is [no longer a required header value](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com).
+
 For a request to succeed, the access token's API account must have permission to receive the response. Configure your API account with the minimum set of OAuth scopes that your implementation needs. 
 
 To find the specific OAuth scopes your requests require, consult the root API reference pages for the families of endpoints you plan to use. For example, see the [OAuth scopes for the Email Templates endpoints](/api-reference/store-management/email-templates). We also maintain a [list of all our OAuth scopes](/api-docs/getting-started/authentication/rest-api-authentication#oauth-scopes).

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -15,7 +15,7 @@ Every active API account has at least one `access_token`. [Store API accounts](#
 **Guard these values closely.** The `client_id` and `client_secret` will never change; `access_token`s do not expire based on time and cannot be manually invalidated. It's best practice to limit each account's [OAuth scope](#oauth-scopes) to only the privileges needed to complete that app or user's designated tasks. Create separate API accounts for each app, store API user, and/or function.
 
 <!-- theme: info -->
-> Although the **client ID** value uniquely identifies the app or user making a request, you don't need to pass it in the header of each API request.
+> Although the **client ID** value uniquely identifies the app or user making a request, you [no longer need to pass it in the header](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com) of each API request.
 
 ## Store API accounts
 

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -78,6 +78,8 @@ After one of these changes, the store owner will be prompted to review the chang
 > #### Delete apps carefully
 > When you delete an app in the [Dev Portal](https://devtools.bigcommerce.com), there is no way to recover the client ID or client secret. If you choose to do this, don't forget to mitigate the potential loss of [webhook and metafield](#dont-forget-your-webhooks-and-metafields)-related data and functionality.
 
+To delete an app API account, consult our article on [Managing Apps in the Developer Portal](/api-docs/apps/guide/developer-portal#delete-an-app).
+
 ## Choosing the right kind of API account
 
 Where both types of API account are supported, review the preceding sections to make an informed choice about which best fits your use case. In the following table, links go to the relevant section of our [Authentication](/api-docs/getting-started/authentication) article.

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -14,9 +14,6 @@ Every active API account has at least one `access_token`. [Store API accounts](#
 
 **Guard these values closely.** The `client_id` and `client_secret` will never change; `access_token`s do not expire based on time and cannot be manually invalidated. It's best practice to limit each account's [OAuth scope](#oauth-scopes) to only the privileges needed to complete that app or user's designated tasks. Create separate API accounts for each app, store API user, and/or function.
 
-<!-- theme: info -->
-> Although the **client ID** value uniquely identifies the app or user making a request, you [no longer need to pass it in the header](https://developer.bigcommerce.com/changelog#posts/o-auth-client-id-is-no-longer-required-for-requests-to-api-bigcommerce-com) of each API request.
-
 ## Store API accounts
 
 Merchants generate single-store API credentials when they create API accounts in their store control panel (**Advanced Settings** > **API Accounts**). Use these credentials to read and change one store's data with BigCommerce's APIs. You can't change store API accounts' access tokens or OAuth scopes. 
@@ -63,7 +60,7 @@ For more on working with apps, see our [Guide to Building Apps](/api-docs/apps/g
 
 ### Obtaining app API credentials
 
-
+To create an app and its associated API account, consult our article on [Managing Apps in the Developer Portal](/api-docs/apps/guide/developer-portal#create-an-app).
 
 ### App access tokens
 
@@ -79,7 +76,7 @@ After one of these changes, the store owner will be prompted to review the chang
 
 <!-- theme: danger -->
 > #### Delete apps carefully
-> When you delete an app in the Dev Portal, there is no way to recover the client ID or client secret. If you choose to do this, don't forget to mitigate potential loss of [webhook and metafield](#dont-forget-your-webhooks-and-metafields)-related data and functionality.
+> When you delete an app in the [Dev Portal](https://devtools.bigcommerce.com), there is no way to recover the client ID or client secret. If you choose to do this, don't forget to mitigate potential loss of [webhook and metafield](#dont-forget-your-webhooks-and-metafields)-related data and functionality.
 
 ## Choosing the right kind of API account
 

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -63,32 +63,7 @@ For more on working with apps, see our [Guide to Building Apps](/api-docs/apps/g
 
 ### Obtaining app API credentials
 
-To get app API credentials, you need a BigCommerce [Developer Portal](https://devtools.bigcommerce.com) account. Once you have an account, sign in and perform the following steps:
 
-1. Click the **Create an app** button on the right side of the landing page.
-
-![Create an App](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537389767940 "Create an App")
-
-2. Give your app a name. This name is only visible to you.
-3. Click **Create**.
-4. At the top of the modal that opens next, click **Step 2 - Technical**. Scroll down to assign your app the desired OAuth scopes. 
-
-![Step 2 - Technical](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtools-technical.png "Step 2 - Technical")
-
-![Assign OAuth scopes](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-oauth-scopes.png "Assign OAuth scopes")
-
-5. Click **Update & Close** at the lower right-hand corner of the modal.
-
-<!-- theme: info -->
-> #### Information optional
-> When you create or edit an app in the Dev Portal, no app information fields are mandatory unless you're preparing the app for BigCommerce [App Marketplace](https://bigcommerce.com/apps) approval.
-
-6. A new modal will appear, asking if you want to add new OAuth scopes. Click **Confirm Update**.
-7. Back on the Developer Portal landing page, find your app listed under the **Create an app** button. To view your client ID and client secret, click **View Client ID** next to the relevant app. You can access your API account credentials until you delete the app.
-
-![View Client ID](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537390078741 "View Client ID")
-
-![Client ID and client secret](https://s3.amazonaws.com/user-content.stoplight.io/6012/1537390135692 "Client ID and client secret")
 
 ### App access tokens
 

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -138,8 +138,8 @@ Rate limiting works differently for OAuth API connections. For details, see the 
 All OAuth scopes except `default` provide `read-only` permissions scopes so that you can limit some accounts to sending `GET` and `HEAD` requests.
 
 <!-- theme: info -->
+> #### Webhooks scope
 > Webhooks are accessible from the default scope that is automatically accessible to all API accounts.
-
 
 | UI Name | Permission | Parameter | Description | Resources |
 |:--------|:-----------|:----------|:------------|:----------|

--- a/docs/api-docs/getting-started/rest-api-authentication.md
+++ b/docs/api-docs/getting-started/rest-api-authentication.md
@@ -76,7 +76,7 @@ After one of these changes, the store owner will be prompted to review the chang
 
 <!-- theme: danger -->
 > #### Delete apps carefully
-> When you delete an app in the [Dev Portal](https://devtools.bigcommerce.com), there is no way to recover the client ID or client secret. If you choose to do this, don't forget to mitigate potential loss of [webhook and metafield](#dont-forget-your-webhooks-and-metafields)-related data and functionality.
+> When you delete an app in the [Dev Portal](https://devtools.bigcommerce.com), there is no way to recover the client ID or client secret. If you choose to do this, don't forget to mitigate the potential loss of [webhook and metafield](#dont-forget-your-webhooks-and-metafields)-related data and functionality.
 
 ## Choosing the right kind of API account
 

--- a/docs/msf/msf-app-compatibility.md
+++ b/docs/msf/msf-app-compatibility.md
@@ -22,6 +22,8 @@ Ensure that your app's settings acknowledge multiple storefronts and convey that
 
 In testing, make sure that users can install and load the app in a store with multiple BigCommerce storefront channels. Use the [Channels API](/api-reference/store-management/channels) to work with basic data about the store's channels. Use the [Sites API](/api-reference/store-management/sites) to work with the channels' sites.
 
+Edit the app's profile in your [Developer Portal](https://devtools.bigcommerce.com/my/apps) to indicate that it supports multi-storefront functionality. See [Managing Apps in the Developer Portal](/api-docs/apps/guide/developer-portal#enable-multi-storefront-functionality).
+
 
 ## Reading from and writing to multiple channels
 


### PR DESCRIPTION
# [DEVDOCS-3876](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3876)

## What changed?
* Updates re Dev Portal and MSF app compatibility inputs. Docs include:
  * managing apps in the dev portal
  * apps publishing guide
* Additionally, relocated info on creating app API accounts from auth to managing apps in the dev portal (linked)
* Also relocated the best version of the x-auth-client header deprecation callout
