### PR TITLE
[hachachacha] Updated broken Figma and Youtube URLs

### DIFF
--- a/docs/api-docs/apps/guide/apps-01-introduction.mdx
+++ b/docs/api-docs/apps/guide/apps-01-introduction.mdx
@@ -85,7 +85,7 @@ Here's how to get started with BigCommerce development:
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-02-types.mdx
+++ b/docs/api-docs/apps/guide/apps-02-types.mdx
@@ -61,7 +61,7 @@ There are three visibility options for apps: **Draft**, **Unlisted**, and **Publ
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-03-developing.mdx
+++ b/docs/api-docs/apps/guide/apps-03-developing.mdx
@@ -88,7 +88,7 @@ Any store registered to the same email as your [Developer Portal](https://devtoo
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-05-oauth.mdx
+++ b/docs/api-docs/apps/guide/apps-05-oauth.mdx
@@ -196,7 +196,7 @@ The following BigCommerce API clients expose helper methods for BigCommerce's co
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https:https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-06-callbacks.mdx
+++ b/docs/api-docs/apps/guide/apps-06-callbacks.mdx
@@ -152,7 +152,7 @@ The following BigCommerce API clients expose helper methods for verifying the `s
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https:https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-07-users.mdx
+++ b/docs/api-docs/apps/guide/apps-07-users.mdx
@@ -55,7 +55,7 @@ For details about remove user and load requests, see [Single-click App Callbacks
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-08-events.mdx
+++ b/docs/api-docs/apps/guide/apps-08-events.mdx
@@ -71,7 +71,7 @@ Accept: application/json
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-09-ui.mdx
+++ b/docs/api-docs/apps/guide/apps-09-ui.mdx
@@ -50,7 +50,7 @@ We've built a channels app that serves as a reference implementation for BigDesi
 ### Design kits
 
 Do you design with Figma? If so, check out our design kit:
-* [BigDesign Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [BigDesign Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 
 
 ## Developing for the iFrame
@@ -90,7 +90,7 @@ To load inside the control panel iFrame, your app must do the following:
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-10-buttons.mdx
+++ b/docs/api-docs/apps/guide/apps-10-buttons.mdx
@@ -88,7 +88,7 @@ end
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-11-best-practices.mdx
+++ b/docs/api-docs/apps/guide/apps-11-best-practices.mdx
@@ -155,7 +155,7 @@ BigCommerce hosts [Google Cloud Platform](https://cloud.google.com/) in the [us-
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-12-requirements.mdx
+++ b/docs/api-docs/apps/guide/apps-12-requirements.mdx
@@ -77,7 +77,7 @@ For App Marketplace approval, you'll need to fill out all fields on your listing
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [BigDesign Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/apps/guide/apps-13-publishing.mdx
+++ b/docs/api-docs/apps/guide/apps-13-publishing.mdx
@@ -139,7 +139,7 @@ can take up to 24 hours to appear on the App Marketplace. Feel free to use this 
 * [Ruby API Client](https://github.com/bigcommerce/bigcommerce-api-ruby)
 * [Ruby OmniAuth Gem](https://github.com/bigcommerce/omniauth-bigcommerce)
 * [Big Design Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog posts

--- a/docs/api-docs/channels/channels-toolkit-reference.mdx
+++ b/docs/api-docs/channels/channels-toolkit-reference.mdx
@@ -54,7 +54,7 @@ To assist in the rapid development of apps that match the native UI and UX of th
 |[BigDesign Developer Playground](https://developer.bigcommerce.com/big-design)| BigDesign react component documentation and playground |
 |[CodeSandbox app](https://codesandbox.io/s/mkvv7)| CodeSandbox app showcasing BigDesign components|
 |[Big Design Repo](https://github.com/bigcommerce/big-design)|GitHub repository for BigDesign components|
-|[Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1)|Figma UI kit for BigDesign components|
+|[Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1)|Figma UI kit for BigDesign components|
 
 ### Required UI components
 

--- a/docs/api-docs/partner/dev-portal-overview.mdx
+++ b/docs/api-docs/partner/dev-portal-overview.mdx
@@ -22,7 +22,7 @@ For instructions on how to use the Developer Portal to create an app, see [Manag
 
 ### Tools
 * [BigDesign Developer Playground](https://developer.bigcommerce.com/big-design)
-* [Figma UI Kit](//figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
+* [Figma UI Kit](https://figma.com/file/jTVuUkiZ1j3rux8WHG4IKK/BigDesign-UI-Kit?node-id=0%3A1/duplicate)
 * [Adobe Illustrator UI Kit](https://design.bigcommerce.com/bigdesign-ui-kit)
 
 ### Blog Posts

--- a/docs/stencil-docs/configure-store-design-ui/defining-global-styles.mdx
+++ b/docs/stencil-docs/configure-store-design-ui/defining-global-styles.mdx
@@ -220,4 +220,4 @@ In `templates/components/common/footer.html`, add a reference to the new templat
 Refresh the page. The Categories list should reappear in the footer.
 ## Resources
 ### Additional resources
-- [Customizing a Theme Video](//youtube.com/watch?v=VZYZsDoEOpQ) (YouTube)
+- [Customizing a Theme Video](https://youtube.com/watch?v=VZYZsDoEOpQ) (YouTube)

--- a/docs/stencil-docs/getting-started/stencil-technology-stack.mdx
+++ b/docs/stencil-docs/getting-started/stencil-technology-stack.mdx
@@ -80,5 +80,5 @@ blog:
 
 ### Additional Resources
 
-* [Stencil Technology Stack Video](//youtube.com/watch/p5SR8N0SeCg) (YouTube)
+* [Stencil Technology Stack Video](https://youtube.com/watch/p5SR8N0SeCg) (YouTube)
 * [Cornerstone Components Subdirectory](https://github.com/bigcommerce/cornerstone) (BigCommerce GitHub)

--- a/docs/stencil-docs/getting-started/transitioning-to-stencil.mdx
+++ b/docs/stencil-docs/getting-started/transitioning-to-stencil.mdx
@@ -74,7 +74,7 @@ Unlike Blueprint, Stencil does not require that custom template file names start
 ### Resources
 
 For more information about switching to Stencil, see the following resources:
-- [Getting Started with the Stencil Framework - YouTube Playlist](//youtube.com/watch?v=s5_GjU51h-w&list=PLwTYtMwfzbe7EZiIWPAmPtuwRHkY7BG-0&index=1)
+- [Getting Started with the Stencil Framework - YouTube Playlist](https://youtube.com/watch?v=s5_GjU51h-w&list=PLwTYtMwfzbe7EZiIWPAmPtuwRHkY7BG-0&index=1)
 - [Stencil Theme Editor](https://support.bigcommerce.com/s/article/Stencil-Themes)
 - [Editing Stencil Theme Files](https://support.bigcommerce.com/s/article/Stencil-Themes#edit)
 - [Personalizing Your Stencil Theme](https://support.bigcommerce.com/articles/Learning/Personalizing-your-New-Theme)

--- a/docs/stencil-docs/localization/localization-tutorial.mdx
+++ b/docs/stencil-docs/localization/localization-tutorial.mdx
@@ -102,6 +102,6 @@ Other browsers may look and act differently. We suggest previewing your site to 
 
 ## Related resources
 * [Using Translation Keys](/stencil-docs/localization/translation-keys)
-* [Customizing a Theme - lang directory Video Demo (YouTube)](//youtube.com/watch?v=ygiRGfSrmnA)
+* [Customizing a Theme - lang directory Video Demo (YouTube)](https://youtube.com/watch?v=ygiRGfSrmnA)
 * [JSON translation files (BigCommerce GitHub)](https://github.com/bigcommerce/cornerstone/tree/master/lang)
 * [Handlebars helpers reference](/stencil-docs/reference-docs/handlebars-helpers-reference#string-helpers)

--- a/docs/stencil-docs/localization/translation-keys.mdx
+++ b/docs/stencil-docs/localization/translation-keys.mdx
@@ -196,6 +196,6 @@ Translation files for other languages would use a similar format to define key-v
 
 ### Additional resources
 
-* [Customizing a Theme - lang directory Video Demo](//youtube.com/embed/ygiRGfSrmnA) (YouTube)
+* [Customizing a Theme - lang directory Video Demo](https://youtube.com/embed/ygiRGfSrmnA) (YouTube)
 * [Handlebars String Helpers](/stencil-docs/reference-docs/handlebars-helpers-reference#string-helpers)
 * [JSON translation file](https://github.com/bigcommerce/cornerstone/tree/master/lang) (BigCommerce GitHub)

--- a/docs/stencil-docs/storefront-customization/custom-templates.mdx
+++ b/docs/stencil-docs/storefront-customization/custom-templates.mdx
@@ -190,4 +190,4 @@ If you have an old version of Stencil CLI installed, custom templates may not be
 
 ### Additional Resources
 
-* [Custom Templates Video Demo](//youtube.com/watch?v=qgaDX7bhmd8) (YouTube)
+* [Custom Templates Video Demo](https://youtube.com/watch?v=qgaDX7bhmd8) (YouTube)

--- a/docs/stencil-docs/storefront-customization/theme-accessibility.mdx
+++ b/docs/stencil-docs/storefront-customization/theme-accessibility.mdx
@@ -100,7 +100,7 @@ Your main heading should be H1 and indicate the main content. The incorrect exam
 
 The correct structure displayed above on the right shows heading levels from largest to smallest communicating more specific information about the previous section.
 
-For an example video on how to create text headings, see [How Headings Help Screen Reader Users](//youtube.com/watch?v=zRTqCGJ_HwQ).
+For an example video on how to create text headings, see [How Headings Help Screen Reader Users](https://youtube.com/watch?v=zRTqCGJ_HwQ).
 
 ### Font size and text alignment
 The use of white space around blocks of text makes it easier to read. We recommend the following text formatting:
@@ -159,7 +159,7 @@ To see `tabindex` in action, open the following example in a new tab: [native-ke
 
 Press the `Tab` key and navigate from the top of the page to the bottom, highlighting active elements. You can also use the arrow keys to scroll through the drop-down menu.
 
-For an example video on keyboard accessibility, see [Accessible Components: Keyboard access -- Polycasts#49](//youtube.com/watch?v=REVxMvdBYMw).
+For an example video on keyboard accessibility, see [Accessible Components: Keyboard access -- Polycasts#49](https://youtube.com/watch?v=REVxMvdBYMw).
 
 ## Customization
 You can add scripts or code to improve the accessibility of your theme. As stated above, you can use the `tabindex` global attribute to add an element for keyboard navigation. Also, we suggest doing the following:
@@ -191,6 +191,6 @@ For apps that can check and improve your site's accessibility, see our Site Tool
 - [AccessiBe](https://accessibe.com/)
 
 ### Videos
-- [How Headings Help Screen Reader Users](//youtube.com/watch?v=zRTqCGJ_HwQ)
+- [How Headings Help Screen Reader Users](https://youtube.com/watch?v=zRTqCGJ_HwQ)
 - [WebAIM article on Typefaces and Fonts](https://webaim.org/techniques/textlayout/)
-- [Accessible Components: Keyboard access -- Polycasts#49](//youtube.com/watch?v=REVxMvdBYMwaccessioa)
+- [Accessible Components: Keyboard access -- Polycasts#49](https://youtube.com/watch?v=REVxMvdBYMwaccessioa)

--- a/docs/stencil-docs/storefront-customization/theme-assets.mdx
+++ b/docs/stencil-docs/storefront-customization/theme-assets.mdx
@@ -120,5 +120,5 @@ This subdirectory’s children contain CSS for the following page elements.
 * [Getting Started With Foundation 5](https://get.foundation/sites/docs-v5/) (Zurb)
 * [BEM](http://getbem.com/) (Get BEM)
 * [SUIT CSS](https://suitcss.github.io/) (GitHub)
-* [Customizing a Theme (Assets Directory)](//youtube.com/embed/zUDNgprOEts) (YouTube)
+* [Customizing a Theme (Assets Directory)](https://youtube.com/embed/zUDNgprOEts) (YouTube)
 * [BigCommerce Sass Styling Guide](https://github.com/bigcommerce/sass-style-guide) (BigCommerce GitHub)

--- a/docs/stencil-docs/storefront-customization/using-custom-fonts-and-icons.mdx
+++ b/docs/stencil-docs/storefront-customization/using-custom-fonts-and-icons.mdx
@@ -176,6 +176,6 @@ Simply add your new icon SVG file to the `assets/icons/ `folder. Then, from your
 
 ### Additional resources
 * [Stencil Custom Sass Functions](/stencil-docs/storefront-customization/custom-sass-functions)
-* [Custom Icons Video Tutorial (BigCommerce YouTube)](//youtube.com/watch?v=ZwrVN5QrEZY)  
-* [Custom Fonts Video Tutorial (BigCommerce YouTube)](//youtube.com/watch/-w7Hbn_p_pw) 
+* [Custom Icons Video Tutorial (BigCommerce YouTube)](https://youtube.com/watch?v=ZwrVN5QrEZY)  
+* [Custom Fonts Video Tutorial (BigCommerce YouTube)](https://youtube.com/watch/-w7Hbn_p_pw) 
 * [Google Fonts (Google)](https://fonts.google.com/)


### PR DESCRIPTION
# [DEVDOCS-QIKFIX]

## What changed?
* The GitHub action has given notices about URLs starting with `//` not working. I recall this was a workaround to prevent embedded links in Stoplight, but they don't currently work.

