### PR TITLE
DEVDOCS-4649: [update] Stencil CLI logging options

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -82,7 +82,7 @@ stencil start --open # opens live theme preview in default browser
 | `--variation NAME`           |`-v` | Set which theme variation to use while developing                                     |
 | `--test`                     |`-t` | Enable QA mode which will bundle all javascript for speed to test locally             |
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
-| `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes               |
+| `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)              |
 | `--verbose`                  |`-vb`| Enable verbose logging                                                                |
 | `--help`                     |`-h` | Output usage information                                                              |
 

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -67,7 +67,7 @@ stencil init [--url STORE_URL] [--token API_TOKEN]
 Starts the live theme preview using the theme files in the current directory.
 
 ```shell title="Usage: stencil start"
-stencil start [-V|--version] [-o|--open] [-v|--variation] [-t|--test] [-t|--tunnel] [-nov|--no-verbose] [-vb|--verbose]
+stencil start [-V|--version] [-o|--open] [-v|--variation] [-t|--test] [-t|--tunnel] [-vb|--verbose]
 stencil start [-h|--help]
 ```
 &nbsp;

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -82,9 +82,8 @@ stencil start --open # opens live theme preview in default browser
 | `--variation NAME`           |`-v` | Set which theme variation to use while developing                                     |
 | `--test`                     |`-t` | Enable QA mode which will bundle all javascript for speed to test locally             |
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
-| `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)              |
-| `--no-verbose`               | `-nov`| Disable verbose logging                                                             |
-| `--verbose`                  |`-vb` | Enable verbose logging                                                               |
+| `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes               |
+| `--verbose`                  |`-vb`| Enable verbose logging                                                                |
 | `--help`                     |`-h` | Output usage information                                                              |
 
 <!-- theme: info -->

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -67,7 +67,7 @@ stencil init [--url STORE_URL] [--token API_TOKEN]
 Starts the live theme preview using the theme files in the current directory.
 
 ```shell title="Usage: stencil start"
-stencil start [-V|--version] [-o|--open] [-v|--variation] [-t|--test] [-t|--tunnel]
+stencil start [-V|--version] [-o|--open] [-v|--variation] [-t|--test] [-t|--tunnel] [-nov|--no-verbose] [-vb|--verbose]
 stencil start [-h|--help]
 ```
 &nbsp;
@@ -77,12 +77,14 @@ stencil start --open # opens live theme preview in default browser
 
 | Option                       |Alias| Description                                                                           |
 |-|-|-|
-| `--version`                  |`-V` | Output the version number                                                            |
+| `--version`                  |`-V` | Output the version number                                                             |
 | `--open`                     |`-o` | Automatically open default browser                                                    |
-| `--variation NAME`       |`-v` | Set which theme variation to use while developing                                     |
+| `--variation NAME`           |`-v` | Set which theme variation to use while developing                                     |
 | `--test`                     |`-t` | Enable QA mode which will bundle all javascript for speed to test locally             |
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
-| `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)             |
+| `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)              |
+| `--no-verbose`               | `-nov`| Disable verbose logging                                                             |
+| `--verbose`                  |`-vb` | Enable verbose logging                                                               |
 | `--help`                     |`-h` | Output usage information                                                              |
 
 <!-- theme: info -->


### PR DESCRIPTION
# [DEVDOCS-4649]

## What changed?
added --no-verbose and --verbose to stencil start

## Anything else?
Related PRs, salient notes, etc


[DEVDOCS-4649]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ