### PR TITLE
(no ticket): [revise] add PR template, change codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in the repo. Unless a later match takes precedence, @global-owner1 and @global-owner2 will be requested for review when someone opens a pull request.
 
-@slsriehl @bigcommerce/devdocs-codeowners @markcmurphy
+@slsriehl @bigcommerce/dev-docs-team @markcmurphy
 
 # Teams can be specified as code owners as well. Teams should
 # be identified in the format @org/team-name. Teams must have

--- a/.github/PULL_REQUEST_TEMPLATE/publication_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/publication_pr_template.md
@@ -1,9 +1,0 @@
-# Publish with Rebase Merge
-
-## Included tickets / PRs
-* [DEVDOCS-] - #
-* [DEVDOCS-] - #
-* [DEVDOCS-] - #
-
-## Additional information
-Related Developer Center PRs, other related PRs, salient notes, etc.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,7 +1,0 @@
-# [DEVDOCS-]
-
-## What changed?
-* present tense description of what changed
-
-## Anything else?
-Related PRs, salient notes, etc.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+# [DEVDOCS-]
+{Ticket number or summary of work}
+
+## What changed?
+Provide a bulleted list in the present tense
+* 
+
+## Anything else?
+Add related PRs, salient notes, ticket numbers, etc.
+
+ping {names}


### PR DESCRIPTION
# Add PR template, change codeowners

## What changed?
Provide a bulleted list in the present tense
* Restore PR template
* Make the team codeowner

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping @bigcommerce/dev-docs-team
