### PR TITLE
DEVDOCS-4560: [add] Shipping Provider, add form_fields to destination

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -238,7 +238,6 @@ Accept: application/json
       "state_iso2": "CA",
       "country_iso2": "US",
       "address_type": "commercial"
-      "form_fields": {}
     },
     "destination": {
       "street_1": "",

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -248,10 +248,7 @@ Accept: application/json
       "country_iso2": "US",
       "address_type": "residential",
       "form_fields": {
-        "1234": {
-          "id": "1234",
-          "value": "checkbox_selection_1"
-        }
+          "1234": "checkbox_selection_1"
       }
     },
     "items": [

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.md
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.md
@@ -238,6 +238,7 @@ Accept: application/json
       "state_iso2": "CA",
       "country_iso2": "US",
       "address_type": "commercial"
+      "form_fields": {}
     },
     "destination": {
       "street_1": "",
@@ -246,7 +247,13 @@ Accept: application/json
       "city": "",
       "state_iso2": "CA",
       "country_iso2": "US",
-      "address_type": "residential"
+      "address_type": "residential",
+      "form_fields": {
+        "1234": {
+          "id": "1234",
+          "value": "checkbox_selection_1"
+        }
+      }
     },
     "items": [
       {


### PR DESCRIPTION
# [DEVDOCS-4560]

Added custom form fields to Shipping Provider API

This PR is related to [PR 1038](https://github.com/bigcommerce/api-specs/pull/1038)

[DEVDOCS-4560]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ