### PR TITLE
DEVDOCS-4129: [remove] Old BODL overview

### DIFF
--- a/.stoplight.json
+++ b/.stoplight.json
@@ -23,7 +23,8 @@
     "docs/legacy/stencil-themes/installing-legacy-theme-modules.md",
     "docs/stencil-docs/configure-store-design-ui/defining-ui-options.md",
     "docs/stencil-docs/configure-store-design-ui/store-design-overview.md",
-    "docs/stencil-docs/javascript-and-event-hooks/dynamic-content-rendering.md"
+    "docs/stencil-docs/javascript-and-event-hooks/dynamic-content-rendering.md",
+    "docs/api-docs/analytics/bodl-overview.md"
   ],
   "formats": {
     "openapi": {

--- a/toc.json
+++ b/toc.json
@@ -937,18 +937,6 @@
     },
     {
       "type": "group",
-      "title": "Analytics Solutions",
-      "items": [
-        {
-          "type": "item",
-          "title": "Big Open Data Layer (BODL)",
-          "href": "/api-docs/partner/analytics-solutions/bodl",
-          "uri": "docs/api-docs/analytics/bodl-overview.md"
-        }
-      ]
-    },
-    {
-      "type": "group",
       "title": "POS Solutions",
       "items": [
         {


### PR DESCRIPTION
# [DEVDOCS-4129]

We're moving into closed beta for BODL on 10/17. BODL is very different now, so this old/outdated BODL doc should be taken down (to avoid confusion for merchants).

I didn't delete the file because it helps me with the new (in-progress) BODL doc. Simply removed the file from toc.json.

[DEVDOCS-4129]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ