### PR TITLE
DEVDOCS-4428: [update] Standardize references to the App Marketplace

### DIFF
--- a/docs/api-docs/apps/guide/apps-01-introduction.md
+++ b/docs/api-docs/apps/guide/apps-01-introduction.md
@@ -1,6 +1,6 @@
 # Introduction to Building Apps
 
-Using BigCommerce's powerful APIs, SDKs, and toolkits, developers can build apps that are installable on BigCommerce stores. Once approved, apps can be sold (or made available free of charge) to all BigCommerce merchants on the [Apps Marketplace](https://www.bigcommerce.com/apps). This is the first article in a comprehensive developer's guide to building BigCommerce apps. It provides a brief, high-level introduction for developers new to the platform. If you already have experience developing for BigCommerce, feel free to [skip ahead](#next-steps) or check out the [quick start tutorial](/api-docs/apps/quick-start).
+Using BigCommerce's powerful APIs, SDKs, and toolkits, developers can build apps that are installable on BigCommerce stores. Once approved, apps can be sold (or made available free of charge) to all BigCommerce merchants on the [App Marketplace](https://www.bigcommerce.com/apps). This is the first article in a comprehensive developer's guide to building BigCommerce apps. It provides a brief, high-level introduction for developers new to the platform. If you already have experience developing for BigCommerce, feel free to [skip ahead](#next-steps) or check out the [quick start tutorial](/api-docs/apps/quick-start).
 
 
 ## About BigCommerce apps
@@ -8,7 +8,7 @@ Using BigCommerce's powerful APIs, SDKs, and toolkits, developers can build apps
 Let's first take a look how apps are discovered, displayed, and managed on BigCommerce stores.
 
 ### Discovery
-Approved apps are listed on the app [Marketplace](https://www.bigcommerce.com/apps/) for merchants to browse, search, and install.
+Approved apps are listed on the [App Marketplace](https://www.bigcommerce.com/apps/) for merchants to browse, search, and install.
 
 ![App Marketplace](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/apps-01-introduction-01.png "App Marketplace")
 

--- a/docs/api-docs/apps/guide/apps-04-devloper-portal.md
+++ b/docs/api-docs/apps/guide/apps-04-devloper-portal.md
@@ -4,7 +4,7 @@ Create, edit, and submit apps for approval using the [Developer Portal](https://
 
 <!-- theme: info -->
 > #### Store email address constraint
-> Apps that aren't approved for distribution through the [Apps Marketplace](https://bigcommerce.com/apps) can only be installed on stores owned by the same email address as the developer portal account's email address.
+> Apps that aren't approved for distribution through the [App Marketplace](https://bigcommerce.com/apps) can only be installed on stores owned by the same email address as the developer portal account's email address.
 
 ## Create an app
 
@@ -12,7 +12,7 @@ Creating an app also creates an app API account. To learn more about app API acc
 
 <!-- theme: info -->
 > #### Information optional
-> No app profile fields are mandatory unless you're preparing the app for BigCommerce [Apps Marketplace](https://bigcommerce.com/apps) approval. To learn more about preparing an app for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
+> No app profile fields are mandatory unless you're preparing the app for BigCommerce [App Marketplace](https://bigcommerce.com/apps) approval. To learn more about preparing an app for approval, see our [App Publishing Guide](/api-docs/apps/guide/publishing).
 
 1. Sign in or create an account with the [Developer Portal](https://devtools.bigcommerce.com).
 
@@ -97,7 +97,7 @@ To read about designing or modifying your app to support multi-storefront, see [
 
 ## Submit an app for approval
 
-1. Submit apps for [Apps Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. 
+1. Submit apps for [App Marketplace](https://www.bigcommerce.com/apps) approval by navigating to the Dev Portal's [My Apps dashboard](https://devtools.bigcommerce.com/my/apps), then finding the app you want approved and clicking the **Submit** checkmark icon to the right of its listing. 
 
 ![Menu - submit](https://storage.googleapis.com/bigcommerce-production-dev-center/images/app-api-account/devtool-app-menu-submit.png "Submit an App")
 
@@ -139,4 +139,4 @@ To learn about mitigating the risks of deleting an app and its API account, see 
 * [Developer Portal](https://devtools.bigcommerce.com/) (devtools.bigcommerce.com)
 * [Partner Portal](https://partners.bigcommerce.com/English/) (partners.bigcommerce.com)
 * [Technology Partner Program](https://partners.bigcommerce.com/English/register_email.aspx) (partners.bigcommerce.com)
-* [BigCommerce Apps Marketplace](https://www.bigcommerce.com/apps/) (bigcommerce.com)
+* [BigCommerce App Marketplace](https://www.bigcommerce.com/apps/) (bigcommerce.com)

--- a/docs/api-docs/apps/guide/apps-05-oauth.md
+++ b/docs/api-docs/apps/guide/apps-05-oauth.md
@@ -16,7 +16,7 @@ Your app must expose a callback endpoint, `GET /auth`, that the merchant's store
 BigCommerce uses a modified version of the [OAuth2 authorization code grant (tools.ietf.org)](https://tools.ietf.org/html/rfc6749#section-4.1). The sequence is as follows:
 
 1. The merchant initiates installing your app by signing in to their store control panel and doing one of the following: 
-  * clicking **Install** in the [Apps Marketplace](https://www.bigcommerce.com/apps/), or 
+  * clicking **Install** in the [App Marketplace](https://www.bigcommerce.com/apps/), or 
   * following a direct installation link.
 2. The merchant accepts the app's OAuth scope permissions. The OAuth consent view presented to the merchant requires them to approve all the scopes to install the app; at this time, merchants cannot pick and choose scopes.
 3. The merchant's [browser sends a GET request to the app](#receiving-the-auth-callback) server's `GET /auth` endpoint that contains some of the information necessary to request a unique `access_token` for the store. 

--- a/docs/api-docs/apps/guide/apps-09-ui.md
+++ b/docs/api-docs/apps/guide/apps-09-ui.md
@@ -55,7 +55,7 @@ Do you design with Figma? If so, check out our design kit:
 
 ## Developing for the iFrame
 
-Single-click apps benefit from a high level of integration with the BigCommerce control panel. BigCommerce achieves this by rendering your app's UI in an iFrame. To meet [Apps Marketplace](https://www.bigcommerce.com/apps/) requirements, your app should perform all functions inside the iFrame. The iFrame approach requires special attention from app developers.
+Single-click apps benefit from a high level of integration with the BigCommerce control panel. BigCommerce achieves this by rendering your app's UI in an iFrame. To meet [App Marketplace](https://www.bigcommerce.com/apps/) requirements, your app should perform all functions inside the iFrame. The iFrame approach requires special attention from app developers.
 
 To load inside the control panel iFrame, your app must do the following:
 1. **Serve app resources over HTTPS:** BigCommerce's control panel is served over HTTPS. Your app must also be served over HTTPS, including any remote resources referenced (such as CSS, JS, and image files). If any resources are served over HTTP, the user's browser will display a mixed content error and refuse to render your app's UI in the control panel iFrame.
@@ -63,7 +63,7 @@ To load inside the control panel iFrame, your app must do the following:
 
 <!-- theme: info -->
 > #### Note
-> Apps that operate in the iFrame get strong preference during [Apps Marketplace](https://www.bigcommerce.com/apps/) consideration; however, we sometimes make exceptions for apps that need to interact with other services.
+> Apps that operate in the iFrame get strong preference during [App Marketplace](https://www.bigcommerce.com/apps/) consideration; however, we sometimes make exceptions for apps that need to interact with other services.
 
 
 

--- a/docs/api-docs/apps/guide/apps-11-best-practices.md
+++ b/docs/api-docs/apps/guide/apps-11-best-practices.md
@@ -2,7 +2,7 @@
 
 
 
-Review the following best practices before submitting your app to the [Apps Marketplace](https://www.bigcommerce.com/apps/).
+Review the following best practices before submitting your app to the [App Marketplace](https://www.bigcommerce.com/apps/).
 
 ## OAuth flow
 

--- a/docs/api-docs/apps/guide/apps-12-requirements.md
+++ b/docs/api-docs/apps/guide/apps-12-requirements.md
@@ -2,7 +2,7 @@
 
 
 
-The App Marketplace team reviews all app submissions and tests apps to verify they meet [Marketplace](https://www.bigcommerce.com/apps/) listing standards. Verify your app meets the requirements below before submitting it for approval.
+The Marketplace team reviews all app submissions and tests apps to verify they meet [App Marketplace](https://www.bigcommerce.com/apps/) listing standards. Verify your app meets the requirements below before submitting it for approval.
 
 ## General requirements
 
@@ -20,7 +20,7 @@ Don't reference competitor platforms in the app's listing information or dashboa
 
 ## Listing
 
-* Approval for the [Marketplace](https://www.bigcommerce.com/apps/) requires all fields listed in the Publishing Apps section (**Case Studies** and **Videos** are optional).
+* Approval for the [App Marketplace](https://www.bigcommerce.com/apps/) requires all fields listed in the Publishing Apps section (**Case Studies** and **Videos** are optional).
 * Listings should be well worded, cleanly formatted, and follow wording and image specifications.
 * App listing name should be restricted to only branding and not include taglines.
 
@@ -29,8 +29,8 @@ Don't reference competitor platforms in the app's listing information or dashboa
 * Apps must work as intended and cannot conflict with BigCommerce functionality.
 * Apps must use V3 endpoints in favor of V2 endpoints when feature parity exists.
 * Apps must serve all callback URLs over HTTPS.
-* Apps in the Marketplace must be[ multi-user enabled](/api-docs/apps/guide/users).
-* Apps that process transactions or handle credit card data must pass a PCI Compliance review by BigCommerce's security team. New payment gateway app submissions may not be accepted for Marketplace review.
+* Apps in the App Marketplace must be [multi-user enabled](/api-docs/apps/guide/users).
+* Apps that process transactions or handle credit card data must pass a PCI Compliance review by BigCommerce's security team. New payment gateway app submissions may not be accepted for App Marketplace review.
 * Apps that access the Checkout Content scope will also be subject to a security assessment by BigCommerce's security team.
 * Apps that modify the checkout experience must use the BigCommerce [Checkout SDK](/stencil-docs/customizing-checkout/checkout-sdk).
 * Apps that add another marketplace or sales channel to a store should make use of the [Channels Toolkit](/api-docs/channels/guide/building-channel-apps) and follow [Channel App Requirements](/api-docs/channels/guide/channel-app-requirements).
@@ -53,7 +53,7 @@ Don't reference competitor platforms in the app's listing information or dashboa
 ## FAQ
 
 **Are all fields required?**
-For Marketplace approval, you'll need to fill out all fields on your listing with applicable content and links. These will be reviewed as part of the Marketplace approval process. **Case Studies** and **Videos** are optional.
+For App Marketplace approval, you'll need to fill out all fields on your listing with applicable content and links. These will be reviewed as part of the Marketplace approval process. **Case Studies** and **Videos** are optional.
 
 ## Next steps
 * [Publish your app](/api-docs/apps/guide/publishing).

--- a/docs/api-docs/apps/guide/apps-12-requirements.md
+++ b/docs/api-docs/apps/guide/apps-12-requirements.md
@@ -2,7 +2,7 @@
 
 
 
-The Apps Marketplace team reviews all app submissions and tests apps to verify they meet [Marketplace](https://www.bigcommerce.com/apps/) listing standards. Verify your app meets the requirements below before submitting it for approval.
+The App Marketplace team reviews all app submissions and tests apps to verify they meet [Marketplace](https://www.bigcommerce.com/apps/) listing standards. Verify your app meets the requirements below before submitting it for approval.
 
 ## General requirements
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.md
+++ b/docs/api-docs/apps/guide/apps-13-publishing.md
@@ -4,7 +4,7 @@ After completing development, verifying best practices, and checking approval re
 
 ## Before you begin
 
-Your listing on the [Apps Marketplace](https://www.bigcommerce.com/apps/) plays a major role in your app's success. A good listing accomplishes three goals:
+Your listing on the [App Marketplace](https://www.bigcommerce.com/apps/) plays a major role in your app's success. A good listing accomplishes three goals:
 * Shows users how your platform or solution differs from competitive offerings
 * Includes keywords so prospective users can find your listing in searches
 * Sets up clear and accurate user expectations as to your solution's features and functionality
@@ -117,10 +117,10 @@ You may have logged in with the wrong account. Each listing can only be owned by
 **I saved my changes, but my listing has not updated yet. What's the problem?**
 
 The changes will be effective immediately in your control panel app card, but the updates
-can take up to 24 hours to appear on the Apps Marketplace. Feel free to use this as a grace period to make edits as needed.
+can take up to 24 hours to appear on the App Marketplace. Feel free to use this as a grace period to make edits as needed.
 
 ## Next steps
-[Review the Apps Marketplace listing guide (PDF)](https://grow.bigcommerce.com/rs/695-JJT-333/images/Updated_List_of_App_Fields_for_Tech_Partners.pdf)
+[Review the App Marketplace listing guide (PDF)](https://grow.bigcommerce.com/rs/695-JJT-333/images/Updated_List_of_App_Fields_for_Tech_Partners.pdf)
 
 ## Resources
 

--- a/docs/api-docs/cart-and-checkout/channels-sites-routes.md
+++ b/docs/api-docs/cart-and-checkout/channels-sites-routes.md
@@ -75,7 +75,7 @@ These APIs are not always required, but highly recommended for app developers ba
 
 ### Preferred App Placement in the Control Panel
 
-Currently, certain channel apps, including native BigCommerce apps and specific partner apps, can be found in a merchant’s BigCommerce control panel in the “Channel Manager” section. Partners can work with the BigCommerce team to get strategic placement in this section, enabling merchants to see their specific channel first. Additionally, this discovery takes place in the control panel, which is deeply integrated into all merchants’ day to day workflow; whereas those found in the app marketplace must be found by searching within the app marketplace, which is not natively found in the control panel.
+Currently, certain channel apps, including native BigCommerce apps and specific partner apps, can be found in a merchant’s BigCommerce control panel in the “Channel Manager” section. Partners can work with the BigCommerce team to get strategic placement in this section, enabling merchants to see their specific channel first. Additionally, this discovery takes place in the control panel, which is deeply integrated into all merchants’ day to day workflow; whereas those found in the App Marketplace must be found by searching within the App Marketplace, which is not natively found in the control panel.
 
 ### BigDesign
 
@@ -87,4 +87,4 @@ An express installable app means that all scopes and permissions will be automat
 
 ### Must Meet App Requirements
 
-Any app, whether it is in the app marketplace or channel manager, must meet BigCommerce’s [app requirements](/api-docs/partner/app-store-approval-requirements).
+Any app, whether it is in the App Marketplace or channel manager, must meet BigCommerce’s [app requirements](/api-docs/partner/app-store-approval-requirements).

--- a/docs/api-docs/channels/building-channel-apps.md
+++ b/docs/api-docs/channels/building-channel-apps.md
@@ -4,7 +4,7 @@
 
 
 
-Using BigCommerce's [Channels Toolkit](/api-docs/channels/channels-toolkit-reference), developers can create channel apps that integrate with point-of-sale devices, [headless storefronts](/api-docs/storefronts/developers-guide-headless), online marketplaces, marketing platforms, and social networking sites. BigCommerce lists all approved channel apps on the [Apps Marketplace](https://www.bigcommerce.com/apps/) and markets channel apps developed by [select partners](https://www.bigcommerce.com/partners/) in [Channel Manager](https://support.bigcommerce.com/s/article/Selling-Everywhere-with-Channel-Manager).
+Using BigCommerce's [Channels Toolkit](/api-docs/channels/channels-toolkit-reference), developers can create channel apps that integrate with point-of-sale devices, [headless storefronts](/api-docs/storefronts/developers-guide-headless), online marketplaces, marketing platforms, and social networking sites. BigCommerce lists all approved channel apps on the [App Marketplace](https://www.bigcommerce.com/apps/) and markets channel apps developed by [select partners](https://www.bigcommerce.com/partners/) in [Channel Manager](https://support.bigcommerce.com/s/article/Selling-Everywhere-with-Channel-Manager).
 
 This article is a comprehensive guide on the foundations of integrating [Channels Toolkit](/api-docs/channels/guide/channels-toolkit-reference) into [single-click apps](/api-docs/apps/guide/types). For a high-level overview of channels on BigCommerce, see [Channels Overview](/api-docs/channels/channels-overview).
 

--- a/docs/api-docs/channels/channels-overview.md
+++ b/docs/api-docs/channels/channels-overview.md
@@ -35,7 +35,7 @@ BigCommerce channel apps allow merchants to list products on external sales chan
 
 ### Discovery
 
-Merchants discover channel apps either through the [Apps Marketplace](https://www.bigcommerce.com/apps/) or
+Merchants discover channel apps either through the [App Marketplace](https://www.bigcommerce.com/apps/) or
 
 ![App Marketplace](https://storage.googleapis.com/bigcommerce-production-dev-center/images/channels/channels-marketplace.png "App Marketplace")
 

--- a/docs/api-docs/provider-apis/tax/overview.md
+++ b/docs/api-docs/provider-apis/tax/overview.md
@@ -64,7 +64,7 @@ Additionally, when providing the details for a sandbox tax provider configuratio
 
 ## Building the app
 
-Tax providers are required to build a BigCommerce [single-click app](/api-docs/apps/guide/types#single-click) in order to utilise the Tax Provider API to provide tax estimates and submit tax documents. A BigCommerce single-click app provides many benefits, for example, it enables tax providers to promote their solution in the BigCommerce apps marketplace, ask for merchant authorisation of API scopes during app install, as well as enable configuration of tax provider settings via an iFrame in the BigCommerce control panel.
+Tax providers are required to build a BigCommerce [single-click app](/api-docs/apps/guide/types#single-click) in order to utilise the Tax Provider API to provide tax estimates and submit tax documents. A BigCommerce single-click app provides many benefits, for example, it enables tax providers to promote their solution in the BigCommerce App Marketplace, ask for merchant authorisation of API scopes during app install, as well as enable configuration of tax provider settings via an iFrame in the BigCommerce control panel.
 
 Review our [introduction to building apps](/api-docs/apps/guide/intro) guide and use the sidebar to explore topics including: types of apps, managing apps in the dev portal, implementing OAuth, and designing the UI.
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -105,7 +105,7 @@ In the case of errors, include human-readable error messages in the response pay
 
 To use the Shipping Provider API to provide shipping quotes, shipping providers must build a BigCommerce [single-click app](/api-docs/apps/guide/types#single-click). 
 
-Using a BigCommerce app enables shipping providers to promote their solution in the BigCommerce apps marketplace, request merchant authorization of API scopes during app install, and enable configuration of shipping provider settings and/or order fulfillment via an iFrame in the BigCommerce control panel.
+Using a BigCommerce app enables shipping providers to promote their solution in the BigCommerce App Marketplace, request merchant authorization of API scopes during app install, and enable configuration of shipping provider settings and/or order fulfillment via an iFrame in the BigCommerce control panel.
 
 For more information, see our [Introduction to Building Apps](/api-docs/apps/guide/intro).
 

--- a/docs/stencil-docs/customizing-checkout/checkout-confirmation-injection.md
+++ b/docs/stencil-docs/customizing-checkout/checkout-confirmation-injection.md
@@ -137,7 +137,7 @@ The following sections present examples of scripts that inject popular apps into
 
 ### Olark Live Chat
 
-As an example of injecting an app from the BigCommerce Apps Marketplace, you could enable the Olark Live Chat app on either page by using the script manager or our new Scripts API:
+As an example of injecting an app from the BigCommerce App Marketplace, you could enable the Olark Live Chat app on either page by using the script manager or our new Scripts API:
 
 ```js
 <!-- begin olark code -->

--- a/docs/stencil-docs/page-builder/third-party-widgets.md
+++ b/docs/stencil-docs/page-builder/third-party-widgets.md
@@ -19,7 +19,7 @@ To use this method, you will need to obtain API credentials with OAuth content s
 
 ### App Marketplace
 
-The [Apps Marketplace](https://www.bigcommerce.com/apps/) is an area inside the control panel where merchants can browse for apps available for installation on their BigCommerce store.
+The [App Marketplace](https://www.bigcommerce.com/apps/) is an area inside the control panel where merchants can browse for apps available for installation on their BigCommerce store.
 
 To create a widget using the App Marketplace, you will need to create a marketplace application that injects new widgets into the storefront using the Widgets API.
 


### PR DESCRIPTION
# [DEVDOCS-4428]

## What changed?
change to App Marketplace




[DEVDOCS-4428]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ