### PR TITLE
DEVDOCS-4922: [update] Webhook Events, rename store/variant/metafield

### DIFF
--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -461,10 +461,10 @@ Consult the [product assignment section of the Channel Webhooks Guide](/api-docs
 | store/product/metafield/created | A new product metafield is created. |
 | store/product/metafield/updated | Occurs when product metafield details are edited. |
 | store/product/metafield/deleted | A product metafield is deleted.|
-| store/variant/metafield/* | Subscribe to all store/variant/metafield events. |
-| store/variant/metafield/created | A new product variant metafield is created. |
-| store/variant/metafield/updated | Occurs when product variant metafield details are edited. |
-| store/variant/metafield/deleted | A product variant metafield is deleted.|
+| store/product/variant/metafield/* | Subscribe to all store/product/variant/metafield events. |
+| store/product/variant/metafield/created | A new product variant metafield is created. |
+| store/product/variant/metafield/updated | Occurs when product variant metafield details are edited. |
+| store/product/variant/metafield/deleted | A product variant metafield is deleted.|
 
 Payload objects with the following scopes take the form that follows:
 
@@ -562,9 +562,9 @@ Payload objects with the following scopes take the form that follows:
 ```
 Payload objects with the following scopes take the form that follows:
 
-* `store/variant/metafield/deleted`
-* `store/variant/metafield/created`
-* `store/variant/metafield/updated`
+* `store/product/variant/metafield/deleted`
+* `store/product/variant/metafield/created`
+* `store/product/variant/metafield/updated`
 
 ```json filename="Example product variant metafield payload object" showLineNumbers copy
 {


### PR DESCRIPTION
# [DEVDOCS-4922]


## What changed?
Renamed `store/variant/metafield` to `store/product/variant/metafield`

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-4922]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ