### PR TITLE
DEVDOCS-5105: [update] Update using-front-matter.mdx

### DIFF
--- a/docs/stencil-docs/storefront-customization/using-front-matter.mdx
+++ b/docs/stencil-docs/storefront-customization/using-front-matter.mdx
@@ -32,9 +32,8 @@ You can use front matter to specify attributes on the tops of pages in your `tem
 You **cannot** use front matter to accomplish this on pages in the following subdirectories:
 * `templates/components/`
 * `templates/layout/`
-* `templates/pages/custom/`
 
-* Injecting objects in the front matter of `templates/pages/page.html` will make the objects available to custom templates.
+
 
 * Indent using only spaces, not tabs. (YAML forbids tabs, to avoid inconsistent encoding of tabs across platforms.) An indent of even one space indicates a child.
 


### PR DESCRIPTION
# [DEVDOCS-5105] and [DEVDOCS-4951]
{Ticket number or summary of work}

## What changed?
It is possible to use front matter in custom templates. See [GitHub issue 1925](https://github.com/bigcommerce/dev-docs/issues/1925) and [Slack conversation](https://bigcommerce.slack.com/archives/CCSUP1W1J/p1687362456478229).

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5105]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEVDOCS-4951]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ