### PR TITLE
DEVDOCS-4438-remove-suggested-products-section

### DIFF
--- a/docs/stencil-docs/reference-docs/other-objects-and-properties-overview.md
+++ b/docs/stencil-docs/reference-docs/other-objects-and-properties-overview.md
@@ -470,13 +470,6 @@ For further details about catalog price properties, please see [Catalog Price Ob
 | message  | System-generated messages for the cart  |
 |type|Type of message: error, info, or success	|
 
-### Suggested Products
-
-**Description:** A list of suggested products, based on cart contents; displays only if enabled by the `cart.suggestions` front-matter attribute, and only immediately after a product is added to the cart
-
-**Handlebars Expression:** `{{cart.suggested_products}}`
-
-**Object Properties:** References standard product card model.
 
 ## Customer
 


### PR DESCRIPTION
# [DEVDOCS-4438](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4438)

## What changed?
Removed the suggested products section. You can see a screenshot of the slack conversation in the ticket.

## Anything else?
Related PRs, salient notes, etc
