### PR TITLE
DEVDOCS-4799 [revise] Stencil Docs, Common Objects `has_options` description update

### DIFF
--- a/docs/stencil-docs/reference-docs/common-objects.mdx
+++ b/docs/stencil-docs/reference-docs/common-objects.mdx
@@ -157,7 +157,7 @@ This consistent behavior is true for each of the common objects documented in th
 | date_added | Date the product was added to this BigCommerce storefront | string Ex. `"Aug 15th 2018"` |
 | pre_order |Product’s availability for pre-order | boolean |
 | show_cart_action | Indicates whether the product is available for purchase | boolean |
-| has_options | Indicates whether customer is required to specify options when ordering the product. A `false` variable appears When product is out of stock, including it's options.  | Boolean | 
+| has_options | Indicates whether the customer must specify options when ordering the product. A `false` variable appears when the product is out of stock, including its options.  | Boolean | 
 | stock_level | If inventory tracking is turned on: The number of items available for sale (0 or more). If inventory tracking is turned off: A "null" string. | number or null |
 | low_stock_level | If inventory tracking is turned on: Sets a threshold low-stock level. You can use conditional logic to display a "limited availability" badge if the `stock_level` property's value falls below this threshold. If inventory tracking is turned off: A "null" string. | number or "null" |
 | custom_fields | Array of [custom fields](https://support.bigcommerce.com/articles/Public/Custom-Fields) for this product; custom fields can be used for purposes like: alternate brand name, merchandising title for the product, product type, "gift idea" indicator, etc. | array |

--- a/docs/stencil-docs/reference-docs/common-objects.mdx
+++ b/docs/stencil-docs/reference-docs/common-objects.mdx
@@ -157,7 +157,7 @@ This consistent behavior is true for each of the common objects documented in th
 | date_added | Date the product was added to this BigCommerce storefront | string Ex. `"Aug 15th 2018"` |
 | pre_order |Product’s availability for pre-order | boolean |
 | show_cart_action | Indicates whether the product is available for purchase | boolean |
-| has_options | Indicates whether customer is required to specify options when ordering the product | Boolean | 
+| has_options | Indicates whether customer is required to specify options when ordering the product. A `false` variable appears When product is out of stock, including it's options.  | Boolean | 
 | stock_level | If inventory tracking is turned on: The number of items available for sale (0 or more). If inventory tracking is turned off: A "null" string. | number or null |
 | low_stock_level | If inventory tracking is turned on: Sets a threshold low-stock level. You can use conditional logic to display a "limited availability" badge if the `stock_level` property's value falls below this threshold. If inventory tracking is turned off: A "null" string. | number or "null" |
 | custom_fields | Array of [custom fields](https://support.bigcommerce.com/articles/Public/Custom-Fields) for this product; custom fields can be used for purposes like: alternate brand name, merchandising title for the product, product type, "gift idea" indicator, etc. | array |


### PR DESCRIPTION
# [DEVDOCS-4799]

## What changed?

* Document `has_options` behavior for products that are out of stock, including options

## Anything else?

ping {names}


[DEVDOCS-4799]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ