### PR TITLE
DEVDOCS-4770: [update] Webhooks, reverse SKU inventory method definitions

### DIFF
--- a/docs/api-docs/getting-started/webhooks/webhook-events.md
+++ b/docs/api-docs/getting-started/webhooks/webhook-events.md
@@ -425,8 +425,8 @@ Payload objects with the following scopes take the form that follows:
         "inventory": {
             "product_id": 167, // ID of the product
             "method": "absolute", // absolute or relative
-                // absolute -- inventory updated by an order
-		        // relative -- inventory updated using the API or the control panel
+                // absolute -- inventory updated using the API or the control panel
+		        // relative -- inventory updated by an order
             "value": 100000000 // the number of items that the inventory changed by
                 // value can be negative if the inventory is decreased (-3) or positive if an item is returned to the inventory from an order, (+2)
         }
@@ -562,8 +562,8 @@ Payload objects with the following scopes take the form that follows:
         "inventory": {
             "product_id": 206, // ID of the product
             "method": "absolute", // absolute or relative
-                // absolute -- inventory updated by an order
-		        // relative -- inventory updated using the API or the control panel
+                // absolute -- inventory updated using the API or the control panel
+		        // relative -- inventory updated by an order
             "value": 5, //  the number of items that the inventory changed by. 
                 // This can be negative if the inventory is decreased (-3), or positive if an item is returned to the inventory from an order (+2).
             "variant_id": 509 // ID of the variant


### PR DESCRIPTION
# [DEVDOCS-4770]

## What changed?
Reversed the definition of absolute and relative
This is an outstanding change from DEVDOCS-3453.

## Anything else?
Related PRs, salient notes, etc


[DEVDOCS-4770]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ