### PR TITLE
DEVDOCS-4988: [new] Storefront, Code examples - Add popularBrands GQL example

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-examples.mdx
+++ b/docs/api-docs/storefront/graphql/graphql-api-examples.mdx
@@ -374,3 +374,22 @@ query {
   }
 }
 ```
+
+## Get popular brands
+
+```graphql filename="Example query: Get popular brands" showLineNumbers copy
+query {
+  site {
+    popularBrands {
+      edges {
+        node {
+          entityId
+          count
+          name
+          path
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
# [DEVDOCS-4988]
Add `popularBrands` example query.

## What changed?
* Add GQL node popularBrands to the example query

## Anything else?
Releasing with other GQL storefront endpoints.

ping @bc-andreadao 


[DEVDOCS-4988]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ