### PR TITLE
DEVDOCS-5138: [update] B2B Edition, remove caveat about invoicing

### DIFF
--- a/docs/partner-apps/bundleb2b/b2b-edition.mdx
+++ b/docs/partner-apps/bundleb2b/b2b-edition.mdx
@@ -12,7 +12,7 @@ B2B Edition offers multiple B2B feature enhancements to your BigCommerce store, 
 - Shared shopping lists and "buy again" functionality
 - Sales representative enablement tools
 - Quote management
-- Invoice & payment management (Stencil only; Buyer Portal-based invoicing features are in development)
+- Invoice & payment management
 
 For a more complete list of B2B Edition feature enhancements, see our Help Center [article on B2B Edition's features](https://support.bigcommerce.com/s/article/B2B-Edition#features).
 


### PR DESCRIPTION
# [DEVDOCS-5138]

## What changed?
Provide a bulleted list in the present tense
* Remove caveat about invoicing not being available in B2B Edition's Buyer Portal

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping @bc-vince
