### PR TITLE
DEVDOCS-3351: [internal] Update PR templates

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,7 @@
-# [DEVDOCS-](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-)
+# [DEVDOCS-]
 
 ## What changed?
 * thing_that_changed
+
+## Anything else?
+Related PRs, salient notes, etc

--- a/pull_request_template_CODEOWNER.md
+++ b/pull_request_template_CODEOWNER.md
@@ -1,13 +1,16 @@
-# Controlled Merge with link check
+# Publication rebase merge with link check
 
-## Included Tickets / PRs
-* [DEVDOCS-](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-) - #PRnumber - @person
-* [DEVDOCS-](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-) - #PRnumber - @person
+## Included tickets / PRs
+* [DEVDOCS-] - #
+* [DEVDOCS-] - #
+* [DEVDOCS-] - #
 
-## To Do
-Indicate when done.
+## Links
+Indicate work. Options include the following:
 
-* Check links with tool -- @person
-* Check ToC -- @person
-* Add redirects if needed -- @person
-  * Slug changes not detected or [Dev Center link PR xx](https://github.com/bigcommerce-labs/next-dev-center-prototype/pull/xx)
+* Add redirects if needed
+  * See [Dev Center link PR xx](https://github.com/bigcommerce-labs/next-dev-center-prototype/pull/xx)
+
+Link check techniques; please indicate which you used, if any.
+* Check links with tool
+* Check ToC


### PR DESCRIPTION
# [DEVDOCS-3351]

## What changed?
* remove markdown link bodies that now auto-populate
* update codeowner publication template to reflect current workflow

## Anything else?
Related PRs, salient notes, etc
* This doesn't complete DEVDOCS-3351
* See parallel [PR 957](https://github.com/bigcommerce/api-specs/pull/957) in the api-specs repo

[DEVDOCS-3351]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ