### PR TITLE
DEVDOCS-5115: [revise] Price Lists, Add webhook notes to price lists overview

### DIFF
--- a/docs/api-docs/catalog/price-list-overview.mdx
+++ b/docs/api-docs/catalog/price-list-overview.mdx
@@ -135,7 +135,7 @@ Under `discount_rules` the `type` is set to `price_list`. The `price_list_id` is
 
 - If a variant has a `Price Record`, any existing product-level bulk pricing will not apply in the cart. For variants without `Price Records`, any existing product bulk pricing will apply.
 
-- `Price Lists Records` accepts bulk upsert. You can only do one [Bulk upsert](/docs/rest-management/price-lists/price-lists-records#upsert-price-list-records) at a time. Running more than one in parallel on the **same store** will cause a 429 error, and the request will fail.
+- `Price Lists Records` accepts bulk upsert. You can only do one [Bulk upsert](/docs/rest-management/price-lists/price-lists-records#upsert-price-list-records) at a time. Running more than one in parallel on the **same store** will cause a `429` error, and the request will fail.
 
 ## Related resources
 
@@ -143,7 +143,8 @@ Under `discount_rules` the `type` is set to `price_list`. The `price_list_id` is
 * [Get Price List Collection](/docs/rest-management/price-lists#get-all-price-lists)
 
 ### Webhooks
-There are no direct webhooks available for Price Lists. Since Price Lists directly relate to products, webhooks related to products will fire for corresponding changes such as pricing.
+There are webhooks available for Price Lists assignments. The price list assignment webhook fires when a price list assignment is assigned, reassigned, or unassigned. Note that since Price Lists directly relate to products, neither product nor SKU webhooks will fire for corresponding changes, such as pricing.
 
+* [Price list assignments] (/api-docs/channels/guide/webhooks#price-list-assignments)
 * [Products](/api-docs/getting-started/webhooks/webhook-events#webhook-events_products)
 * [SKU](/api-docs/getting-started/webhooks/webhook-events#webhook-events_sku)


### PR DESCRIPTION
# [DEVDOCS-5115]

## What changed?

* Add webhook information for price lists
* Add webhook link to webhooks segment

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5115]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ