### PR TITLE
DEVDOCS-4668: [update] GraphQL overview, clarify intent of Revoke a token endpoint

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -133,7 +133,8 @@ Content-Type: application/json
 }
 ```
 
-Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Uncompromised short-lived tokens do not need to be revoked.  
+Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Uncompromised short-lived tokens do not need to be revoked and should be allowed to naturally expire.  
+
 
 ### Authenticating with an auto-generated Stencil token
 

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -133,7 +133,7 @@ Content-Type: application/json
 }
 ```
 
-Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Uncompromised short-lived tokens do not need to be revoked and should be allowed to naturally expire.  
+Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Allow uncompromised short-lived tokens to naturally expire, as these do not need to be revoked.
 
 
 ### Authenticating with an auto-generated Stencil token

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -133,7 +133,7 @@ Content-Type: application/json
 }
 ```
 
-Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Allow uncompromised short-lived tokens to naturally expire, as these do not need to be revoked.
+Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Allow uncompromised short-lived tokens to expire naturally, as these do not need to be revoked.
 
 
 ### Authenticating with an auto-generated Stencil token

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -133,6 +133,8 @@ Content-Type: application/json
 }
 ```
 
+Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Uncompromised short-lived tokens do not need to be revoked.  
+
 ### Authenticating with an auto-generated Stencil token
 
 Client code in BigCommerce Stencil themes can be passed a token at render time with the `{{settings.storefront_api.token}}` Handlebars object:

--- a/docs/api-docs/storefront/graphql/graphql-api-overview.md
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.md
@@ -133,7 +133,7 @@ Content-Type: application/json
 }
 ```
 
-Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Allow uncompromised short-lived tokens to expire naturally, as these do not need to be revoked.
+Only use the [Revoke a token](/api-reference/store-management/tokens/api-token/revoketoken) endpoint to revoke compromised tokens under emergency situations. Let uncompromised short-lived tokens expire naturally, as you do not need to revoke these.
 
 
 ### Authenticating with an auto-generated Stencil token


### PR DESCRIPTION
# [DEVDOCS-4668]

Added note about revoking only compromised tokens

This PR is related to [PR 1115](https://github.com/bigcommerce/api-specs/pull/1115) (api doc)

[DEVDOCS-4668]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ