### PR TITLE
DEVDOCS-4558: [update] Handlebars helpers, specify inclusivity of forloop end number

### DIFF
--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -34,7 +34,7 @@ The following table contains BigCommerce's open source [Handlebars helpers](http
 | [all](#all) | logic | Renders block if **all** params are true. |
 | [compare](#compare) | logic | Compares values with JavaScript operators, including `typeof`. |
 | [contains](#contains) | logic | Renders block if first param is in second param. |
-| [for](#for) | logic | Iterates for range `a` to `b`. |
+| [for](#for) | logic | Iterates for range `a` to `b`, inclusive of `b`. |
 | [if](#if) | logic | Renders block if statement is true. |
 | [or](#or) | logic | Renders block if one or more parameters evaluate to true. |
 | [unless](#unless) | logic | Renders block if a statement evaluates to false. |

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -879,7 +879,7 @@ Repeats block for a specified range from index `a` to index `b`. To protect agai
 #### Parameters
 
 - `a` {Number}: Starting number.
-- `b` {Number}: Ending number.
+- `b` {Number}: Ending number. (Inclusive)
 
 #### Example
 


### PR DESCRIPTION
Specify whether the for loop ending number is inclusive or exclusive.

# [DEVDOCS-4558]

## What changed?
* thing_that_changed

## Anything else?
Related PRs, salient notes, etc


[DEVDOCS-4558]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ