### PR TITLE
DEVDOCS-4922: [revise] cleanup webhook events

### DIFF
--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -364,9 +364,7 @@ Payload objects with the following scopes take the form that follows:
 }
 ```
 
-## Inventory
-
-Consult the [inventory section of the _Buy Online, Pick up in Store_ Webhook Events](/buy-online-pick-up-in-store/webhooks#inventory).
+Also, consult the [inventory section of the _Buy Online, Pick up in Store_ Webhook Events](/buy-online-pick-up-in-store/webhooks#inventory).
 
 ## Locations
 


### PR DESCRIPTION
# [DEVDOCS-4922]
{Ticket number or summary of work}

## What changed?
Removed duplicate inventory sections in the Webhooks Events article.

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-4922]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ