### PR TITLE
DEVDOCS-4761: Stencil CLI 7x release with node 18 support

### DIFF
--- a/docs/api-docs/apps/apps-quick-start.mdx
+++ b/docs/api-docs/apps/apps-quick-start.mdx
@@ -9,7 +9,7 @@ To successfully complete this tutorial, you will need the following:
 * [BigCommerce sandbox store](/api-docs/partner/getting-started/create-a-sandbox-store) (required to develop and test apps)
 * [Developer Portal Account](https://devtools.bigcommerce.com/) (required to register apps)
 * Experience using [npm](https://www.npmjs.com/)
-* Node.js 14.x
+* Node.js 18.x
 
 ## Get started
 

--- a/docs/api-docs/partner/pos/foundation-guide.mdx
+++ b/docs/api-docs/partner/pos/foundation-guide.mdx
@@ -6,7 +6,7 @@ POS Foundation scaffolds manual connector apps that use [store API accounts](/ap
 
 
 ## Software requirements
-* [Node.js](https://nodejs.org/en/) 14.0.0+
+* [Node.js](https://nodejs.org/en/) 18.0.0+
 * The [npm](https://www.npmjs.com/) package manager
 * A MongoDB database instance; this guide uses [MongoDB Cloud](https://www.mongodb.com/cloud)
 

--- a/docs/api-docs/partner/subscriptions/foundation-guide.mdx
+++ b/docs/api-docs/partner/subscriptions/foundation-guide.mdx
@@ -5,7 +5,7 @@ Subscription Foundation delivers an [open source framework](https://github.com/b
 Subscription Foundation uses the [Channels toolkit](/api-docs/channels/guide/overview#channels-toolkit) to display the custom subscription channel in the **Channel Manager** of a store's control panel alongside other sales channels. 
 
 ## Software requirements 
-* [Node.js](https://nodejs.org/en/) 14.17.0
+* [Node.js](https://nodejs.org/en/) 18.15.0
 * The [npm](https://www.npmjs.com/) package manager
 * A [supported SQL database engine](https://www.prisma.io/docs/concepts/components/prisma-schema/data-sources), either Postgres or another database server of your choice
 

--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.mdx
@@ -1,10 +1,15 @@
 # Installing Stencil CLI
 
+<Callout type="warning">
+BigCommerce is currently targeting 11/1/2023 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/stencil-docs/installing-stencil-cli/troubleshooting-your-setup#incompatible-scss-directives), which can cause issues with the styling of your storefront.
+
+</Callout>
 
 
 Stencil CLI gives developers the power to locally edit and preview themes with no impact to a merchant’s live storefront, and it's built-in [Browsersync](https://github.com/bigcommerce/browser-sync) capabilities make simultaneous testing across desktop, mobile, and tablet devices a breeze. Once work is complete, developers can push themes to BigCommerce storefronts (and set them live) using Stencil CLI's simple, yet powerful commands.
 
 This article contains the detailed instructions needed to install and configure Stencil CLI -- the first step to developing themes on the BigCommerce platform.
+
 
 ## Installing on Mac
 
@@ -23,10 +28,10 @@ arch -x86_64 /bin/zsh
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
 
 # Install Stencil CLI supported version of Node.js
-nvm install 14.20.0
+nvm install 18.15.0
 
 # Switch to Stencil CLI supported version of Node.js:
-nvm use 14.20.0
+nvm use 18.15.0
 
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli
@@ -54,10 +59,10 @@ Run the following commands:
 
 ```shell showLineNumbers copy
 # Install Stencil CLI supported version of Node.js
-nvm install 14.20.0
+nvm install 18.15.0
 
 # Switch to Stencil CLI supported version of Node.js
-nvm use 14.20.0
+nvm use 18.15.0
 
 # Install Stencil CLI
 npm install -g @bigcommerce/stencil-cli
@@ -82,7 +87,7 @@ choco install git
 #####################################################################################
 
 # Install nvm-windows and stencil compatible node.js
-choco install nvm; nvm install 14.20.0; nvm use 14.20.0
+choco install nvm; nvm install 18.15.0; nvm use 18.15.0
 
 # Install Windows C++ Build Tools (also installs python2)
 npm install -g windows-build-tools --vs2015
@@ -111,7 +116,7 @@ If you're a pro at installing and configuring Python and Node.js environments on
 **Required Dependencies:**
 * [Git](https://git-scm.com/downloads) - required to run npm install
 * [Python 2.7.x](https://www.python.org/downloads/) - required to build some dependencies
-* [Node.js 14 and npm](https://nodejs.org/en/download/releases/) - later versions not currently supported on Windows
+* [Node.js 18.15.0 and npm](https://nodejs.org/en/download/releases/)
 * [Visual C++ Build Tools 2015](https://www.npmjs.com/package/windows-build-tools) - required to compile some dependencies
 
 Once they're installed and configured, use `npm` to install Stencil CLI:
@@ -137,9 +142,9 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash
 source ~/.bashrc
 
 # Explicitly install and use supported node version
-nvm install 14.20.0
+nvm install 18.15.0
 
-nvm use 14.20.0
+nvm use 18.15.0
 
 # Install stencil
 npm install -g @bigcommerce/stencil-cli

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.mdx
@@ -4,6 +4,10 @@
 
 This article is a comprehensive command reference for Stencil CLI, BigCommerce's powerful theme development and deployment tool. For installation instructions for your OS, see [Installing Stencil CLI](/stencil-docs/installing-stencil-cli/installing-stencil). For more information on BigCommerce's Stencil Theme Engine, see [About Stencil](/stencil-docs/getting-started/about-stencil). Continue reading below for detailed information on each Stencil CLI command and option.
 
+<Callout type="warning">
+BigCommerce is currently targeting 11/1/2023 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/stencil-docs/installing-stencil-cli/troubleshooting-your-setup#incompatible-scss-directives), which can cause issues with the styling of your storefront.
+</Callout>
+
 ## Commands overview
 
 The syntax to run a Stencil CLI command is as follows:

--- a/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.mdx
@@ -6,6 +6,36 @@ For any unexpected behavior you encounter while developing your Stencil theme, w
 
 In some cases, the terminal will provide a verbose error message specifying where to look for problems. It has the potential to provide further insight on the issue. Diagnostic suggestions are listed on this page for error messages that may not be helpful in revealing the issue you're experiencing.
 
+<Callout type="warning">
+BigCommerce is currently targeting 11/1/2023 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/stencil-docs/installing-stencil-cli/troubleshooting-your-setup#incompatible-scss-directives), which can cause issues with the styling of your storefront.
+</Callout>
+
+## Incompatible SCSS directives
+
+To ensure that your storefront is up to date, perform the following steps:
+
+1. Using the latest version of Stencil CLI, run the stencil bundle command to validate your theme's code. Note any errors in the console output.
+```shell copy
+stencil bundle
+```
+2. Update your files to ensure the correct formatting by running the following script. This step allows you to see changes before merging.
+```shell copy
+stencil scss-autofix --dry
+```
+3. To commit the changes and revalidate, run the following commands:
+```shell showLineNumbers copy
+stencil scss-autofix 
+stencil bundle
+```
+4. After making changes, you can test your site by running the following command:
+```shell copy
+stencil start
+```
+5. If everything looks good, push your changes live to your storefront with the following command.
+```shell copy
+stencil push
+```
+
 ## Unsupported Node version
 
 If you receive the following error message, please reinstall Node.js to a supported "LTS" ("Long-Term Support") version:


### PR DESCRIPTION
Changed node version to 18.15.0
Added warning about the deprecation of node-sass

Here is a summary of my changes.
1. Updated node version from 14.20.0 to 18.15.0 in the following files:

- apps-quick-start.mdx
- /pos/foundation-guide.mdx
- /subscriptions/foundation-guide.mdx
-  installing-stencil.mdx

2. Added a warning message to the following files:

-  installing-stencil.mdx
-  stencil-cli-options-and-commands.mdx
-  troubleshooting-your-setup.mdx

3. Added instructions on how to update your system in the following file:

-  troubleshooting-your-setup.mdx