### PR TITLE
DEVDOCS-5220 [feat]: Update Shipping Provider API how-to guide on carrier configurations

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -42,6 +42,81 @@ BigCommerce makes a distinction between single-carrier and multi-carrier shippin
 
 ![Multi-carrier quote example](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Multi%20Carrier%20Example.png)
 
+### Carrier configurations
+
+The configurations schema is optional and defines the settings that should be provided when setting up a shipping method or carrier connection in a store. BigCommerce then includes these settings in requests it makes to your service.
+
+If you're unsure about the configurations you may need, you can leave them unspecified for now and request to add them later.
+
+There are two types of configuration options: "connection" and "settings". For each configuration option, please provide the following details:
+
+*Code*: An identifier for this option. This identifier, along with the merchant's input value for this configuration, will be provided on the rate or check and validate connection endpoints.
+*Type*: The display element for this option. Valid types include: `text`, `checkbox`, `select`, `multiselect`, or `password`.
+*Label*: Text to be displayed on the BigCommerce control panel for this option.
+*Description*: A concise and clear description explaining the purpose of this option.
+*Required*: Indicate whether this option is mandatory or optional.
+*Map[only required if the type is select or multiselect]*: If the option type is select or multiselect, provide a key-value pair that will be sent.
+
+Here's an example:
+
+Connection Configurations
+```json
+[
+    {
+        "code": "api_token",
+        "type": "password",
+        "label": "API Token",
+        "description": "API token to access the carrier.",
+        "required": true
+    },
+    {
+        "code": "account_key",
+        "type": "text",
+        "label": "Account Key",
+        "description": "Client ID for your carrier.",
+        "required": true
+    },
+    {
+        "code": "use_sandbox",
+        "type": "checkbox",
+        "label": "Sandbox",
+        "description": "When enabled sandbox mode is used",
+        "required": false
+    }
+]
+```
+
+Settings Configurations
+
+```json
+[
+    {
+        "code": "destination_type",
+        "type": "select",
+        "label": "Destination Type",
+        "description": "Selection of either residential or commercial destination type.",
+        "required": false,
+        "map": {
+            "residential": "Residential",
+            "commercial": "Commercial"
+        }
+    },
+    {
+        "code": "delivery_services",
+        "type": "multiselect",
+        "label": "Delivery Services",
+        "description": "Checklist of delivery services to support",
+        "required": true,
+        "map": {
+            "1_day_air": "1 Day Air",
+            "2_day_air": "2 Day Air",
+            "1 day ground": "1 Day Ground Delivery",
+            "2 day ground": "2 Day Ground Delivery"
+        }
+    }
+]
+```
+
 ## Sign up
 When your app is complete, it will be listed in our carrier registry, so that your shipping rates are available for merchants and shoppers to use. Register your app and get a carrier ID to get started.
 
@@ -67,6 +142,7 @@ Please include the following information:
 - A description of the app
 - [Your service URLs](#your-service-urls)
 - [Whether you prefer single-carrier or multi-carrier status](#single-carrier-versus-multi-carrier-apps)
+- [Carrier configurations](#carrier-configurations): Optional. If unsure leave this out.
 
 ## Before development
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -50,14 +50,19 @@ If you're unsure about the configurations you may need, leave them unspecified f
 
 There are two types of configuration options: "connection" and "settings". For each configuration option, please provide the following details:
 
-*Code*: An identifier for this option. This identifier and the merchant's input value for this configuration will be provided on the rate or check and validate connection endpoints.
-*Type*: The display element for this option. Valid types include: `text`, `checkbox`, `select`, `multiselect`, or `password`.
-*Label*: Text displayed on the BigCommerce control panel for this option.
-*Description*: A concise and clear description explaining the purpose of this option.
-*Required*: Indicate whether this option is mandatory or optional.
-*Map[only required if the type is select or multiselect]*: If the option type is select or multiselect, provide a key-value pair to send.
+- *Code*: An identifier for this option. This identifier and the merchant's input value for this configuration will be provided on the rate or check and validate connection endpoints.
 
-Here's an example:
+- *Type*: The display element for this option. Valid types include: `text`, `checkbox`, `select`, `multiselect`, or `password`.
+
+- *Label*: Text displayed on the BigCommerce control panel for this option.
+
+- *Description*: A concise and clear description explaining the purpose of this option.
+
+- *Required*: Indicate whether this option is mandatory or optional.
+
+- *Map[only required if the type is select or multiselect]*: If the option type is select or multiselect, provide a key-value pair to send.
+
+Here are examples:
 
 ```json filename="Connection Configurations" showLineNumbers copy
 [

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -46,7 +46,7 @@ BigCommerce makes a distinction between single-carrier and multi-carrier shippin
 
 The configurations schema is optional and defines the settings you should provide when setting up a shipping method or carrier connection in a store. BigCommerce then includes these settings in requests it makes to your service.
 
-If you're unsure about the configurations you may need, you can leave them unspecified for now and request to add them later.
+If you're unsure about the configurations you may need, leave them unspecified for now and request to add them later.
 
 There are two types of configuration options: "connection" and "settings". For each configuration option, please provide the following details:
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -88,7 +88,7 @@ Connection Configurations
 
 Settings Configurations
 
-```json
+```json filename="Settings Configurations" showLineNumbers copy
 [
     {
         "code": "destination_type",

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -44,7 +44,7 @@ BigCommerce makes a distinction between single-carrier and multi-carrier shippin
 
 ### Carrier configurations
 
-The configurations schema is optional and defines the settings that should be provided when setting up a shipping method or carrier connection in a store. BigCommerce then includes these settings in requests it makes to your service.
+The configurations schema is optional and defines the settings you should provide when setting up a shipping method or carrier connection in a store. BigCommerce then includes these settings in requests it makes to your service.
 
 If you're unsure about the configurations you may need, you can leave them unspecified for now and request to add them later.
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -55,7 +55,7 @@ There are two types of configuration options: "connection" and "settings". For e
 *Label*: Text displayed on the BigCommerce control panel for this option.
 *Description*: A concise and clear description explaining the purpose of this option.
 *Required*: Indicate whether this option is mandatory or optional.
-*Map[only required if the type is select or multiselect]*: If the option type is select or multiselect, provide a key-value pair that will be sent.
+*Map[only required if the type is select or multiselect]*: If the option type is select or multiselect, provide a key-value pair to send.
 
 Here's an example:
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -85,7 +85,6 @@ Here's an example:
 ]
 ```
 
-Settings Configurations
 
 ```json filename="Settings Configurations" showLineNumbers copy
 [

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -52,7 +52,7 @@ There are two types of configuration options: "connection" and "settings". For e
 
 *Code*: An identifier for this option. This identifier, along with the merchant's input value for this configuration, will be provided on the rate or check and validate connection endpoints.
 *Type*: The display element for this option. Valid types include: `text`, `checkbox`, `select`, `multiselect`, or `password`.
-*Label*: Text to be displayed on the BigCommerce control panel for this option.
+*Label*: Text displayed on the BigCommerce control panel for this option.
 *Description*: A concise and clear description explaining the purpose of this option.
 *Required*: Indicate whether this option is mandatory or optional.
 *Map[only required if the type is select or multiselect]*: If the option type is select or multiselect, provide a key-value pair that will be sent.

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -50,7 +50,7 @@ If you're unsure about the configurations you may need, leave them unspecified f
 
 There are two types of configuration options: "connection" and "settings". For each configuration option, please provide the following details:
 
-*Code*: An identifier for this option. This identifier, along with the merchant's input value for this configuration, will be provided on the rate or check and validate connection endpoints.
+*Code*: An identifier for this option. This identifier and the merchant's input value for this configuration will be provided on the rate or check and validate connection endpoints.
 *Type*: The display element for this option. Valid types include: `text`, `checkbox`, `select`, `multiselect`, or `password`.
 *Label*: Text displayed on the BigCommerce control panel for this option.
 *Description*: A concise and clear description explaining the purpose of this option.

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -142,7 +142,7 @@ Please include the following information:
 - A description of the app
 - [Your service URLs](#your-service-urls)
 - [Whether you prefer single-carrier or multi-carrier status](#single-carrier-versus-multi-carrier-apps)
-- [Carrier configurations](#carrier-configurations): Optional. If unsure leave this out.
+- [Carrier configurations](#carrier-configurations): Optional. If unsure, leave this out.
 
 ## Before development
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -60,7 +60,7 @@ There are two types of configuration options: "connection" and "settings". For e
 Here's an example:
 
 Connection Configurations
-```json
+```json filename="Connection Configurations" showLineNumbers copy
 [
     {
         "code": "api_token",

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -59,7 +59,6 @@ There are two types of configuration options: "connection" and "settings". For e
 
 Here's an example:
 
-Connection Configurations
 ```json filename="Connection Configurations" showLineNumbers copy
 [
     {


### PR DESCRIPTION
# [DEVDOCS-5220](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5220)

## What changed?
Provide a bulleted list in the present tense
* Add new section explaining how to setup carrier configurations when using the Shipping Provider API.
   * Provide relevant examples.

ping @bigcommerce/team-shipping @bc-andreadao 


[DEVDOCS-5220]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ