### PR TITLE
DEVDOCS-4543 Early Hints

### DIFF
--- a/docs/api-docs/cart-and-checkout/open-source-checkout.md
+++ b/docs/api-docs/cart-and-checkout/open-source-checkout.md
@@ -82,7 +82,7 @@ To install a custom checkout on a store, follow these steps:
   
   *It is important to include `<version>` number in the Script URL field. Because if you make changes to the same provided loader filename, you could serve a cached version to the user.
   
-  ![custom-checkout-01](https://raw.githubusercontent.com/bigcommerce/dev-docs/master/assets/images/custom-checkout-01.png "Custom Checkout")
+  ![custom-checkout-01](https://storage.googleapis.com/bigcommerce-production-dev-center/images/custom-checkout-01.png "Custom Checkout")
  
 4. Click the **Save** button at the bottom of the page.
 5. Navigate to your live storefront to view your new custom checkout.

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -266,7 +266,8 @@ Early Hints reduces page load time and perceived latency by allowing browsers to
   - Corresponds to the `rel` attribute in `<link>`.
   - Value can be any of `no`, `anonymous`, `use-credentials`.
   - Defaults to `no` when no value is provided.
-  - Optional.
+  - This parameter is optional.
+
   - For more information, see [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin) on MDN Web Docs.
 
 ##### Example

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -259,7 +259,8 @@ Early Hints reduces page load time and perceived latency by allowing browsers to
   - Corresponds to the `as` attribute in `<link>`.
   - Value can be any of `style`, `font`, `script`, `document`.
   - If an invalid value is provided, `as` won't be included.
-  - Optional.
+  - This parameter is optional.
+
   - For more information, see [as](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-as) on MDN Web Docs.
 - `cors` - {String}
   - Corresponds to the `rel` attribute in `<link>`.

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -272,12 +272,13 @@ Early Hints reduces page load time and perceived latency by allowing browsers to
 
 ##### Example
 
+The following script is an example of Early Hints usage in the Cornerstone theme:
+
 ```javascript
-<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' 
-resourceHint='preload'
-as='script'}}">
-</script>
+<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
 ```
+
+You can view other Cornerstone updates that use Early Hints in a commit to the Cornerstone repository modifying [templates/layout/base.html](https://github.com/bigcommerce/cornerstone/commit/f70fcd502343503969c2e475b777a85347137542#).
 
 ### {{moment}}
 

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -278,7 +278,7 @@ The following script is an example of Early Hints usage in the Cornerstone theme
 <script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
 ```
 
-You can view other Cornerstone updates that use Early Hints in a commit to the Cornerstone repository modifying [templates/layout/base.html](https://github.com/bigcommerce/cornerstone/commit/f70fcd502343503969c2e475b777a85347137542#).
+You can view more Early Hints usage in Cornerstone's `templates/layout/base.html` file by visiting the [Cornerstone Repository](https://github.com/bigcommerce/cornerstone/commit/f70fcd502343503969c2e475b777a85347137542#).
 
 ### {{moment}}
 

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -1,7 +1,5 @@
 # Handlebars Helpers Reference
 
-
-
 This article is a reference for [Stencil](/stencil-docs/getting-started/about-stencil) supported [Handlebars](https://handlebarsjs.com/) helpers. It includes [custom helpers](#custom-helpers) documentation and a list of whitelisted [standard helpers](#standard-helpers).
 
 ## Custom helpers
@@ -180,6 +178,7 @@ A URL transformer for content delivery networks.
 
 - `assetPath` {String}: Path to the file containing static assets.
 
+
 #### Example
 
 ```handlebars
@@ -246,6 +245,37 @@ As highlighted above, the helper is configured to rewrite *local* URLs to an `as
 - [See it in GitHub](https://github.com/bigcommerce/paper-handlebars/blob/master/helpers/cdn.js)
 - [See it in Cornerstone](https://github.com/bigcommerce/cornerstone/search?l=HTML&q=cdn)
 
+#### Early Hints and cdn
+
+Early Hints reduces page load time and perceived latency by allowing browsers to download critical assets earlier in the request lifecycle. For more information, see [Early Hints](#).
+
+##### Parameters
+
+- `resourceHint` - {String}
+  - Corresponds to the `rel` attribute in `<link>`.
+  - Value can be any of `preload`, `preconnect`, `prerender`, `dns-prefetch`.
+  - For more information, see [rel](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-rel) on MDN Web Docs.
+- `as` - {String}
+  - Corresponds to the `as` attribute in `<link>`.
+  - Value can be any of `style`, `font`, `script`, `document`.
+  - If an invalid value is provided, `as` won't be included.
+  - Optional.
+  - For more information, see [as](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-as) on MDN Web Docs.
+- `cors` - {String}
+  - Corresponds to the `rel` attribute in `<link>`.
+  - Value can be any of `no`, `anonymous`, `use-credentials`.
+  - Defaults to `no` when no value is provided.
+  - Optional.
+  - For more information, see [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin) on MDN Web Docs.
+
+##### Example
+
+```javascript
+<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' 
+resourceHint='preload'
+as='script'}}">
+</script>
+```
 
 ### {{moment}}
 

--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.md
@@ -34,7 +34,7 @@ The following table contains BigCommerce's open source [Handlebars helpers](http
 | [all](#all) | logic | Renders block if **all** params are true. |
 | [compare](#compare) | logic | Compares values with JavaScript operators, including `typeof`. |
 | [contains](#contains) | logic | Renders block if first param is in second param. |
-| [for](#for) | logic | Iterates for range `a` to `b`. |
+| [for](#for) | logic | Iterates for range `a` to `b`, inclusive of `b`. |
 | [if](#if) | logic | Renders block if statement is true. |
 | [or](#or) | logic | Renders block if one or more parameters evaluate to true. |
 | [unless](#unless) | logic | Renders block if a statement evaluates to false. |
@@ -879,7 +879,7 @@ Repeats block for a specified range from index `a` to index `b`. To protect agai
 #### Parameters
 
 - `a` {Number}: Starting number.
-- `b` {Number}: Ending number.
+- `b` {Number}: Ending number. (Inclusive)
 
 #### Example
 

--- a/docs/stencil-docs/storefront-customization/early-hints.md
+++ b/docs/stencil-docs/storefront-customization/early-hints.md
@@ -1,0 +1,75 @@
+---
+stoplight-id: agn3uhaasqd2r
+---
+
+# Early Hints
+
+Early Hints lets developers indicate which site assets are required for full page render. When a client makes a request to a site using Early Hints, the server responds with a `103 Early Hints` response containing important assets. The client begins to load these assets while the `200 OK` response is compiled and returned to the client, reducing page load time and perceived latency. 
+
+For more details on Early Hints, see [An HTTP Status Code for Indicating Hints](https://httpwg.org/specs/rfc8297.html#introduction). Because Stencil's implementation of Early Hints relies on usage of the Cloudflare CDN, also read 
+[Early Hints: How Cloudflare Can Improve Website Load Times by 30%](https://blog.cloudflare.com/early-hints/). 
+
+While many of Stencil's assets are optimized to use Early Hints automatically, some assets require theme updates. The following sections detail what assets are optimized automatically and which require theme updates. 
+
+## Automatic
+
+### Script Manager
+
+Developers don't need to make any theme updates to take advantage of Early Hints on Script Manager scripts. 
+
+#### Not using Cookie Consent
+
+If the store is not using the Cookie Consent feature, all scripts are marked for preloading. For more information, see [Using Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager). 
+
+#### Using Cooking Consent
+
+If a store is using the Cookie Consent feature, only scripts marked as `Essential` are marked for preloading. `Essential` scripts load on all pages for all shoppers.
+
+### Stylesheets & Fonts
+
+Assets loaded through the `{{stylesheet}}` or `{{getFontsCollection}}` handlebars helpers are marked for preloading. 
+
+- https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#stylesheet
+- https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#getfontscollection
+
+
+## Manual
+
+### Theme Scripts & other resources
+
+JavaScript files within themes, such as the main JavaScript bundle, are typically loaded using the `{{cdn}}` helper.
+
+In order to take advantage of early hints, theme developers need to mark the highest-priority resources within their theme for preloading by adding a new argument on the [`{{cdn}}` helper](https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#cdn).
+
+Here’s an example of the changes made to Cornerstone to get these improvements:
+
+<!-- https://github.com/bigcommerce/cornerstone/pull/2261/files -->
+
+```javascript title="before"
+<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js'}}"></script>
+```
+</br>
+
+```javascript title="after"
+<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
+```
+
+`resourceHint`
+<!-- https://github.com/bigcommerce/paper-handlebars/blob/061f730ef30b0e22103518625b658b95523a8be6/helpers/lib/resourceHints.js -->
+
+```
+ * @param {string} path - The uri to the resource.
+ * @param {string} rel - any of [preload, preconnect, prerender, dns-prefetch]
+ * @param {string} type? - (as attr in HTML link tag) any of [style, font, script,document] If an invalid value is provided, property won't be included
+ * @param {string} cors? - (crossorigin attr in HTML tag) any of [no, anonymous, use-credentials] defaults to no when no value is provided
+```
+
+`as`
+
+Theme developers should not simply mark every resource for preloading; the focus should be on resources which are critically important for painting the page and loading the above-the-fold content. Using the Cornerstone example, this was the main JavaScript bundle(s) necessary for the theme to function. For any resources which cannot be [deferred](https://web.dev/render-blocking-resources/) (which should always be the fist priority), they should be preloaded.
+
+## Moving to Cloudflare
+
+As of this writing, 80% of BigCommerce storefronts are behind Cloudflare. The remaining 20% need to move to Cloudflare to get the full benefit of this change, as Cloudflare is necessary to enable early hints. Without Cloudflare in the mix, there will only be a minor performance improvement.
+
+<!-- Merchants need to <> -->

--- a/docs/stencil-docs/storefront-customization/early-hints.md
+++ b/docs/stencil-docs/storefront-customization/early-hints.md
@@ -4,72 +4,67 @@ stoplight-id: agn3uhaasqd2r
 
 # Early Hints
 
-Early Hints reduces page load time and perceived latency by allowing browsers to download critical assets earlier in the request lifecycle. When a server uses Early Hints, the server indicates which site assets (such as CSS/JS files, images, fonts) a browser needs to fully render a page. When a client makes a request to a site, the server responds with a `103 Early Hints` response that contains the important assets. The client begins to load these assets while the server compiles and returns the `200 OK` response to the client. 
+Early Hints reduces page load time and perceived latency by allowing browsers to download critical assets earlier in the request lifecycle. When a server uses Early Hints, the server indicates which site assets (such as CSS files, JS scripts, and fonts) a browser needs to render a page fully. When a client requests a site, the server responds with a `103 Early Hints` response containing the essential assets. The client begins to load these assets while the server compiles and returns the `200 OK` response to the client. 
 
-For more details on Early Hints, see [An HTTP Status Code for Indicating Hints](https://httpwg.org/specs/rfc8297.html#introduction). Because Stencil's implementation of Early Hints relies on usage of the Cloudflare CDN, also read 
+For more details on Early Hints, see [An HTTP Status Code for Indicating Hints](https://httpwg.org/specs/rfc8297.html#introduction). Because Stencil's implementation of Early Hints relies on the usage of the Cloudflare CDN, also read 
 [Early Hints: How Cloudflare Can Improve Website Load Times by 30%](https://blog.cloudflare.com/early-hints/). 
 
 While many of Stencil's assets are automatically optimized to use Early Hints, some assets require theme updates. The following sections detail what assets are automatically optimized and which require theme updates. 
 
-## Automatic
+## Theme assets that are automatically optimized
 
-### Script Manager
+### Script Manager scripts
 
-Developers don't need to make any theme updates to take advantage of Early Hints on Script Manager scripts. 
+Developers don't need to make any theme updates to take advantage of Early Hints on Script Manager scripts that are required to render a page. 
 
-#### Not using Cookie Consent
+  If the store is not using the Cookie Consent feature, BigCommerce marks all scripts for preloading. 
 
-If the store is not using the Cookie Consent feature, all scripts are marked for preloading. For more information, see [Using Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager). 
+  If a store uses the Cookie Consent feature, BigCommerce only marks scripts marked as `Essential` for preloading. `Essential` scripts load on all pages for all shoppers.
 
-#### Using Cooking Consent
+<!-- For more information, see [Using Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager).  -->
 
-If a store is using the Cookie Consent feature, only scripts marked as `Essential` are marked for preloading. `Essential` scripts load on all pages for all shoppers.
+<!-- TODO: link to info on Cookie Consent feature -->
 
 ### Stylesheets & Fonts
 
-Assets loaded through the `{{stylesheet}}` or `{{getFontsCollection}}` handlebars helpers are marked for preloading. 
+Assets loaded through the `{{stylesheet}}` or `{{getFontsCollection}}` Handlebars helpers are automatically marked for preloading.
 
-- https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#stylesheet
-- https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#getfontscollection
+<!-- - https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#stylesheet
+- https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#getfontscollection -->
 
+## Theme assets that require manual updates
 
-## Manual
+### Theme scripts loaded using the cdn Handlebars helper
 
-Theme developers should not simply mark every resource for preloading; the focus should be on resources which are critically important for painting the page and loading the above-the-fold content. For example, the Cornerstone theme uses main JavaScript bundle(s) that are necessary for the theme to function. Resources that cannot be [deferred](https://web.dev/render-blocking-resources/) (which should always be the fist priority) should be preloaded.
+JavaScript files within themes, such as the primary JavaScript bundle, are typically loaded using the [`{{cdn}}` helper](https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#cdn).
 
-### Theme Scripts & other resources
-
-JavaScript files within themes, such as the main JavaScript bundle, are typically loaded using the `{{cdn}}` helper.
-
-In order to take advantage of early hints, theme developers need to mark the highest-priority resources within their theme for preloading by adding a new argument on the [`{{cdn}}` helper](https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#cdn).
-
-Here’s an example of the changes made to Cornerstone to get these improvements:
-
-<!-- https://github.com/bigcommerce/cornerstone/pull/2261/files -->
-
-```javascript title="before"
-<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js'}}"></script>
-```
-</br>
-
-```javascript title="after"
-<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
-```
+To take advantage of Early Hints, theme developers must mark the highest-priority resources within their theme for preloading by adding the following arguments to the `{{cdn}}` helper:
 
 `resourceHint`
 <!-- https://github.com/bigcommerce/paper-handlebars/blob/061f730ef30b0e22103518625b658b95523a8be6/helpers/lib/resourceHints.js -->
 
-```
- * @param {string} path - The uri to the resource.
- * @param {string} rel - any of [preload, preconnect, prerender, dns-prefetch]
- * @param {string} type? - (as attr in HTML link tag) any of [style, font, script,document] If an invalid value is provided, property won't be included
- * @param {string} cors? - (crossorigin attr in HTML tag) any of [no, anonymous, use-credentials] defaults to no when no value is provided
-```
+- `rel` - any of [preload, preconnect, prerender, dns-prefetch]
+
+`crossorigin`
+- `cors`? - (crossorigin attr in HTML tag) any of [no, anonymous, use-credentials]. Defaults to no when no value is provided.
 
 `as`
 
-## Moving to Cloudflare
+- `type`? - (as attr in HTML link tag) any of [style, font, script, document]. If an invalid value is provided, property won't be included.
 
-As of this writing, 80% of BigCommerce storefronts are behind Cloudflare. The remaining 20% need to move to Cloudflare to get the full benefit of this change, as Cloudflare is necessary to enable early hints. Without Cloudflare in the mix, there will only be a minor performance improvement.
+The following is an example of the changes made to Cornerstone to get these improvements:
 
-<!-- Merchants need to <> -->
+<!-- https://github.com/bigcommerce/cornerstone/pull/2261/files -->
+
+```javascript title="Before"
+<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js'}}"></script>
+```
+</br>
+
+```javascript title="After"
+<script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
+```
+
+#### Best practice
+
+Theme developers should only mark some resources for preloading; the focus should be on critical resources for painting the page and loading the above-the-fold content. For example, the Cornerstone theme uses the main JavaScript bundle(s) necessary for the theme to function. Resources that cannot be [deferred](https://web.dev/render-blocking-resources/) (which should always be the first priority) should be preloaded.

--- a/docs/stencil-docs/storefront-customization/early-hints.md
+++ b/docs/stencil-docs/storefront-customization/early-hints.md
@@ -17,20 +17,13 @@ While many of Stencil's assets are automatically optimized to use Early Hints, s
 
 Developers don't need to make any theme updates to take advantage of Early Hints on Script Manager scripts that are required to render a page. 
 
-  If the store is not using the Cookie Consent feature, BigCommerce marks all scripts for preloading. 
+If the store is not using the Cookie Consent feature, BigCommerce marks all scripts for preloading. 
 
-  If a store uses the Cookie Consent feature, BigCommerce only marks scripts marked as `Essential` for preloading. `Essential` scripts load on all pages for all shoppers.
-
-<!-- For more information, see [Using Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager).  -->
-
-<!-- TODO: link to info on Cookie Consent feature -->
+If a store uses the Cookie Consent feature, BigCommerce only marks scripts marked as `Essential` for preloading. `Essential` scripts load on all pages for all shoppers.
 
 ### Stylesheets & Fonts
 
 Assets loaded through the `{{stylesheet}}` or `{{getFontsCollection}}` Handlebars helpers are automatically marked for preloading.
-
-<!-- - https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#stylesheet
-- https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#getfontscollection -->
 
 ## Theme assets that require manual updates
 
@@ -38,21 +31,9 @@ Assets loaded through the `{{stylesheet}}` or `{{getFontsCollection}}` Handlebar
 
 JavaScript files within themes, such as the primary JavaScript bundle, are typically loaded using the [`{{cdn}}` helper](https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#cdn).
 
-To take advantage of Early Hints, theme developers must mark the highest-priority resources within their theme for preloading by adding the following arguments to the `{{cdn}}` helper:
+To take advantage of Early Hints, theme developers must mark the highest-priority resources within their theme for preloading by adding the `resourceHint`, `rel`, and `cors` arguments to the `{{cdn}}` helper. For detailed information, see {{cdn}} on the [Handlebars helpers reference](https://developer.bigcommerce.com/stencil-docs/ZG9jOjIyMDcxOA-handlebars-helpers-reference#cdn).
 
-`resourceHint` 
-<!-- https://github.com/bigcommerce/paper-handlebars/blob/061f730ef30b0e22103518625b658b95523a8be6/helpers/lib/resourceHints.js -->
-
-- `rel` - any of [preload, preconnect, prerender, dns-prefetch]
-
-`crossorigin`
-- `cors`? - (crossorigin attr in HTML tag) any of [no, anonymous, use-credentials]. Defaults to no when no value is provided.
-
-`as`
-
-- `type`? - (as attr in HTML link tag) any of [style, font, script, document]. If an invalid value is provided, property won't be included.
-
-The following is an example of the changes made to Cornerstone to get these improvements:
+The following is an example of using the Early Hints arguments on the `{{cdn}}` helper:
 
 <!-- https://github.com/bigcommerce/cornerstone/pull/2261/files -->
 
@@ -65,6 +46,6 @@ The following is an example of the changes made to Cornerstone to get these impr
 <script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
 ```
 
-#### Best practice
+#### How to choose which scripts to preload
 
-Theme developers should only mark some resources for preloading; the focus should be on critical resources for painting the page and loading the above-the-fold content. For example, the Cornerstone theme uses the main JavaScript bundle(s) necessary for the theme to function. Resources that cannot be [deferred](https://web.dev/render-blocking-resources/) (which should always be the first priority) should be preloaded.
+Developers should only mark a script for preloading if that script is responsible for painting the page and loading the above-the-fold content. Non-critical scripts should be [deferred](https://web.dev/render-blocking-resources/) instead of preloaded. 

--- a/docs/stencil-docs/storefront-customization/early-hints.md
+++ b/docs/stencil-docs/storefront-customization/early-hints.md
@@ -40,7 +40,7 @@ JavaScript files within themes, such as the primary JavaScript bundle, are typic
 
 To take advantage of Early Hints, theme developers must mark the highest-priority resources within their theme for preloading by adding the following arguments to the `{{cdn}}` helper:
 
-`resourceHint`
+`resourceHint` 
 <!-- https://github.com/bigcommerce/paper-handlebars/blob/061f730ef30b0e22103518625b658b95523a8be6/helpers/lib/resourceHints.js -->
 
 - `rel` - any of [preload, preconnect, prerender, dns-prefetch]

--- a/docs/stencil-docs/storefront-customization/early-hints.md
+++ b/docs/stencil-docs/storefront-customization/early-hints.md
@@ -6,7 +6,7 @@ stoplight-id: agn3uhaasqd2r
 
 Early Hints reduces page load time and perceived latency by allowing browsers to download critical assets earlier in the request lifecycle. When a server uses Early Hints, the server indicates which site assets (such as CSS files, JS scripts, and fonts) a browser needs to render a page fully. When a client requests a site, the server responds with a `103 Early Hints` response containing the essential assets. The client begins to load these assets while the server compiles and returns the `200 OK` response to the client. 
 
-For more details on Early Hints, see [An HTTP Status Code for Indicating Hints](https://httpwg.org/specs/rfc8297.html#introduction). Because Stencil's implementation of Early Hints relies on the usage of the Cloudflare CDN, also read 
+For more details on Early Hints, see [An HTTP Status Code for Indicating Hints](https://httpwg.org/specs/rfc8297.html#introduction). Because Stencil's implementation of Early Hints relies on using the Cloudflare CDN, also read 
 [Early Hints: How Cloudflare Can Improve Website Load Times by 30%](https://blog.cloudflare.com/early-hints/). 
 
 While many of Stencil's assets are automatically optimized to use Early Hints, some assets require theme updates. The following sections detail what assets are automatically optimized and which require theme updates. 


### PR DESCRIPTION
# [DEVDOCS-4543]

## What changed?
* add new page for Early Hints
* update {{cdn}} Handlebars helpers page with Early Hint info

[DEVDOCS-4543]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ