### PR TITLE
DEVDOCS-4388: [deprecate] Widgets, Get widgets by search

### DIFF
--- a/docs/api-docs/getting-started/deprecations-and-sunsets.md
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.md
@@ -17,7 +17,7 @@ The following APIs are deprecated. We discourage using these APIs, as BigCommerc
 |`/v2/option_sets`| [V3 Catalog Product Modifiers](/api-reference/store-management/catalog/product-modifiers/getmodifiers), [V3 Catalog Product Variant Options](/api-reference/store-management/catalog/product-variant-options/getoptions). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/legacy/v2-products/v2-v3). |
 |`/v2/products `| [V3 Catalog Products](/api-reference/store-management/catalog/products/getproducts) |
 |`/v2/redirects`| [V3 Redirects](/api-reference/store-management/redirects) |
-| `/v3/content/widgets/search` | [V3 Get All Widgets](/api-reference/store-management/widgets/widget/getwidgets) |
+|`/v3/content/widgets/search` | [V3 Get All Widgets](/api-reference/store-management/widgets/widget/getwidgets) |
 
 
 <!-- theme: info -->

--- a/docs/api-docs/getting-started/deprecations-and-sunsets.md
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.md
@@ -17,6 +17,7 @@ The following APIs are deprecated. We discourage using these APIs, as BigCommerc
 |`/v2/option_sets`| [V3 Catalog Product Modifiers](/api-reference/store-management/catalog/product-modifiers/getmodifiers), [V3 Catalog Product Variant Options](/api-reference/store-management/catalog/product-variant-options/getoptions). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/legacy/v2-products/v2-v3). |
 |`/v2/products `| [V3 Catalog Products](/api-reference/store-management/catalog/products/getproducts) |
 |`/v2/redirects`| [V3 Redirects](/api-reference/store-management/redirects) |
+| `/v3/content/widgets/search` | [V3 Get All Widgets](/api-reference/store-management/widgets/widget/getwidgets) |
 
 
 <!-- theme: info -->


### PR DESCRIPTION
# [DEVDOCS-4388]

## What changed?
* remove Get widgets by search

## Anything else?
* [api-specs 1097](https://github.com/bigcommerce/api-specs/pull/1097)
* [redirects 164](https://github.com/bigcommerce-labs/next-dev-center-prototype/pull/164)

[DEVDOCS-4388]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ