### PR TITLE
DEVDOCS-4666: [update] Payments API, clarify no test payment gateway support

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.md
+++ b/docs/api-docs/payments/payments-api-overview.md
@@ -72,6 +72,11 @@ The following table lists the payment gateways that are compatible with our publ
 | Worldpay         |                             | &check; |
 | Worldpay Core    |                             | &check; |
 
+<!-- theme: warning -->
+> #### Test payment gateway
+> The Payments API does not support the [BigCommerce Test Payment Gateway](https://support.bigcommerce.com/s/article/Testing-Shipping-Tax-and-Payment-Settings?language=en_US#test-gateway).
+
+
 To learn more about the BigCommerce-compatible features of these gateways, see [All Available Payment Gateways](https://support.bigcommerce.com/s/article/Available-Payment-Gateways#all-available). 
 
 ## Stored cards and PayPal accounts


### PR DESCRIPTION
# [DEVDOCS-4666]

## What changed?
Added a sentence about the payments API not supporting the Test Payment Gateway

## Anything else?
Related PRs, salient notes, etc


[DEVDOCS-4666]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ