### PR TITLE
DEVDOCS-3855: [net new] Rescoped Analytics API

### DIFF
--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -26,17 +26,6 @@ You can get **all** web analytics, get a **single** web analytic, or **update** 
 
 ## Google Analytics
 
-| Field | Type | Description |
-| ------------- | -------- |  -------- |
-| id | integer | ID of the web analytic. `1` for Google Analytics |
-| channel_id | integer | ID of the storefront channel. Default is `0`. |
-| name | string | Name of web analytic `Google Analytics` |
-| enabled | boolean | Indicates whether the merchant has [enabled Google Analytics](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
-| version | integer | Corresponds to connection field that merchant is using to connect to Google Analytics. Value is `1` when tracking code is used. Value is `2` when property id is used. |
-| data_tag_enabled | boolean | Indicates whether data tags are enabled by Google Analytics |
-| tracking_code | string | Tracking code merchant uses to connect Google Analytics to store. Only returned if the version is `1`. |
-| property_id | string | Property id merchant uses to connect Google Analytics to store. Only returned if the version is `2`.  |
-
 The version corresponds with the "Connect with Field" that a merchant uses to connect to Google Analytics. This connection field affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic).
 ![Version on Google Analytics](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Version%20for%20Google%20Analytics.png).
 
@@ -164,14 +153,6 @@ title: Response
 
 ## Visual Website Optimizer
 
-| Field | Type | Description |
-| ------------- | -------- |  -------- |
-| id | integer | ID of the web analytic. `2` for Visual Website Optimizer |
-| channel_id | integer | ID of the storefront channel. Default is `0`. |
-| name | string | Name of web analytic `Visual Website Optimizer` |
-| enabled | boolean | Indicates whether merchant has [enabled Visual Website Optimizer](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
-| vwo_smartcode | string | Visual Website Optimizer Smartcode used to connect store to Visual Website Optimizer analytic| 
-
 ### Get the Visual Website Optimizer Analytic
 
 If a merchant has not entered a VWO Smartcode, `vwo_smartcode` will return as an empty string.
@@ -252,15 +233,6 @@ title: Response
 
 ## Facebook Pixel
 
-| Field | Type | Description |
-| ------------- | -------- |  -------- |
-| id | integer | ID of the web analytic. `1` for Facebook Pixel |
-| channel_id | integer | ID of the storefront channel. Default is `0`. |
-| name | string | Name of web analytic `Facebook Pixel` |
-| enabled | boolean | Indicates whether merchant has [enabled Facebook Pixel](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
-| pixel_id | string | Facebook Pixel ID used to connect store to Facebook Pixel |
-| is_oauth_connected | boolean | Indicates whether store has been granted OAuth token to connect to FB Pixel|
-
 ### Get the Facebook Pixel Analytic
 
 If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
@@ -339,15 +311,6 @@ title: Response
 &nbsp;
 
 ## Segment
-
-| Field | Type | Description |
-| ------------- | -------- |  -------- |
-| id | integer | ID of the web analytic. `1` for Segment |
-| channel_id | integer | ID of the storefront channel. Default is `0`. |
-| name | string | Name of web analytic `Segment` |
-| enabled | boolean | Indicates whether merchant has [enabled Segment](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
-| api_key | string | Segment API key used to connect store to Segment |
-| data_tag_enabled | boolean | Indicates whether data tags are enabled by Segment Analytic |
 
 ### Get the Segment Analytic
 
@@ -433,14 +396,6 @@ title: Response
 
 ## Site Verification Tags
 
-| Field | Type | Description |
-| ------------- | -------- |  -------- |
-| id | integer | ID of the web analytic. `1` for Site Verification Tags |
-| channel_id | integer | ID of the storefront channel. Default is `0`. |
-| name | string | Name of web analytic `Site Verification Tags` |
-| enabled | boolean | Indicates whether merchant has [enabled Site Verification Tags](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
-| verification_tag | string | Site Verification Tag |
-
 ### Get the Site Verification Tags Analytic
 
 If a merchant has not entered a verification tag, `verification_tag` will return as an empty string.
@@ -522,14 +477,6 @@ title: Response
 &nbsp;
 
 ## Affiliate Conversion Tracking
-
-| Field | Type | Description |
-| ------------- | -------- |  -------- |
-| id | integer | ID of the web analytic. `1` for Affiliate Conversion Tracking |
-| channel_id | integer | ID of the storefront channel. Default is `0`. |
-| name | string | Name of web analytic `Affiliate Conversion Tracking` |
-| enabled | boolean | Indicates whether merchant has [enabled Affiliate Conversion Tracking](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
-| connection | string | Affiliate Conversion Tracking Code |
 
 ### Get the Affiliate Conversion Tracking Analytic
 

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -1,6 +1,6 @@
 # Data Solutions API
 
-The Data Solutions V3 API lets you configure **storefront** channel settings for a store's prebuilt data analytic solutions.  
+The Web Analytics API lets you configure **storefront** channel settings for a store's prebuilt data analytic solutions.  
 
 Note that a store has global settings for data solutions, from which any storefront channel can inherit. A merchant can override these global settings with storefront-specific settings for their data solutions. This API configures settings for **storefront** channels at the store's global level (`channel_id` is `0`) and at the specific storefront channel level (by specifying a `channel_id` in the query). If no channel ID is specified in the query, the default channel is the global channel `0`.    
 
@@ -8,7 +8,7 @@ Note that a store has global settings for data solutions, from which any storefr
 > #### Note
 > You can obtain storefront channel IDs using the [Get all channels](/api-reference/store-management/channels/channels/listchannels) endpoint. 
 
-This article introduces how to configure web analytics using the Data Solutions V3 API. Because each web analytic requires different fields in the request and/or response, this article is divided by web analytics.
+This article shows you how to manage web analytics using the Web Analytics API.
 
 You can get **all** web analytics, get a **single** web analytic, or **update** a single analytic. To get or update a **single** web analytic, the `id` of the web analytic must be specified in the path.
 
@@ -20,6 +20,7 @@ You can get **all** web analytics, get a **single** web analytic, or **update** 
 | Segment | 4 |
 | Site Verification Tags | 6 |
 | Affiliate Conversion Tracking | 7 |
+| Google Analytic 4 | 8 |
 
 **Note**: Web analytic ID 5 is no longer in use.
 
@@ -614,6 +615,89 @@ title: Response
 
 &nbsp;
 
+## Google Analytic 4 
+
+### Get the Google Analytic 4 Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+  "data": {
+      "id": 8,
+      "channel_id": 0,
+      "name": "Google Analytics 4",
+      "enabled": false,
+      "measurement_id": "G-0123456789",
+      "data_tag_enabled": false
+  },
+  "meta": {}
+}
+```
+
+<!-- type: tab-end -->
+
+### Update the Google Analytic 4 Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "id": 8,
+  "channel_id": 0,
+  "name": "Google Analytics 4",
+  "enabled": true,
+  "measurement_id": "G-9876543210",
+  "data_tag_enabled": true
+}
+
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 8,
+        "channel_id": 0,
+        "name": "Google Analytics 4",
+        "enabled": true,
+        "measurement_id": "G-9876543210",
+        "data_tag_enabled": true
+    },
+    "meta": {}
+}
+```
+
+<!-- type: tab-end -->
+
+
 ## Get all web analytics
 
 All six web analytics will be returned. As shown, fields for codes (such as `verification_tag`) in which a merchant has not entered a value will return as an empty string.     
@@ -684,6 +768,14 @@ title: Response
             "enabled": false,
             "connection": "<script>js code here...</script>"
         }
+        {
+            "id": 8,
+            "channel_id": 0,
+            "name": "Google Analytics 4",
+            "enabled": true,
+            "measurement_id": "G-9876543210",
+            "data_tag_enabled": true
+          }
     ],
     "meta": {}
 }

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -1,6 +1,6 @@
-# Web Analytics API
+# Data Solutions
 
-The Web Analytics API lets you set **storefront** channel settings for a store's prebuilt data solutions. These settings help merchants connect and enable data solutions for a store. A store has global settings for each web analytic, from which any storefront channel can inherit. You can override these global settings with storefront-specific settings. 
+The Settings API lets you set **storefront** channel settings for a store's prebuilt data solutions. These settings help merchants connect web analytics to a store. A store has global settings for each web analytic, from which any storefront channel can inherit. You can override these global settings with storefront-specific settings. 
 
 You can get all web analytics, get a single web analytic, or update a single analytic. To get or update a single web analytic, the `id` of the web analytic must be specified in the path.
 
@@ -21,7 +21,7 @@ You can get all web analytics, get a single web analytic, or update a single ana
 > - If you query a storefront channel, the response returns global (not storefront) settings if the channel inherits global settings. The `channel_id` in the response will be that of the default global channel (`0`).   
 > - Web analytic ID 5 is no longer in use.
 
-This article shows you how to manage web analytics using the Web Analytics API. For more, see the [Web Analytics API Reference](/...).
+This article shows you how to manage web analytics using the Settings API. For more, see the [Settings API Reference](/api-reference/store-management/settings).
 
 
 ## Google Analytics
@@ -746,6 +746,7 @@ title: Response
 &nbsp;
 
 ## Resources
+- [Settings API Reference](/api-reference/store-management/settings)
 - [Web Analytics Overview](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics)
 
 ### Web Analytics reference

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -70,7 +70,7 @@ title: Response
 
 <!-- type: tab-end -->
 
-When a merchant uses a property ID, your response will have a version of `2` and the `property_id` field. If a merchant has not entered a property ID, `property_id` will return as an empty string.
+When a merchant uses a property ID, your response will have a version of `2` in the `property_id` field. If a merchant has not entered a property ID, `property_id` will return as an empty string.
 
 <!--
 type: tab

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -32,7 +32,7 @@ A merchant can use a tracking code or property ID to connect Google Analytics to
 
 ### Get the Google Analytic
 
-To get a Google Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Google Analytics in the path.
+To get a Google Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Google Analytics in the path.
 
 When a merchant uses a tracking code, your response will have a version of `1` and the `tracking_code` field. If a merchant has not entered a tracking code, `tracking_code` will return as an empty string.
 
@@ -108,7 +108,7 @@ title: Response
 
 ### Update the Google Analytic
 
-To update a Google Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Google Analytics in the path.
+To update a Google Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Google Analytics in the path.
 
 <!--
 type: tab
@@ -159,7 +159,7 @@ title: Response
 
 ### Get the Visual Website Optimizer Analytic
 
-To get a Visual Website Optimizer Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Visual Website Optimizer in the path. If a merchant has not entered a VWO Smartcode, `vwo_smartcode` will return as an empty string.
+To get a Visual Website Optimizer Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Visual Website Optimizer in the path. If a merchant has not entered a VWO Smartcode, `vwo_smartcode` will return as an empty string.
 
 <!--
 type: tab
@@ -194,7 +194,7 @@ title: Response
 
 ### Update the Visual Website Optimizer Analytic
 
-To update a Visual Website Optimizer Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Visual Website Optimizer in the path.
+To update a Visual Website Optimizer Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Visual Website Optimizer in the path.
 
 <!--
 type: tab
@@ -241,7 +241,7 @@ title: Response
 
 ### Get the Facebook Pixel Analytic
 
-To get a Facebook Pixel Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Facebook Pixel in the path. If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
+To get a Facebook Pixel Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Facebook Pixel in the path. If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
 
 <!--
 type: tab
@@ -275,7 +275,7 @@ title: Response
 
 ### Update the Facebook Pixel Analytic
 
-To update a Facebook Pixel Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Facebook Pixel in the path. 
+To update a Facebook Pixel Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Facebook Pixel in the path. 
 
 <!--
 type: tab
@@ -322,7 +322,7 @@ title: Response
 
 ### Get the Segment Analytic
 
-To get a Segment Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Segment in the path. If a merchant has not entered an API Key, `api_key` will return as an empty string.
+To get a Segment Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Segment in the path. If a merchant has not entered an API Key, `api_key` will return as an empty string.
 
 <!--
 type: tab
@@ -358,7 +358,7 @@ title: Response
 
 ### Update the Segment Analytic
 
-To update a Segment Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Segment in the path.
+To update a Segment Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Segment in the path.
 
 <!--
 type: tab
@@ -408,7 +408,7 @@ title: Response
 
 ### Get the Site Verification Tags Analytic
 
-To get a Site Verification Tags Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Site Verification Tags in the path. If a merchant has not entered a verification tag, `verification_tag` will return as an empty string.
+To get a Site Verification Tags Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Site Verification Tags in the path. If a merchant has not entered a verification tag, `verification_tag` will return as an empty string.
 
 <!--
 type: tab
@@ -444,7 +444,7 @@ title: Response
 
 ### Update the Site Verification Tags Analytic
 
-To update a Site Verification Tags Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Site Verification Tags in the path. 
+To update a Site Verification Tags Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Site Verification Tags in the path. 
 
 <!--
 type: tab
@@ -492,7 +492,7 @@ title: Response
 
 ### Get the Affiliate Conversion Tracking Analytic
 
-To get a Affiliate Conversion Tracking Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Affiliate Conversion Tracking in the path. If a merchant has not entered an Affiliate Conversion Tracking Code, `connection` will return as an empty string.
+To get a Affiliate Conversion Tracking Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Affiliate Conversion Tracking in the path. If a merchant has not entered an Affiliate Conversion Tracking Code, `connection` will return as an empty string.
 
 <!--
 type: tab
@@ -528,7 +528,7 @@ title: Response
 
 ### Update the Affiliate Conversion Tracking Analytic
 
-To update a Affiliate Conversion Tracking Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Affiliate Conversion Tracking in the path. 
+To update a Affiliate Conversion Tracking Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Affiliate Conversion Tracking in the path. 
 
 <!--
 type: tab
@@ -577,7 +577,7 @@ title: Response
 
 ### Get the Google Analytic 4 Analytic
 
-To get a Google Analytic 4, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Google Analytic 4 in the path. If a merchant has not entered a measurement ID, `measurement_id` will return as an empty string.
+To get a Google Analytic 4, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Google Analytic 4 in the path. If a merchant has not entered a measurement ID, `measurement_id` will return as an empty string.
 
 <!--
 type: tab
@@ -614,7 +614,7 @@ title: Response
 
 ### Update the Google Analytic 4 Analytic
 
-To update a Google Analytic 4, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Google Analytic 4 in the path. 
+To update a Google Analytic 4, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Google Analytic 4 in the path. 
 
 <!--
 type: tab
@@ -662,7 +662,7 @@ title: Response
 
 ## Get all web analytics
 
-To get all analytics, send a request to the [Get all analytics](/...) endpoint.
+To get all analytics, send a request to the [Get all web analytics](/api-reference/store-management/settings/analytics/get-all-web-analytics) endpoint.
 
 <!--
 type: tab
@@ -747,9 +747,10 @@ title: Response
 
 ## Resources
 - [Web Analytics Overview](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics)
-- [Google Analytics](https://support.bigcommerce.com/s/article/Setting-Up-Google-Analytics?language=en_US)
-- [Facebook Pixel](https://support.bigcommerce.com/s/article/Facebook-Pixel?language=en_US)
-- [Segment](https://support.bigcommerce.com/s/article/Setting-up-Segment-com?language=en_US)
-- [Affiliate Conversion Tracking](https://support.bigcommerce.com/s/article/Passing-Order-Data-to-Affiliate-Programs?language=en_US)
+
+### Web Analytics reference
+- [Get all web analytics](/api-reference/store-management/settings/analytics/get-all-web-analytics)
+- [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic)
+- [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic)
 
 

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -6,13 +6,13 @@ You can get all web analytics, get a single web analytic, or update a single ana
 
 | Web analytic | ID |
 | ------------- | -------- |
-| Google Analytics | 1 |
-| Visual Website Optimizer | 2 |
-| Facebook Pixel | 3 |
-| Segment | 4 |
-| Site Verification Tags | 6 |
-| Affiliate Conversion Tracking | 7 |
-| Google Analytics 4 | 8 |
+| Google Analytics | `1` |
+| Visual Website Optimizer | `2` |
+| Meta Pixel | `3` |
+| Segment | `4` |
+| Site Verification Tags | `6` |
+| Affiliate Conversion Tracking | `7` |
+| Google Analytics 4 | `8` |
 
 <!-- theme: info -->
 > #### Note
@@ -26,7 +26,7 @@ This article shows you how to manage web analytics using the Settings API. For m
 
 ## Google Analytics
 
-A merchant can use a tracking code or property ID to connect Google Analytics to a store. This affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic) endpoints.
+A merchant can use either a tracking code or property ID to connect Google Analytics to a store. This affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic) endpoints.
 ![Version on Google Analytics](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Version%20for%20Google%20Analytics.png).
 
 
@@ -237,18 +237,18 @@ title: Response
 
 &nbsp;
 
-## Facebook Pixel
+## Meta Pixel
 
-### Get the Facebook Pixel Analytic
+### Get the Meta Pixel Analytic
 
-To get a Facebook Pixel Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Facebook Pixel in the path. If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
+To get a Meta Pixel Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Meta Pixel in the path. If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
 
 <!--
 type: tab
 title: Request
 -->
 
-```http title="Example request: Get the Facebook Pixel Analytic" lineNumbers
+```http title="Example request: Get the Meta Pixel Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -259,7 +259,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example response: Get the Facebook Pixel Analytic" lineNumbers
+```json title="Example response: Get the Meta Pixel Analytic" lineNumbers
 {
   "data": {
     "id": 3,
@@ -273,16 +273,16 @@ title: Response
 ```
 <!-- type: tab-end -->
 
-### Update the Facebook Pixel Analytic
+### Update the Meta Pixel Analytic
 
-To update a Facebook Pixel Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Facebook Pixel in the path. 
+To update a Meta Pixel Analytic, send a request to the [Update a web analytic](/api-reference/store-management/settings/analytics/update-web-analytic) endpoint and specify the `id` of Meta Pixel in the path. 
 
 <!--
 type: tab
 title: Request
 -->
 
-```http title="Example request: Update the Facebook Pixel Analytic" lineNumbers
+```http title="Example request: Update the Meta Pixel Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -302,7 +302,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example response: Update the Facebook Pixel Analytic" lineNumbers
+```json title="Example response: Update the Meta Pixel Analytic" lineNumbers
 {
   "data": {
     "id": 3,

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -288,8 +288,7 @@ title: Response
         "channel_id": 0,
         "name": "Facebook Pixel",
         "enabled": true,
-        "pixel_id": "FP-1234567890",
-        "is_oauth_connected": true
+        "pixel_id": "FP-1234567890"
     },
     "meta": {}
 }
@@ -314,8 +313,7 @@ Accept: application/json
   "channel_id": 0,
   "name": "Facebook Pixel",
   "enabled": true,
-  "pixel_id": "FP-1234567890",
-  "is_oauth_connected": true
+  "pixel_id": "FP-1234567890"
 }
 
 ```
@@ -331,8 +329,7 @@ title: Response
         "channel_id": 0,
         "name": "Facebook Pixel",
         "enabled": true,
-        "pixel_id": "FP-1234567890",
-        "is_oauth_connected": true
+        "pixel_id": "FP-1234567890"
     },
     "meta": {}
 }
@@ -557,11 +554,14 @@ title: Response
 
 ```json title="Example GET response" lineNumbers
 {
-  "id": 7,
-  "channel_id": 0,
-  "name": "Affiliate Conversion Tracking",
-  "enabled": false,
-  "connection": "<script>js code here...</script>"
+    "data": {
+        "id": 7,
+        "channel_id": 0,
+        "name": "Affiliate Conversion Tracking",
+        "enabled": false,
+        "connection": "<script>js code here...</script>"
+    },
+    "meta": {}
 }
 ```
 
@@ -580,17 +580,14 @@ X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
 Accept: application/json
 
-{
-    "data": {
-        "id": 7,
-        "channel_id": 0,
-        "name": "Affiliate Conversion Tracking",
-        "enabled": false,
-        "connection": "<script>js code here...</script>"
-    },
-    "meta": {}
-}
 
+{
+  "id": 7,
+  "channel_id": 0,
+  "name": "Affiliate Conversion Tracking",
+  "enabled": false,
+  "connection": "<script>js code here...</script>"
+}
 ```
 
 <!--
@@ -743,8 +740,7 @@ title: Response
             "channel_id": 0,
             "name": "Facebook Pixel",
             "enabled": true,
-            "pixel_id": "FP-1234567890",
-            "is_oauth_connected": true
+            "pixel_id": "FP-1234567890"
         },
         {
             "id": 4,

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -17,7 +17,7 @@ You can get all web analytics, get a single web analytic, or update a single ana
 <!-- theme: info -->
 > #### Note
 > - You can obtain storefront channel IDs using the [Get all channels](/api-reference/store-management/channels/channels/listchannels) endpoint. 
-> - To get or update settings for specific storefronts, specify the `channel_id` in the query. If no channel ID is specified in the query, the request defaults to the global settings for a store, whose `channel_id` is 0. 
+> - To get or update settings for specific storefronts, specify the `channel_id` in the query. If you do not specify a channel ID in the query, the request defaults to the global settings for a store whose `channel_id` is 0. 
 > - If you query a storefront channel, the response returns global (not storefront) settings if the channel inherits global settings. The `channel_id` in the response will be that of the default global channel (`0`).   
 > - Web analytic ID 5 is no longer in use.
 

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -1,16 +1,8 @@
 # Data Solutions API
 
-The Web Analytics API lets you configure **storefront** channel settings for a store's prebuilt data analytic solutions.  
+The Web Analytics API lets you set **storefront** channel settings for a store's prebuilt data analytic solutions. A store has global settings for each web analytic, from which any storefront channel can inherit. You can override these global settings with storefront-specific settings. 
 
-Note that a store has global settings for data solutions, from which any storefront channel can inherit. A merchant can override these global settings with storefront-specific settings for their data solutions. This API configures settings for **storefront** channels at the store's global level (`channel_id` is `0`) and at the specific storefront channel level (by specifying a `channel_id` in the query). If no channel ID is specified in the query, the default channel is the global channel `0`.    
-
-<!-- theme: info -->
-> #### Note
-> You can obtain storefront channel IDs using the [Get all channels](/api-reference/store-management/channels/channels/listchannels) endpoint. 
-
-This article shows you how to manage web analytics using the Web Analytics API.
-
-You can get **all** web analytics, get a **single** web analytic, or **update** a single analytic. To get or update a **single** web analytic, the `id` of the web analytic must be specified in the path.
+You can get all web analytics, get a single web analytic, or update a single analytic. To get or update a single web analytic, the `id` of the web analytic must be specified in the path.
 
 | Web analytic | ID |
 | ------------- | -------- |
@@ -20,9 +12,16 @@ You can get **all** web analytics, get a **single** web analytic, or **update** 
 | Segment | 4 |
 | Site Verification Tags | 6 |
 | Affiliate Conversion Tracking | 7 |
-| Google Analytic 4 | 8 |
+| Google Analytics 4 | 8 |
 
-**Note**: Web analytic ID 5 is no longer in use.
+<!-- theme: info -->
+> #### Note
+> - You can obtain storefront channel IDs using the [Get all channels](/api-reference/store-management/channels/channels/listchannels) endpoint. 
+> - To get or update settings for specific storefronts, specify the `channel_id` in the query. If no channel ID is specified in the query, the request defaults to the global settings for a store, whose `channel_id` is 0. 
+> - Web analytic ID 5 is no longer in use.
+
+This article shows you how to manage web analytics using the Web Analytics API.
+
 
 ## Google Analytics
 

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -53,16 +53,16 @@ title: Response
 
 ```json title="Example response: Get the Google Analytic" lineNumbers
 {
-    "data": {
-        "id": 1,
-        "channel_id": 0,
-        "name": "Google Analytics",
-        "enabled": true,
-        "version": 1,
-        "data_tag_enabled": true,
-        "tracking_code": "GA-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 1,
+    "channel_id": 0,
+    "name": "Google Analytics",
+    "enabled": true,
+    "version": 1,
+    "data_tag_enabled": true,
+    "tracking_code": "GA-1234567890"
+  },
+  "meta": {}
 }
 ```
 
@@ -89,16 +89,16 @@ title: Response
 
 ```json title="Example response: Get the Google Analytic" lineNumbers
 {
-    "data": {
-        "id": 1,
-        "channel_id": 0,
-        "name": "Google Analytics",
-        "enabled": true,
-        "version": 2,
-        "data_tag_enabled": true,
-        "property_id": "GA-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 1,
+    "channel_id": 0,
+    "name": "Google Analytics",
+    "enabled": true,
+    "version": 2,
+    "data_tag_enabled": true,
+    "property_id": "GA-1234567890"
+  },
+  "meta": {}
 }
 ```
 
@@ -118,13 +118,13 @@ Content-Type: application/json
 Accept: application/json
 
 {
-    "id": 1,
-    "channel_id": 0,
-    "name": "Google Analytics",
-    "enabled": true,
-    "version": 2,
-    "data_tag_enabled": true,
-    "property_id": "GA-1234567890"
+  "id": 1,
+  "channel_id": 0,
+  "name": "Google Analytics",
+  "enabled": true,
+  "version": 2,
+  "data_tag_enabled": true,
+  "property_id": "GA-1234567890"
 }
 ```
 
@@ -135,16 +135,16 @@ title: Response
 
 ```json title="Example response: Update the Google Analytic" lineNumbers
 {
-    "data": {
-        "id": 1,
-        "channel_id": 0,
-        "name": "Google Analytics",
-        "enabled": true,
-        "version": 2,
-        "data_tag_enabled": true,
-        "property_id": "GA-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 1,
+    "channel_id": 0,
+    "name": "Google Analytics",
+    "enabled": true,
+    "version": 2,
+    "data_tag_enabled": true,
+    "property_id": "GA-1234567890"
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -176,14 +176,14 @@ title: Response
 
 ```json title="Example response: Get the Visual Website Optimizer Analytic" lineNumbers
 {
-    "data": {
-        "id": 2,
-        "channel_id": 0,
-        "name": "Visual Website Optimizer",
-        "enabled": false,
-        "vwo_smartcode": "VWO-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 2,
+    "channel_id": 0,
+    "name": "Visual Website Optimizer",
+    "enabled": false,
+    "vwo_smartcode": "VWO-1234567890"
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -202,11 +202,11 @@ Content-Type: application/json
 Accept: application/json
 
 {
-"id": 2,
-"channel_id": 0,
-"name": "Visual Website Optimizer",
-"enabled": false,
-"vwo_smartcode": "VWO-1234567890"
+  "id": 2,
+  "channel_id": 0,
+  "name": "Visual Website Optimizer",
+  "enabled": false,
+  "vwo_smartcode": "VWO-1234567890"
 }
 ```
 
@@ -217,14 +217,14 @@ title: Response
 
 ```json title="Example response: Update the Visual Website Optimizer Analytic" lineNumbers
 {
-    "data": {
-        "id": 2,
-        "channel_id": 0,
-        "name": "Visual Website Optimizer",
-        "enabled": false,
-        "vwo_smartcode": "VWO-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 2,
+    "channel_id": 0,
+    "name": "Visual Website Optimizer",
+    "enabled": false,
+    "vwo_smartcode": "VWO-1234567890"
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -255,14 +255,14 @@ title: Response
 
 ```json title="Example response: Get the Facebook Pixel Analytic" lineNumbers
 {
-    "data": {
-        "id": 3,
-        "channel_id": 0,
-        "name": "Facebook Pixel",
-        "enabled": true,
-        "pixel_id": "FP-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 3,
+    "channel_id": 0,
+    "name": "Facebook Pixel",
+    "enabled": true,
+    "pixel_id": "FP-1234567890"
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -296,14 +296,14 @@ title: Response
 
 ```json title="Example response: Update the Facebook Pixel Analytic" lineNumbers
 {
-    "data": {
-        "id": 3,
-        "channel_id": 0,
-        "name": "Facebook Pixel",
-        "enabled": true,
-        "pixel_id": "FP-1234567890"
-    },
-    "meta": {}
+  "data": {
+    "id": 3,
+    "channel_id": 0,
+    "name": "Facebook Pixel",
+    "enabled": true,
+    "pixel_id": "FP-1234567890"
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -335,15 +335,15 @@ title: Response
 
 ```json title="Example response: Get the Segment Analytic" lineNumbers
 {
-    "data": {
-        "id": 4,
-        "channel_id": 0,
-        "name": "Segment.com",
-        "enabled": false,
-        "api_key": "SEG-1234567890",
-        "data_tag_enabled": true
-    },
-    "meta": {}
+  "data": {
+    "id": 4,
+    "channel_id": 0,
+    "name": "Segment.com",
+    "enabled": false,
+    "api_key": "SEG-1234567890",
+    "data_tag_enabled": true
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -379,15 +379,15 @@ title: Response
 
 ```json title="Example response: Update the Segment Analytic" lineNumbers
 {
-    "data": {
-        "id": 4,
-        "channel_id": 0,
-        "name": "Segment.com",
-        "enabled": false,
-        "api_key": "SEG-1234567890",
-        "data_tag_enabled": true
-    },
-    "meta": {}
+  "data": {
+    "id": 4,
+    "channel_id": 0,
+    "name": "Segment.com",
+    "enabled": false,
+    "api_key": "SEG-1234567890",
+    "data_tag_enabled": true
+  },
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -419,14 +419,14 @@ title: Response
 
 ```json title="Example response: Get the Site Verification Tags Analytic" lineNumbers
 {
-    "data": {
-        "id": 6,
-        "channel_id": 0,
-        "name": "Site Verification Tags",
-        "enabled": false,
-        "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
-    },
-    "meta": {}
+  "data": {
+    "id": 6,
+    "channel_id": 0,
+    "name": "Site Verification Tags",
+    "enabled": false,
+    "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
+  },
+  "meta": {}
 }
 ```
 
@@ -462,14 +462,14 @@ title: Response
 
 ```json title="Example response: Update the Site Verification Tags Analytic" lineNumbers
 {
-    "data": {
-        "id": 6,
-        "channel_id": 0,
-        "name": "Site Verification Tags",
-        "enabled": false,
-        "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
-    },
-    "meta": {}
+  "data": {
+    "id": 6,
+    "channel_id": 0,
+    "name": "Site Verification Tags",
+    "enabled": false,
+    "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
+},
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->
@@ -501,14 +501,14 @@ title: Response
 
 ```json title="Example response: Get the Affiliate Conversion Tracking Analytic" lineNumbers
 {
-    "data": {
-        "id": 7,
-        "channel_id": 0,
-        "name": "Affiliate Conversion Tracking",
-        "enabled": false,
-        "connection": "<script>js code here...</script>"
-    },
-    "meta": {}
+  "data": {
+    "id": 7,
+    "channel_id": 0,
+    "name": "Affiliate Conversion Tracking",
+    "enabled": false,
+    "connection": "<script>js code here...</script>"
+  },
+  "meta": {}
 }
 ```
 
@@ -544,14 +544,14 @@ title: Response
 
 ```json title="Example response: Update the Affiliate Conversion Tracking Analytic" lineNumbers
 {
-    "data": {
-        "id": 7,
-        "channel_id": 0,
-        "name": "Affiliate Conversion Tracking",
-        "enabled": false,
-        "connection": "<script>js code here...</script>"
-    },
-    "meta": {}
+  "data": {
+    "id": 7,
+    "channel_id": 0,
+    "name": "Affiliate Conversion Tracking",
+    "enabled": false,
+    "connection": "<script>js code here...</script>"
+  },
+  "meta": {}
 }
 ```
 
@@ -583,12 +583,12 @@ title: Response
 ```json title="Example response: Get the Google Analytic 4 Analytic" lineNumbers
 {
   "data": {
-      "id": 8,
-      "channel_id": 0,
-      "name": "Google Analytics 4",
-      "enabled": false,
-      "measurement_id": "G-0123456789",
-      "data_tag_enabled": false
+    "id": 8,
+    "channel_id": 0,
+    "name": "Google Analytics 4",
+    "enabled": false,
+    "measurement_id": "G-0123456789",
+    "data_tag_enabled": false
   },
   "meta": {}
 }
@@ -627,15 +627,15 @@ title: Response
 
 ```json title="Example response: Update the Google Analytic 4 Analytic" lineNumbers
 {
-    "data": {
-        "id": 8,
-        "channel_id": 0,
-        "name": "Google Analytics 4",
-        "enabled": true,
-        "measurement_id": "G-9876543210",
-        "data_tag_enabled": true
-    },
-    "meta": {}
+  "data": {
+    "id": 8,
+    "channel_id": 0,
+    "name": "Google Analytics 4",
+    "enabled": true,
+    "measurement_id": "G-9876543210",
+    "data_tag_enabled": true
+  },
+  "meta": {}
 }
 ```
 
@@ -665,62 +665,62 @@ title: Response
 
 ```json title="Example response: Get all web analytics" lineNumbers
 {
-    "data": [
-        {
-            "id": 1,
-            "channel_id": 0,
-            "name": "Google Analytics",
-            "enabled": true,
-            "version": 2,
-            "data_tag_enabled": true,
-            "property_id": "GA-1234567890"
-        },
-        {
-            "id": 2,
-            "channel_id": 0,
-            "name": "Visual Website Optimizer",
-            "enabled": false,
-            "vwo_smartcode": "VWO-1234567890"
-        },
-        {
-            "id": 3,
-            "channel_id": 0,
-            "name": "Facebook Pixel",
-            "enabled": true,
-            "pixel_id": "FP-1234567890"
-        },
-        {
-            "id": 4,
-            "channel_id": 0,
-            "name": "Segment.com",
-            "enabled": false,
-            "api_key": "SEG-1234567890",
-            "data_tag_enabled": true
-        },
-        {
-            "id": 6,
-            "channel_id": 0,
-            "name": "Site Verification Tags",
-            "enabled": false,
-            "verification_tag": ""
-        },
-        {
-            "id": 7,
-            "channel_id": 0,
-            "name": "Affiliate Conversion Tracking",
-            "enabled": false,
-            "connection": "<script>js code here...</script>"
-        }
-        {
-            "id": 8,
-            "channel_id": 0,
-            "name": "Google Analytics 4",
-            "enabled": true,
-            "measurement_id": "G-9876543210",
-            "data_tag_enabled": true
-          }
-    ],
-    "meta": {}
+  "data": [
+    {
+      "id": 1,
+      "channel_id": 0,
+      "name": "Google Analytics",
+      "enabled": true,
+      "version": 2,
+      "data_tag_enabled": true,
+      "property_id": "GA-1234567890"
+    },
+    {
+      "id": 2,
+      "channel_id": 0,
+      "name": "Visual Website Optimizer",
+      "enabled": false,
+      "vwo_smartcode": "VWO-1234567890"
+    },
+    {
+      "id": 3,
+      "channel_id": 0,
+      "name": "Facebook Pixel",
+      "enabled": true,
+      "pixel_id": "FP-1234567890"
+    },
+    {
+      "id": 4,
+      "channel_id": 0,
+      "name": "Segment.com",
+      "enabled": false,
+      "api_key": "SEG-1234567890",
+      "data_tag_enabled": true
+    },
+    {
+      "id": 6,
+      "channel_id": 0,
+      "name": "Site Verification Tags",
+      "enabled": false,
+      "verification_tag": ""
+    },
+    {
+      "id": 7,
+      "channel_id": 0,
+      "name": "Affiliate Conversion Tracking",
+      "enabled": false,
+      "connection": "<script>js code here...</script>"
+    }
+    {
+      "id": 8,
+      "channel_id": 0,
+      "name": "Google Analytics 4",
+      "enabled": true,
+      "measurement_id": "G-9876543210",
+      "data_tag_enabled": true
+    }
+  ],
+  "meta": {}
 }
 ```
 <!-- type: tab-end -->

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -1,6 +1,6 @@
-# Data Solutions API
+# Web Analytics API
 
-The Web Analytics API lets you set **storefront** channel settings for a store's prebuilt data analytic solutions. A store has global settings for each web analytic, from which any storefront channel can inherit. You can override these global settings with storefront-specific settings. 
+The Web Analytics API lets you set **storefront** channel settings for a store's prebuilt data solutions. These settings help merchants connect and enable data solutions for a store. A store has global settings for each web analytic, from which any storefront channel can inherit. You can override these global settings with storefront-specific settings. 
 
 You can get all web analytics, get a single web analytic, or update a single analytic. To get or update a single web analytic, the `id` of the web analytic must be specified in the path.
 
@@ -18,20 +18,23 @@ You can get all web analytics, get a single web analytic, or update a single ana
 > #### Note
 > - You can obtain storefront channel IDs using the [Get all channels](/api-reference/store-management/channels/channels/listchannels) endpoint. 
 > - To get or update settings for specific storefronts, specify the `channel_id` in the query. If no channel ID is specified in the query, the request defaults to the global settings for a store, whose `channel_id` is 0. 
+> - If you query a storefront channel, the response returns global (not storefront) settings if the channel inherits global settings. The `channel_id` in the response will be that of the default global channel (`0`).   
 > - Web analytic ID 5 is no longer in use.
 
-This article shows you how to manage web analytics using the Web Analytics API.
+This article shows you how to manage web analytics using the Web Analytics API. For more, see the [Web Analytics API Reference](/...).
 
 
 ## Google Analytics
 
-The version corresponds with the "Connect with Field" that a merchant uses to connect to Google Analytics. This connection field affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic).
+A merchant can use a tracking code or property ID to connect Google Analytics to a store. This affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic).
 ![Version on Google Analytics](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Version%20for%20Google%20Analytics.png).
 
 
 ### Get the Google Analytic
 
-When a merchant uses a tracking code for the connection field, your response will have a version of `1` and the `tracking_code` field. If a merchant has not entered a tracking code, `tracking_code` will return as an empty string.
+To get a Google Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Google Analytics in the path.
+
+When a merchant uses a tracking code, your response will have a version of `1` and the `tracking_code` field. If a merchant has not entered a tracking code, `tracking_code` will return as an empty string.
 
 <!--
 type: tab
@@ -67,7 +70,7 @@ title: Response
 
 <!-- type: tab-end -->
 
-When a merchant uses property id for the connection field, your response will have a version of `2` and the `property_id` field. If a merchant has not entered a property ID, `property_id` will return as an empty string.
+When a merchant uses a property ID, your response will have a version of `2` and the `property_id` field. If a merchant has not entered a property ID, `property_id` will return as an empty string.
 
 <!--
 type: tab
@@ -104,6 +107,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Google Analytic
+
+To update a Google Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Google Analytics in the path.
 
 <!--
 type: tab
@@ -154,7 +159,7 @@ title: Response
 
 ### Get the Visual Website Optimizer Analytic
 
-If a merchant has not entered a VWO Smartcode, `vwo_smartcode` will return as an empty string.
+To get a Visual Website Optimizer Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Visual Website Optimizer in the path. If a merchant has not entered a VWO Smartcode, `vwo_smartcode` will return as an empty string.
 
 <!--
 type: tab
@@ -188,6 +193,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Visual Website Optimizer Analytic
+
+To update a Visual Website Optimizer Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Visual Website Optimizer in the path.
 
 <!--
 type: tab
@@ -234,7 +241,7 @@ title: Response
 
 ### Get the Facebook Pixel Analytic
 
-If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
+To get a Facebook Pixel Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Facebook Pixel in the path. If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
 
 <!--
 type: tab
@@ -267,6 +274,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Facebook Pixel Analytic
+
+To update a Facebook Pixel Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Facebook Pixel in the path. 
 
 <!--
 type: tab
@@ -313,7 +322,7 @@ title: Response
 
 ### Get the Segment Analytic
 
-If a merchant has not entered an API Key, `api_key` will return as an empty string.
+To get a Segment Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Segment in the path. If a merchant has not entered an API Key, `api_key` will return as an empty string.
 
 <!--
 type: tab
@@ -348,6 +357,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Segment Analytic
+
+To update a Segment Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Segment in the path.
 
 <!--
 type: tab
@@ -397,7 +408,7 @@ title: Response
 
 ### Get the Site Verification Tags Analytic
 
-If a merchant has not entered a verification tag, `verification_tag` will return as an empty string.
+To get a Site Verification Tags Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Site Verification Tags in the path. If a merchant has not entered a verification tag, `verification_tag` will return as an empty string.
 
 <!--
 type: tab
@@ -432,6 +443,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Site Verification Tags Analytic
+
+To update a Site Verification Tags Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Site Verification Tags in the path. 
 
 <!--
 type: tab
@@ -479,7 +492,7 @@ title: Response
 
 ### Get the Affiliate Conversion Tracking Analytic
 
-If a merchant has not entered an Affiliate Conversion Tracking Code, `connection` will return as an empty string.
+To get a Affiliate Conversion Tracking Analytic, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Affiliate Conversion Tracking in the path. If a merchant has not entered an Affiliate Conversion Tracking Code, `connection` will return as an empty string.
 
 <!--
 type: tab
@@ -514,6 +527,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Affiliate Conversion Tracking Analytic
+
+To update a Affiliate Conversion Tracking Analytic, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Affiliate Conversion Tracking in the path. 
 
 <!--
 type: tab
@@ -562,6 +577,8 @@ title: Response
 
 ### Get the Google Analytic 4 Analytic
 
+To get a Google Analytic 4, send a request to the [Get an analytic](/...) endpoint and specify the `id` of Google Analytic 4 in the path. If a merchant has not entered a measurement ID, `measurement_id` will return as an empty string.
+
 <!--
 type: tab
 title: Request
@@ -596,6 +613,8 @@ title: Response
 <!-- type: tab-end -->
 
 ### Update the Google Analytic 4 Analytic
+
+To update a Google Analytic 4, send a request to the [Update an analytic](/...) endpoint and specify the `id` of Google Analytic 4 in the path. 
 
 <!--
 type: tab
@@ -643,7 +662,7 @@ title: Response
 
 ## Get all web analytics
 
-All six web analytics will be returned. As shown, fields for codes (such as `verification_tag`) in which a merchant has not entered a value will return as an empty string.     
+To get all analytics, send a request to the [Get all analytics](/...) endpoint.
 
 <!--
 type: tab

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -1,0 +1,702 @@
+# Data Solutions API
+
+The Data Solutions V3 API lets you configure **storefront** channel settings for a store's prebuilt data analytic solutions.  
+
+Note that a store has global settings for data solutions, from which any storefront channel can inherit. A merchant can override these global settings with storefront-specific settings for their data solutions. This API configures settings for **storefront** channels at the store's global level (`channel_id` is `0`) and at the specific storefront channel level (by specifying a `channel_id` in the query). If no channel ID is specified in the query, the default channel is the global channel `0`.    
+
+<!-- theme: info -->
+> #### Note
+> You can obtain storefront channel IDs using the [Get all channels](/api-reference/store-management/channels/channels/listchannels) endpoint. 
+
+This article introduces how to configure web analytics using the Data Solutions V3 API. Because each web analytic requires different fields in the request and/or response, this article is divided by web analytics.
+
+You can get **all** web analytics, get a **single** web analytic, or **update** a single analytic. To get or update a **single** web analytic, the `id` of the web analytic must be specified in the path.
+
+| Web analytic | ID |
+| ------------- | -------- |
+| Google Analytics | 1 |
+| Visual Website Optimizer | 2 |
+| Facebook Pixel | 3 |
+| Segment | 4 |
+| Site Verification Tags | 6 |
+| Affiliate Conversion Tracking | 7 |
+
+**Note**: Web analytic ID 5 is no longer in use.
+
+## Google Analytics
+
+| Field | Type | Description |
+| ------------- | -------- |  -------- |
+| id | integer | ID of the web analytic. `1` for Google Analytics |
+| channel_id | integer | ID of the storefront channel. Default is `0`. |
+| name | string | Name of web analytic `Google Analytics` |
+| enabled | boolean | Indicates whether the merchant has [enabled Google Analytics](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
+| version | integer | Corresponds to connection field that merchant is using to connect to Google Analytics. Value is `1` when tracking code is used. Value is `2` when property id is used. |
+| data_tag_enabled | boolean | Indicates whether data tags are enabled by Google Analytics |
+| tracking_code | string | Tracking code merchant uses to connect Google Analytics to store. Only returned if the version is `1`. |
+| property_id | string | Property id merchant uses to connect Google Analytics to store. Only returned if the version is `2`.  |
+
+The version corresponds with the "Connect with Field" that a merchant uses to connect to Google Analytics. This connection field affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic).
+![Version on Google Analytics](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Version%20for%20Google%20Analytics.png).
+
+
+### Get the Google Analytic
+
+When a merchant uses a tracking code for the connection field, your response will have a version of `1` and the `tracking_code` field. If a merchant has not entered a tracking code, `tracking_code` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": {
+        "id": 1,
+        "channel_id": 0,
+        "name": "Google Analytics",
+        "enabled": true,
+        "version": 1,
+        "data_tag_enabled": true,
+        "tracking_code": "GA-1234567890"
+    },
+    "meta": {}
+}
+```
+
+<!-- type: tab-end -->
+
+When a merchant uses property id for the connection field, your response will have a version of `2` and the `property_id` field. If a merchant has not entered a property ID, `property_id` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": {
+        "id": 1,
+        "channel_id": 0,
+        "name": "Google Analytics",
+        "enabled": true,
+        "version": 2,
+        "data_tag_enabled": true,
+        "property_id": "GA-1234567890"
+    },
+    "meta": {}
+}
+```
+
+<!-- type: tab-end -->
+
+### Update the Google Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+    "id": 1,
+    "channel_id": 0,
+    "name": "Google Analytics",
+    "enabled": true,
+    "version": 2,
+    "data_tag_enabled": true,
+    "property_id": "GA-1234567890"
+}
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 1,
+        "channel_id": 0,
+        "name": "Google Analytics",
+        "enabled": true,
+        "version": 2,
+        "data_tag_enabled": true,
+        "property_id": "GA-1234567890"
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Visual Website Optimizer
+
+| Field | Type | Description |
+| ------------- | -------- |  -------- |
+| id | integer | ID of the web analytic. `2` for Visual Website Optimizer |
+| channel_id | integer | ID of the storefront channel. Default is `0`. |
+| name | string | Name of web analytic `Visual Website Optimizer` |
+| enabled | boolean | Indicates whether merchant has [enabled Visual Website Optimizer](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
+| vwo_smartcode | string | Visual Website Optimizer Smartcode used to connect store to Visual Website Optimizer analytic| 
+
+### Get the Visual Website Optimizer Analytic
+
+If a merchant has not entered a VWO Smartcode, `vwo_smartcode` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": {
+        "id": 2,
+        "channel_id": 0,
+        "name": "Visual Website Optimizer",
+        "enabled": false,
+        "vwo_smartcode": "VWO-1234567890"
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+### Update the Visual Website Optimizer Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+"id": 2,
+"channel_id": 0,
+"name": "Visual Website Optimizer",
+"enabled": false,
+"vwo_smartcode": "VWO-1234567890"
+}
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 2,
+        "channel_id": 0,
+        "name": "Visual Website Optimizer",
+        "enabled": false,
+        "vwo_smartcode": "VWO-1234567890"
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Facebook Pixel
+
+| Field | Type | Description |
+| ------------- | -------- |  -------- |
+| id | integer | ID of the web analytic. `1` for Facebook Pixel |
+| channel_id | integer | ID of the storefront channel. Default is `0`. |
+| name | string | Name of web analytic `Facebook Pixel` |
+| enabled | boolean | Indicates whether merchant has [enabled Facebook Pixel](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
+| pixel_id | string | Facebook Pixel ID used to connect store to Facebook Pixel |
+| is_oauth_connected | boolean | Indicates whether store has been granted OAuth token to connect to FB Pixel|
+
+### Get the Facebook Pixel Analytic
+
+If a merchant has not entered a Pixel ID, `pixel_id` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": {
+        "id": 3,
+        "channel_id": 0,
+        "name": "Facebook Pixel",
+        "enabled": true,
+        "pixel_id": "FP-1234567890",
+        "is_oauth_connected": true
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+### Update the Facebook Pixel Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "id": 3,
+  "channel_id": 0,
+  "name": "Facebook Pixel",
+  "enabled": true,
+  "pixel_id": "FP-1234567890",
+  "is_oauth_connected": true
+}
+
+```
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 3,
+        "channel_id": 0,
+        "name": "Facebook Pixel",
+        "enabled": true,
+        "pixel_id": "FP-1234567890",
+        "is_oauth_connected": true
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Segment
+
+| Field | Type | Description |
+| ------------- | -------- |  -------- |
+| id | integer | ID of the web analytic. `1` for Segment |
+| channel_id | integer | ID of the storefront channel. Default is `0`. |
+| name | string | Name of web analytic `Segment` |
+| enabled | boolean | Indicates whether merchant has [enabled Segment](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
+| api_key | string | Segment API key used to connect store to Segment |
+| data_tag_enabled | boolean | Indicates whether data tags are enabled by Segment Analytic |
+
+### Get the Segment Analytic
+
+If a merchant has not entered an API Key, `api_key` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": {
+        "id": 4,
+        "channel_id": 0,
+        "name": "Segment.com",
+        "enabled": false,
+        "api_key": "SEG-1234567890",
+        "data_tag_enabled": true
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+### Update the Segment Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "id": 4,
+  "channel_id": 0,
+  "name": "Segment.com",
+  "enabled": false,
+  "api_key": "SEG-1234567890",
+  "data_tag_enabled": true
+}
+
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 4,
+        "channel_id": 0,
+        "name": "Segment.com",
+        "enabled": false,
+        "api_key": "SEG-1234567890",
+        "data_tag_enabled": true
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Site Verification Tags
+
+| Field | Type | Description |
+| ------------- | -------- |  -------- |
+| id | integer | ID of the web analytic. `1` for Site Verification Tags |
+| channel_id | integer | ID of the storefront channel. Default is `0`. |
+| name | string | Name of web analytic `Site Verification Tags` |
+| enabled | boolean | Indicates whether merchant has [enabled Site Verification Tags](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
+| verification_tag | string | Site Verification Tag |
+
+### Get the Site Verification Tags Analytic
+
+If a merchant has not entered a verification tag, `verification_tag` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": {
+        "id": 6,
+        "channel_id": 0,
+        "name": "Site Verification Tags",
+        "enabled": false,
+        "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
+    },
+    "meta": {}
+}
+```
+
+<!-- type: tab-end -->
+
+### Update the Site Verification Tags Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "id": 6,
+  "channel_id": 0,
+  "name": "Site Verification Tags",
+  "enabled": false,
+  "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
+}
+
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 6,
+        "channel_id": 0,
+        "name": "Site Verification Tags",
+        "enabled": false,
+        "verification_tag": "<meta name=\"google-site-verification\" content=\"twLOPnFqwX5JK2-RksTZp_QEkfUPPgfGJ0_UHrEKLcY\" />"
+    },
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Affiliate Conversion Tracking
+
+| Field | Type | Description |
+| ------------- | -------- |  -------- |
+| id | integer | ID of the web analytic. `1` for Affiliate Conversion Tracking |
+| channel_id | integer | ID of the storefront channel. Default is `0`. |
+| name | string | Name of web analytic `Affiliate Conversion Tracking` |
+| enabled | boolean | Indicates whether merchant has [enabled Affiliate Conversion Tracking](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics) in their store |
+| connection | string | Affiliate Conversion Tracking Code |
+
+### Get the Affiliate Conversion Tracking Analytic
+
+If a merchant has not entered an Affiliate Conversion Tracking Code, `connection` will return as an empty string.
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+  "id": 7,
+  "channel_id": 0,
+  "name": "Affiliate Conversion Tracking",
+  "enabled": false,
+  "connection": "<script>js code here...</script>"
+}
+```
+
+<!-- type: tab-end -->
+
+### Update the Affiliate Conversion Tracking Analytic
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example PUT request with X-Auth-Token header" lineNumbers
+PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+    "data": {
+        "id": 7,
+        "channel_id": 0,
+        "name": "Affiliate Conversion Tracking",
+        "enabled": false,
+        "connection": "<script>js code here...</script>"
+    },
+    "meta": {}
+}
+
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example PUT response" lineNumbers
+{
+    "data": {
+        "id": 7,
+        "channel_id": 0,
+        "name": "Affiliate Conversion Tracking",
+        "enabled": false,
+        "connection": "<script>js code here...</script>"
+    },
+    "meta": {}
+}
+```
+
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Get all web analytics
+
+All six web analytics will be returned. As shown, fields for codes (such as `verification_tag`) in which a merchant has not entered a value will return as an empty string.     
+
+<!--
+type: tab
+title: Request
+-->
+
+```json title="Example GET request with X-Auth-Token header" lineNumbers
+GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+<!--
+type: tab
+title: Response
+-->
+
+```json title="Example GET response" lineNumbers
+{
+    "data": [
+        {
+            "id": 1,
+            "channel_id": 0,
+            "name": "Google Analytics",
+            "enabled": true,
+            "version": 2,
+            "data_tag_enabled": true,
+            "property_id": "GA-1234567890"
+        },
+        {
+            "id": 2,
+            "channel_id": 0,
+            "name": "Visual Website Optimizer",
+            "enabled": false,
+            "vwo_smartcode": "VWO-1234567890"
+        },
+        {
+            "id": 3,
+            "channel_id": 0,
+            "name": "Facebook Pixel",
+            "enabled": true,
+            "pixel_id": "FP-1234567890",
+            "is_oauth_connected": true
+        },
+        {
+            "id": 4,
+            "channel_id": 0,
+            "name": "Segment.com",
+            "enabled": false,
+            "api_key": "SEG-1234567890",
+            "data_tag_enabled": true
+        },
+        {
+            "id": 6,
+            "channel_id": 0,
+            "name": "Site Verification Tags",
+            "enabled": false,
+            "verification_tag": ""
+        },
+        {
+            "id": 7,
+            "channel_id": 0,
+            "name": "Affiliate Conversion Tracking",
+            "enabled": false,
+            "connection": "<script>js code here...</script>"
+        }
+    ],
+    "meta": {}
+}
+```
+<!-- type: tab-end -->
+
+&nbsp;
+
+## Resources
+- [Web Analytics Overview](https://support.bigcommerce.com/s/article/Data-Solutions?language=en_US#web-analytics)
+- [Google Analytics](https://support.bigcommerce.com/s/article/Setting-Up-Google-Analytics?language=en_US)
+- [Facebook Pixel](https://support.bigcommerce.com/s/article/Facebook-Pixel?language=en_US)
+- [Segment](https://support.bigcommerce.com/s/article/Setting-up-Segment-com?language=en_US)
+- [Affiliate Conversion Tracking](https://support.bigcommerce.com/s/article/Passing-Order-Data-to-Affiliate-Programs?language=en_US)
+
+

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -50,7 +50,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Google Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -62,7 +62,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Google Analytic" lineNumbers
 {
     "data": {
         "id": 1,
@@ -86,7 +86,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Google Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -98,7 +98,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Google Analytic" lineNumbers
 {
     "data": {
         "id": 1,
@@ -122,7 +122,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Google Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -144,7 +144,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Google Analytic" lineNumbers
 {
     "data": {
         "id": 1,
@@ -181,7 +181,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Visual Website Optimizer Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -193,7 +193,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Visual Website Optimizer Analytic" lineNumbers
 {
     "data": {
         "id": 2,
@@ -214,7 +214,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Visual Website Optimizer Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -234,7 +234,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Visual Website Optimizer Analytic" lineNumbers
 {
     "data": {
         "id": 2,
@@ -270,7 +270,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Facebook Pixel Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -281,7 +281,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Facebook Pixel Analytic" lineNumbers
 {
     "data": {
         "id": 3,
@@ -302,7 +302,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Facebook Pixel Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -322,7 +322,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Facebook Pixel Analytic" lineNumbers
 {
     "data": {
         "id": 3,
@@ -358,7 +358,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Segment Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -370,7 +370,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Segment Analytic" lineNumbers
 {
     "data": {
         "id": 4,
@@ -392,7 +392,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Segment Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -414,7 +414,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Segment Analytic" lineNumbers
 {
     "data": {
         "id": 4,
@@ -450,7 +450,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Site Verification Tags Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -462,7 +462,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Site Verification Tags Analytic" lineNumbers
 {
     "data": {
         "id": 6,
@@ -484,7 +484,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Site Verification Tags Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -505,7 +505,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Site Verification Tags Analytic" lineNumbers
 {
     "data": {
         "id": 6,
@@ -540,7 +540,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Affiliate Conversion Tracking Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -552,7 +552,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Affiliate Conversion Tracking Analytic" lineNumbers
 {
     "data": {
         "id": 7,
@@ -574,7 +574,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Affiliate Conversion Tracking Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -595,7 +595,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Affiliate Conversion Tracking Analytic" lineNumbers
 {
     "data": {
         "id": 7,
@@ -621,7 +621,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get the Google Analytic 4 Analytic" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -633,7 +633,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get the Google Analytic 4 Analytic" lineNumbers
 {
   "data": {
       "id": 8,
@@ -656,7 +656,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example PUT request with X-Auth-Token header" lineNumbers
+```http title="Example request: Update the Google Analytic 4 Analytic" lineNumbers
 PUT https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics/{id}
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -678,7 +678,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example PUT response" lineNumbers
+```json title="Example response: Update the Google Analytic 4 Analytic" lineNumbers
 {
     "data": {
         "id": 8,
@@ -704,7 +704,7 @@ type: tab
 title: Request
 -->
 
-```json title="Example GET request with X-Auth-Token header" lineNumbers
+```http title="Example request: Get all web analytics" lineNumbers
 GET https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/settings/data-solutions/web-analytics
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -716,7 +716,7 @@ type: tab
 title: Response
 -->
 
-```json title="Example GET response" lineNumbers
+```json title="Example response: Get all web analytics" lineNumbers
 {
     "data": [
         {

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -26,7 +26,7 @@ This article shows you how to manage web analytics using the Settings API. For m
 
 ## Google Analytics
 
-A merchant can use a tracking code or property ID to connect Google Analytics to a store. This affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic).
+A merchant can use a tracking code or property ID to connect Google Analytics to a store. This affects the fields that are requested and returned in [Get the Google Analytic](#get-the-google-analytic) and [Update the Google Analytic](#update-the-google-analytic) endpoints.
 ![Version on Google Analytics](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Version%20for%20Google%20Analytics.png).
 
 

--- a/docs/api-docs/analytics/web-analytics.md
+++ b/docs/api-docs/analytics/web-analytics.md
@@ -34,7 +34,7 @@ A merchant can use a tracking code or property ID to connect Google Analytics to
 
 To get a Google Analytic, send a request to the [Get a web analytic](/api-reference/store-management/settings/analytics/get-web-analytic) endpoint and specify the `id` of Google Analytics in the path.
 
-When a merchant uses a tracking code, your response will have a version of `1` and the `tracking_code` field. If a merchant has not entered a tracking code, `tracking_code` will return as an empty string.
+When a merchant uses a tracking code, your response will have a version of `1` in the `tracking_code` field. If a merchant has not entered a tracking code, `tracking_code` will return as an empty string.
 
 <!--
 type: tab

--- a/toc.json
+++ b/toc.json
@@ -934,6 +934,12 @@
           "title": "Big Open Data Layer (BODL)",
           "href": "/api-docs/partner/analytics-solutions/bodl",
           "uri": "docs/api-docs/analytics/bodl-overview.md"
+        },
+        {
+          "type": "item",
+          "title": "Data Solutions",
+          "href": "/api-docs/store-management/settings/data-solutions",
+          "uri": "docs/api-docs/analytics/web-analytics.md"
         }
       ]
     },


### PR DESCRIPTION
# [DEVDOCS-3855]

API Spec changes for rescoped Data Solutions

This PR is related to [PR 987](https://github.com/bigcommerce/api-specs/pull/987) (API Spec) and [PR 104](https://github.com/bigcommerce-labs/next-dev-center-prototype/pull/104) (redirects)

[DEVDOCS-3855]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ