### PR TITLE
#1691 Remove test flag on Stencil Start command && Add channelId and timeout flags

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.md
@@ -80,7 +80,8 @@ stencil start --open # opens live theme preview in default browser
 | `--version`                  |`-V` | Output the version number                                                            |
 | `--open`                     |`-o` | Automatically open default browser                                                    |
 | `--variation NAME`       |`-v` | Set which theme variation to use while developing                                     |
-| `--test`                     |`-t` | Enable QA mode which will bundle all javascript for speed to test locally             |
+| `--channelId CHANNELID`       |`-c` | Set the channel id for the storefront                                     |
+| `--timeout`                     |`-t` | Set a timeout for the bundle operation. Default is 20 secs                                     |
 | `--tunnel`                   |     | Create a tunnel URL which points to your local server which anyone can use            |
 | `--no-cache`                 |`-n` | Turn off caching for API resource data (cache refreshes every 5 minutes)             |
 | `--help`                     |`-h` | Output usage information                                                              |


### PR DESCRIPTION
# [DEVDOCS-4655]

## What changed?
* Remove test flag from stencil-cli-options-and-commands
* Add channelId flag to stencil-cli-options-and-commands
* Add timeout flag to stencil-cli-options-and-commands

## Anything else?
Relating to #1691 

[DEVDOCS-4655]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ