### PR TITLE
DEVDOCS-4701 [update]: GQL Storefront API, update UTC timestamp description

### DIFF
--- a/docs/api-docs/getting-started/making-requests.mdx
+++ b/docs/api-docs/getting-started/making-requests.mdx
@@ -59,7 +59,7 @@ Include the URL of the storefront you will be making the request from as the `al
 ```json
 {
   "channel_id": 1,            // int (only ID 1 currently accepted)
-  "expires_at": 1602288000,   // double utc unix timestamp (required)
+  "expires_at": 1602288000,   // double UTC unix timestamp in seconds (required)
   "allowed_cors_origins": [   // array (accepts 1 origin currently)
     "https://example.com"
   ]


### PR DESCRIPTION
# [DEVDOCS-4701]

## What changed?
- Add seconds to UTC timestamp description

This PR relates to [PR 1403](https://github.com/bigcommerce/api-specs/pull/1403)

[DEVDOCS-4701]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ