### PR TITLE
DEVDOCS-4558: [value add] Handlebars reference, specify inclusivity of forloop end number

### DIFF
--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -879,7 +879,7 @@ Repeats block for a specified range from index `a` to index `b`. To protect agai
 #### Parameters
 
 - `a` {Number}: Starting number.
-- `b` {Number}: Ending number.
+- `b` {Number}: Ending number. (Inclusive)
 
 #### Example
 


### PR DESCRIPTION
Specify whether the for loop ending number is inclusive or exclusive.

I'm not partial on how it should be specified or where, it might work better in the description where it can be explained better. But, since both inclusive and exclusive forloops are common across languages, it should be specified in some way other than relying on the example.

# [DEVDOCS-]

## What changed?
* Specify whether the for loop ending number is inclusive or exclusive.

