### PR TITLE
DEVDOCS-5190: [update] Wallet Buttons, support themes <6.7

### DIFF
--- a/docs/stencil-docs/page-builder/wallet-buttons.mdx
+++ b/docs/stencil-docs/page-builder/wallet-buttons.mdx
@@ -231,9 +231,15 @@ The wallet buttons appear on the PDP as follows:
 
 ### For Cornerstone themes below version 6.7 
 
-You'll need to perform another step to make wallet buttons work as expected for themes below version 6.7. After you enter the code snippet above, insert the following code into your theme markup.
+You'll need to perform another step to make wallet buttons work as expected for themes below version 6.7. After you enter the code snippet above, insert the following code into your theme markup to look as follows:
 
-```html
+```handlebars filename="add-to-cart.html" showLineNumbers copy
+{{#if this.with_wallet_buttons}}
+  {{#if wallet_buttons}}
+    <div class="your-class-for-wallet-buttons-list">
+      {{{wallet_buttons}}}
+    </div>
+
 <script type="text/javascript">
     init();
 
@@ -330,6 +336,9 @@ You'll need to perform another step to make wallet buttons work as expected for 
         }));
     }
 </script>
+
+  {{/if}}
+{{/if}}
 ```
 
 

--- a/docs/stencil-docs/page-builder/wallet-buttons.mdx
+++ b/docs/stencil-docs/page-builder/wallet-buttons.mdx
@@ -231,7 +231,7 @@ The wallet buttons appear on the PDP as follows:
 
 ### For Cornerstone themes below version 6.7 
 
-You'll need to perform another step to make wallet buttons work as expected for themes below version 6.7. After you enter the code snippet above, insert the following code into your theme markup to look as follows:
+In themes below version 6.7, you need to perform another step to make wallet buttons work as expected. After you enter the preceding code snippet, insert the following code into your theme markup:
 
 ```handlebars filename="add-to-cart.html" showLineNumbers copy
 {{#if this.with_wallet_buttons}}

--- a/docs/stencil-docs/page-builder/wallet-buttons.mdx
+++ b/docs/stencil-docs/page-builder/wallet-buttons.mdx
@@ -229,6 +229,110 @@ The wallet buttons appear on the PDP as follows:
 
 ![wallet-buttons-04](https://storage.googleapis.com/bigcommerce-production-dev-center/images/wallet-buttons-04.png "theme-markup")
 
+### For Cornerstone themes below version 6.7 
+
+To make wallet buttons work as expected for themes below version 6.7, insert the following code into your theme markup.
+
+```html
+<script type="text/javascript">
+    init();
+
+    function init() {
+        const form = document.querySelector('form[data-cart-item-add]');
+        const submitButton = form.querySelector('input[type="submit"]');
+        const walletButtonsContainer = document.getElementById('bc-smart-payment-buttons');
+
+        if (!walletButtonsContainer) {
+            return;
+        }
+
+        const submitObserver = new MutationObserver(((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type === 'attributes') {
+                    if (!mutation.target.disabled && form.checkValidity()) {
+                        walletButtonsContainer.style.display = 'block';
+                        updateProductDetailsData(form);
+                    } else {
+                        walletButtonsContainer.style.display = 'none';
+                        resetProductDetailsData();
+                    }
+                }
+            });
+        }));
+
+        submitObserver.observe(submitButton, { attributes: true });
+
+        form.addEventListener('click', () => {
+            setTimeout(() => updateProductDetailsData(form), 0);
+        });
+
+        form.addEventListener('change', () => {
+            if (form.checkValidity() && !submitButton.disabled) {
+                walletButtonsContainer.style.display = 'block';
+                updateProductDetailsData(form);
+            } else {
+                walletButtonsContainer.style.display = 'none';
+                resetProductDetailsData();
+            }
+        });
+
+        form.addEventListener('touchend', () => {
+            setTimeout(() => updateProductDetailsData(form), 0);
+        });
+
+        form.addEventListener('keyup', () => updateProductDetailsData(form));
+
+        if (form.checkValidity() && !submitButton.disabled) {
+            updateProductDetailsData(form);
+        } else {
+            walletButtonsContainer.style.display = 'none';
+            resetProductDetailsData();
+        }
+    }
+
+    function updateProductDetailsData(form) {
+        const productDetails = {};
+        const formData = new FormData(form);
+
+        for (const [fieldName, fieldValue] of formData) {
+            if (fieldName === 'product_id') {
+                productDetails.productId = Number(fieldValue);
+            }
+
+            if (fieldName === 'qty[]') {
+                productDetails.quantity = Number(fieldValue);
+            }
+
+            if (fieldName.match(/attribute/)) {
+                const productOption = {
+                    optionId: Number(fieldName.match(/\d+/g)[0]),
+                    optionValue: fieldValue,
+                };
+
+                productDetails.optionSelections = productDetails?.optionSelections
+                    ? [...productDetails.optionSelections, productOption]
+                    : [productOption];
+            }
+        }
+
+        document.dispatchEvent(new CustomEvent('onProductUpdate', {
+            bubbles: true,
+            detail: { productDetails },
+        }));
+    }
+
+    function resetProductDetailsData() {
+        const productDetails = {};
+
+        document.dispatchEvent(new CustomEvent('onProductUpdate', {
+            bubbles: true,
+            detail: { productDetails },
+        }));
+    }
+</script>
+```
+
+
 ## Resources
 
 ### Related articles

--- a/docs/stencil-docs/page-builder/wallet-buttons.mdx
+++ b/docs/stencil-docs/page-builder/wallet-buttons.mdx
@@ -240,102 +240,102 @@ You'll need to perform another step to make wallet buttons work as expected for 
       {{{wallet_buttons}}}
     </div>
 
-<script type="text/javascript">
-    init();
+    <script type="text/javascript">
+      function updateProductDetailsData(form) {
+        const productDetails = {};
+        const formData = new FormData(form);
 
-    function init() {
+        for (const [fieldName, fieldValue] of formData) {
+          if (fieldName === 'product_id') {
+            productDetails.productId = Number(fieldValue);
+          }
+
+          if (fieldName === 'qty[]') {
+            productDetails.quantity = Number(fieldValue);
+          }
+
+          if (fieldName.match(/attribute/)) {
+            const productOption = {
+              optionId: Number(fieldName.match(/\d+/g)[0]),
+              optionValue: fieldValue,
+            };
+
+            productDetails.optionSelections = productDetails?.optionSelections
+              ? [...productDetails.optionSelections, productOption]
+              : [productOption];
+          }
+        }
+
+        document.dispatchEvent(new CustomEvent('onProductUpdate', {
+          bubbles: true,
+          detail: { productDetails },
+        }));
+      }
+
+      function resetProductDetailsData() {
+        const productDetails = {};
+
+        document.dispatchEvent(new CustomEvent('onProductUpdate', {
+          bubbles: true,
+          detail: { productDetails },
+        }));
+      }
+
+      function init() {
         const form = document.querySelector('form[data-cart-item-add]');
         const submitButton = form.querySelector('input[type="submit"]');
         const walletButtonsContainer = document.getElementById('bc-smart-payment-buttons');
 
         if (!walletButtonsContainer) {
-            return;
+          return;
         }
 
         const submitObserver = new MutationObserver(((mutations) => {
-            mutations.forEach((mutation) => {
-                if (mutation.type === 'attributes') {
-                    if (!mutation.target.disabled && form.checkValidity()) {
-                        walletButtonsContainer.style.display = 'block';
-                        updateProductDetailsData(form);
-                    } else {
-                        walletButtonsContainer.style.display = 'none';
-                        resetProductDetailsData();
-                    }
-                }
-            });
+          mutations.forEach((mutation) => {
+            if (mutation.type === 'attributes') {
+              if (!mutation.target.disabled && form.checkValidity()) {
+                walletButtonsContainer.style.display = 'block';
+                updateProductDetailsData(form);
+              } else {
+                walletButtonsContainer.style.display = 'none';
+                resetProductDetailsData();
+              }
+            }
+          });
         }));
 
         submitObserver.observe(submitButton, { attributes: true });
 
         form.addEventListener('click', () => {
-            setTimeout(() => updateProductDetailsData(form), 0);
+          setTimeout(() => updateProductDetailsData(form), 0);
         });
 
         form.addEventListener('change', () => {
-            if (form.checkValidity() && !submitButton.disabled) {
-                walletButtonsContainer.style.display = 'block';
-                updateProductDetailsData(form);
-            } else {
-                walletButtonsContainer.style.display = 'none';
-                resetProductDetailsData();
-            }
+          if (form.checkValidity() && !submitButton.disabled) {
+            walletButtonsContainer.style.display = 'block';
+            updateProductDetailsData(form);
+          } else {
+            walletButtonsContainer.style.display = 'none';
+            resetProductDetailsData();
+          }
         });
 
         form.addEventListener('touchend', () => {
-            setTimeout(() => updateProductDetailsData(form), 0);
+          setTimeout(() => updateProductDetailsData(form), 0);
         });
 
         form.addEventListener('keyup', () => updateProductDetailsData(form));
 
         if (form.checkValidity() && !submitButton.disabled) {
-            updateProductDetailsData(form);
+          updateProductDetailsData(form);
         } else {
-            walletButtonsContainer.style.display = 'none';
-            resetProductDetailsData();
+          walletButtonsContainer.style.display = 'none';
+          resetProductDetailsData();
         }
-    }
+      }
 
-    function updateProductDetailsData(form) {
-        const productDetails = {};
-        const formData = new FormData(form);
-
-        for (const [fieldName, fieldValue] of formData) {
-            if (fieldName === 'product_id') {
-                productDetails.productId = Number(fieldValue);
-            }
-
-            if (fieldName === 'qty[]') {
-                productDetails.quantity = Number(fieldValue);
-            }
-
-            if (fieldName.match(/attribute/)) {
-                const productOption = {
-                    optionId: Number(fieldName.match(/\d+/g)[0]),
-                    optionValue: fieldValue,
-                };
-
-                productDetails.optionSelections = productDetails?.optionSelections
-                    ? [...productDetails.optionSelections, productOption]
-                    : [productOption];
-            }
-        }
-
-        document.dispatchEvent(new CustomEvent('onProductUpdate', {
-            bubbles: true,
-            detail: { productDetails },
-        }));
-    }
-
-    function resetProductDetailsData() {
-        const productDetails = {};
-
-        document.dispatchEvent(new CustomEvent('onProductUpdate', {
-            bubbles: true,
-            detail: { productDetails },
-        }));
-    }
-</script>
+      init();
+    </script>
 
   {{/if}}
 {{/if}}

--- a/docs/stencil-docs/page-builder/wallet-buttons.mdx
+++ b/docs/stencil-docs/page-builder/wallet-buttons.mdx
@@ -231,7 +231,7 @@ The wallet buttons appear on the PDP as follows:
 
 ### For Cornerstone themes below version 6.7 
 
-To make wallet buttons work as expected for themes below version 6.7, insert the following code into your theme markup.
+You'll need to perform another step to make wallet buttons work as expected for themes below version 6.7. After you enter the code snippet above, insert the following code into your theme markup.
 
 ```html
 <script type="text/javascript">


### PR DESCRIPTION
# [DEVDOCS-5190]


## What changed?
Added a new section for cornerstone themes below version 6.7

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5190]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ