### PR TITLE
DEVDOCS-5026 [update]: links to legacy docs

### DIFF
--- a/docs/legacy/v2-catalog-products/v2-products.mdx
+++ b/docs/legacy/v2-catalog-products/v2-products.mdx
@@ -98,7 +98,7 @@ A product object represents a saleable item in the catalog.
 | custom_fields | resource | See the [Custom Fields](/api/v2/#custom-fields) resource for information. |
 | videos | resource | See the [Videos resource](/api/v2/#videos) for information. |
 | skus | resource | Stock Keeping Units for the product. See the [Product SKUs](/api/v2/#skus) resource for the definition of a sku object. |
-| rules | resource | Rules that apply only to this product, based on the product's [option set](/api-docs/store-management/catalog/v2-vs-v3#product-option-sets). See [Product Rules](/api/v2/#product-rules) resource for information. |
+| rules | resource | Rules that apply only to this product, based on the product's [option set](/legacy/v2-catalog-products/v2-option-sets). See [Product Rules](/legacy/v2-catalog-products/v2-product-rules) resource for information. |
 | option_set | resource | See the [Product Option Sets](/legacy/v2-catalog-products/v2-option-sets) resource for information. |
 | options | resource | Options from the [option set](/api/v2/#option-sets) applied to the product. See the [Product Options](/api/v2/#product-options) resource for information. |
 | tax_class | resource | Assigned tax class, when using a manual tax setup. This can be a number matching one of the tax classes set up in your store. |


### PR DESCRIPTION
# [DEVDOCS-5026]

## What changed?
- Fix links to legacy docs

This PR fixes a mistake in[ PR 2032](https://github.com/bigcommerce/dev-docs/pull/2032)

[DEVDOCS-5026]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ