### PR TITLE
DEVDOCS-3395: [deprecate] Deprecations + Sunsets, add Pages V2

### DIFF
--- a/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
@@ -10,14 +10,15 @@ The following APIs and tools are deprecated. We discourage using these listed it
 
 | Deprecated API | Replacement |
 |:---------------|:------------|
-| `/v2/brands` | [V3 Catalog Brands](/docs/rest-management/catalog/brands#get-all-brands) |
-| `/v2/categories` | [V3 Catalog Categories](/docs/rest-management/catalog/category#get-all-categories) |
-| `/v2/customers` | [V3 Customers](/docs/rest-management/customers) |
-|`/v2/options`| [V3 Catalog Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [V3 Catalog Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). See the [Accessing product options](#accessing-product-options-with-V3) callout.  |
-|`/v2/option_sets`| [V3 Catalog Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [V3 Catalog Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/legacy/v2-products/v2-v3). |
-|`/v2/products `| [V3 Catalog Products](/docs/rest-management/catalog/products#get-all-products) |
-|`/v2/redirects`| [V3 Redirects](/docs/rest-management/redirects) |
-|`/v3/content/widgets/search` | [V3 Get All Widgets](/docs/rest-content/widgets/widget#get-all-widgets) |
+| `/v2/brands` | [Catalog V3 Brands](/docs/rest-management/catalog/brands#get-all-brands) |
+| `/v2/categories` | [Catalog V3 Categories](/docs/rest-management/catalog/category#get-all-categories) |
+| `/v2/customers` | [Customers V3](/docs/rest-management/customers) |
+|`/v2/options`| [Catalog V3 Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). See the [Accessing product options](#accessing-product-options-with-V3) callout.  |
+|`/v2/option_sets`| [Catalog V3 Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/legacy/v2-products/v2-v3). |
+|`/v2/pages`| [Pages V3](/docs/rest-content/pages) |
+|`/v2/products `| [Catalog V3 Products](/docs/rest-management/catalog/products#get-all-products) |
+|`/v2/redirects`| [Redirects V3](/docs/rest-management/redirects) |
+|`/v3/content/widgets/search` | [Widgets V3, Get all widgets](/docs/rest-content/widgets/widget#get-all-widgets) |
 
 
 <Callout type="info">
@@ -39,15 +40,15 @@ We have removed the following endpoints.
 
 | Sunset endpoint / API | Replacement endpoint / API |
 |:----------------------|:---------------------------|
-| `DELETE Collection` [V2 Customers](/docs/rest-management/customers-v2)  | `DELETE Customers` [V3 Customers](/docs/rest-management/customers-v2#delete-customers) |
-| `DELETE Collection` [V2 Option Sets](/legacy/v2-catalog-products/v2-option-sets) | None; can still be deleted individually by ID. |
-| `DELETE Collection` [V2 Products](/legacy/v2-catalog-products/v2-products) | `DELETE Products` [V3 Products](/docs/rest-management/catalog/products#delete-products) or individually `DELETE Product` [V2 Products](/legacy/v2-catalog-products/v2-products#delete-a-product) |
+| `DELETE Collection` [Customers V2](/docs/rest-management/customers-v2) | [Customers V3, Delete customers](/docs/rest-management/customers-v2#delete-customers) |
+| `DELETE Collection` [Option Sets V2](/legacy/v2-catalog-products/v2-option-sets) | None; can still be deleted individually by ID. |
+| `DELETE Collection` [Products V2](/legacy/v2-catalog-products/v2-products) | [Products V3, Delete products](/docs/rest-management/catalog/products#delete-products) or individually, [Products V2, Delete a product](/legacy/v2-catalog-products/v2-products#delete-a-product) |
 
 We have removed the following properties.
 
 | API | Sunset property | Replacement property |
 |:----|:----------------|:---------------------|
-[V3 Channels](/docs/rest-management/channels#get-all-channels) |`is_enabled` | `status` |
+[Channels V3](/docs/rest-management/channels#get-all-channels) |`is_enabled` | `status` |
 
 ## Related resources 
 


### PR DESCRIPTION
# [DEVDOCS-3395]

## What changed?
* Add pages v2 to the list of deprecated APIs and endpoints
* Move the version number after the name of the API to match the newer references elsewhere

## Anything else?
Related PRs, salient notes, etc.


[DEVDOCS-3395]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ