### PR TITLE
DEVDOCS-4028: [update] Payments, add Access Worldpay

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.mdx
+++ b/docs/api-docs/payments/payments-api-overview.mdx
@@ -33,6 +33,7 @@ The following table lists the payment gateways that are compatible with our publ
 
 | Payment Gateway   | Stored instruments | Raw card data   |
 |:------------------|:------------------:|:---------------:|
+| Access Worldpay   | &check;            | &check;         |
 | Adyen             |                    | &check;         |
 | AdyenV2           | &check;            |                 |
 | Adyen V3 oauth    | &check;            | &check;         |


### PR DESCRIPTION
[DEVDOCS-4028](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4028)
Added Access Worldpay to the compatible payment gateways

GA date is May 3, 2023

[DEVDOCS-4028]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ