### PR TITLE
DEVDOCS-4786: [update] hook/events

### DIFF
--- a/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
@@ -13,6 +13,7 @@ The following APIs and tools are deprecated. We discourage using these listed it
 | `/v2/brands` | [Catalog V3 Brands](/docs/rest-management/catalog/brands#get-all-brands) |
 | `/v2/categories` | [Catalog V3 Categories](/docs/rest-management/catalog/category#get-all-categories) |
 | `/v2/customers` | [Customers V3](/docs/rest-management/customers) |
+| `v3/hooks/events`| [Get Events](/docs/webhooks/webhooks/webhook-events#get-events) |
 |`/v2/options`| [Catalog V3 Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). See the [Accessing product options](#accessing-product-options-with-V3) callout.  |
 |`/v2/option_sets`| [Catalog V3 Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/legacy/v2-products/v2-v3). |
 |`/v2/pages`| [Pages V3](/docs/rest-content/pages) |

--- a/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
@@ -13,7 +13,7 @@ The following APIs and tools are deprecated. We discourage using these listed it
 | `/v2/brands` | [Catalog V3 Brands](/docs/rest-management/catalog/brands#get-all-brands) |
 | `/v2/categories` | [Catalog V3 Categories](/docs/rest-management/catalog/category#get-all-categories) |
 | `/v2/customers` | [Customers V3](/docs/rest-management/customers) |
-| `v3/hooks/events`| [Get Events](/docs/webhooks/webhooks/webhook-events#get-events) |
+| `/v3/hooks/events`| [Get Events](/docs/webhooks/webhooks/webhook-events#get-events) |
 |`/v2/options`| [Catalog V3 Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). See the [Accessing product options](#accessing-product-options-with-V3) callout.  |
 |`/v2/option_sets`| [Catalog V3 Product Modifiers](/docs/rest-management/catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-management/catalog/product-variant-options#get-all-product-variant-options). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/legacy/v2-products/v2-v3). |
 |`/v2/pages`| [Pages V3](/docs/rest-content/pages) |


### PR DESCRIPTION
[DEVDOCS-4786](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4786)
Added Get Events to the list of deprecated APIs

[DEVDOCS-4786]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ