### PR TITLE
DEVDOCS-5107: [update] hash definition

### DIFF
--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -13,7 +13,7 @@ To see an example request-response pair for creating a webhook, consult the crea
 | `scope` | The [event](/api-docs/getting-started/webhooks/webhook-events) registered when the webhook was created. |
 | `store_id` | A numerical identifier that is unique to each store. |
 | `data` | A lightweight description of the [event](/api-docs/getting-started/webhooks/webhook-events) that triggered the webhook. Will vary depending on the event registered. |
-| `hash` | The payload data JSON encoded then passed through SH1 encryption. |
+| `hash` | The SHA-1 hash of the JSON-encoded payload data. Ensures users can detect duplicate events. |
 | `created_at` | Hook creation date as a Unix timestamp.|
 | `producer` | Will always follow the pattern `stores/store_hash`. This is the store that created the webhook. |
 


### PR DESCRIPTION
# [DEVDOCS-5107]
{Ticket number or summary of work}

## What changed?
updated hash definition

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5107]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ