### PR TITLE
DEVDOCS-4047, DEVDOCS-4433: [navigation] Promotions & Customer Segmentation API beta, add to toc

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -794,6 +794,12 @@
       "uri": "https://developer.bigcommerce.com/promotions/beta/api-docs/overview"
     },
     {
+      "type": "item",
+      "title": "Customer Segmentation API",
+      "href": "/customers/beta/api-docs/overview",
+      "uri": "https://developer.bigcommerce.com/customers/beta/api-docs/overview"
+    },
+    {
       "type": "divider",
       "title": "Partner Information"
     },

--- a/toc.json
+++ b/toc.json
@@ -785,6 +785,16 @@
     },
     {
       "type": "divider",
+      "title": "Beta Features"
+    },
+    {
+      "type": "item",
+      "title": "Promotions API",
+      "href": "/promotions/beta/api-docs/overview",
+      "uri": "https://developer.bigcommerce.com/promotions/beta/api-docs/overview"
+    },
+    {
+      "type": "divider",
       "title": "Partner Information"
     },
     {

--- a/toc.json
+++ b/toc.json
@@ -85,12 +85,6 @@
           "flag": "code samples",
           "uri": "docs/api-docs/storefront/graphql/graphql-api-examples.md"
         },
-        // {
-        //  "type": "item",
-        //  "title": "Storefront GraphQL Explorer",
-        //  "href": "",
-        //  "uri": ""
-        // },
         {
           "type": "item",
           "title": "GraphQL Storefront Explorer",

--- a/toc.json
+++ b/toc.json
@@ -787,6 +787,7 @@
       "type": "divider",
       "title": "Beta Features"
     },
+
     {
       "type": "item",
       "title": "Promotions API",

--- a/toc.json
+++ b/toc.json
@@ -787,7 +787,6 @@
       "type": "divider",
       "title": "Beta Features"
     },
-
     {
       "type": "item",
       "title": "Promotions API",


### PR DESCRIPTION
# [DEVDOCS-4047], [DEVDOCS-4433]

## What changed?
* add `Beta Features` section to ToC
* add absolute link to Promotions API beta narrative docs
* add absolute link to Customer Segmentation API beta narrative docs

## Anything else?
* see [api-specs PR 973](https://github.com/bigcommerce/api-specs/pull/973)

[DEVDOCS-4047]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEVDOCS-4433]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ