### PR TITLE
DEVDOCS-5158: [revise] remove includes statement

### DIFF
--- a/docs/api-docs/cart-and-checkout/cart-and-checkout-overview.mdx
+++ b/docs/api-docs/cart-and-checkout/cart-and-checkout-overview.mdx
@@ -40,7 +40,7 @@ fetch('/api/storefront/carts', {
 
 ```js filename="Log checkout details to the console" showLineNumbers copy
 console.log('Log Checkout');
-fetch('/api/storefront/carts?includes=consignments.availableShippingOptions', {
+fetch('/api/storefront/carts', {
   credentials: 'include'
 }).then(function (response) {
   return response.json();


### PR DESCRIPTION
# [DEVDOCS-5158]
{Ticket number or summary of work}

## What changed?
Remove includes statement for "Log checkout details to the console" example.

I tested the example and it still works fine.

See slack conversation: https://bigcommerce.slack.com/archives/C0WC9CSJX/p1688674131693349

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5158]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ