### PR TITLE
(no ticket): [update] Guide to API Accounts, add OAuth scopes

### DIFF
--- a/docs/api-docs/getting-started/rest-api-authentication.mdx
+++ b/docs/api-docs/getting-started/rest-api-authentication.mdx
@@ -189,7 +189,7 @@ All OAuth scopes except `default` provide `read-only` permissions scopes so that
 | Storefront API Tokens | modify | `store_storefront_api` | Create GraphQL Storefront API bearer tokens | [Storefront API Token V3](/docs/storefront-auth/tokens#create-a-token) |
 | Storefront API Customer Impersonation Tokens | modify | `store_storefront_api_customer_impersonation` | Create GraphQL Storefront API bearer tokens that allow customer impersonation | [Storefront API Token V3, Customer Impersonation](/docs/storefront-auth/tokens/customer-impersonation-token#create-a-token) |
 
-### Resource scopes
+### Store resource scopes
 
 | UI Name | Permission | Parameter | Description | Resources |
 |:--------|:-----------|:----------|:------------|:----------|
@@ -232,6 +232,11 @@ All OAuth scopes except `default` provide `read-only` permissions scopes so that
 | Channel Settings | read-only | `store_channel_settings_read_only` | View a list of channels | [Channels V3](/docs/rest-management/channels) |
 | Channel Listings | modify | `store_channel_listings` | View and modify a list of all channel listings for a particular channel | [Channels V3, Listings](/docs/rest-management/channels/channel-listings#get-channel-listings) |
 | Channel Listings | read-only | `store_channel_listings_read_only` | View a list of all channel listings for a particular channel | [Channels V3, Listings](/docs/rest-management/channels/channel-listings#get-channel-listings) |
+
+### Account resource scopes
+
+| UI Name | Permission | Parameter | Description | Resources |
+|:--------|:-----------|:----------|:------------|:----------|
 | Account | read-only | `account_read` | View account details | [GraphQL Account API](/docs/graphql-users) |
 | Account Stores | read-only | `account_stores_read` | View the stores associated with an account | [GraphQL Account API](/docs/graphql-users) |
 | Account Apps | read-only | `account_apps_read` | View the apps associated with an account | [GraphQL Account API](/docs/graphql-users) |

--- a/docs/api-docs/getting-started/rest-api-authentication.mdx
+++ b/docs/api-docs/getting-started/rest-api-authentication.mdx
@@ -243,9 +243,6 @@ All OAuth scopes except `default` provide `read-only` permissions scopes so that
 | Account Users | read-only | `account_users_read` | View the users associated with an account | [GraphQL Account API](/docs/graphql-users) |
 | Account Users | write | `account_users_write` | Add and update users | [GraphQL Account API](/docs/graphql-users) |
 | Account Users | delete | `account_users_delete` | Remove a user from an account | [GraphQL Account API](/docs/graphql-users) |
-| Subscriptions | read-only| `subscriptions_read_only` | View or cancel subscriptions | [GraphQL Account API](/docs/graphql-users) |
-| Checkouts | modify | `account_checkouts` | View or cancel checkouts | [GraphQL Account API](/docs/graphql-users) |
-| Charges | modify | `account_charges` | Create or delete charges | [GraphQL Account API](/docs/graphql-users) |
 
 ## Resources
 

--- a/docs/api-docs/getting-started/rest-api-authentication.mdx
+++ b/docs/api-docs/getting-started/rest-api-authentication.mdx
@@ -224,7 +224,7 @@ All OAuth scopes except `default` provide `read-only` permissions scopes so that
 | Themes | read-only | `store_themes_read_only` | View themes | [Themes V3](/docs/rest-content/themes) |
 | Carts | modify | `store_cart` | View and modify carts | [Carts V3](/docs/rest-management/carts) |
 | Carts | read-only | `store_cart_read_only` | View carts | [Carts V3](/docs/rest-management/carts) |
-| Checkouts | modify | `store_checkout` | View and modify a checkout | [Checkouts V3](/docs/rest-storefront/checkouts) |
+| Checkouts | modify | `store_checkout` | View and modify a checkout | [Checkouts V3](/docs/rest-storefront/checkouts)  |
 | Checkouts | read-only | `store_checkout_read_only` | View checkout content | [Checkouts V3](/docs/rest-storefront/checkouts) |
 | Sites & Routes | modify | `store_sites` | View and modify sites and routes | [Sites V3, Routes, Certificates](/docs/rest-management/sites) <br /> [Channels V3 Sites](/docs/rest-management/channels/channel-site#get-a-channel-site) |
 | Sites & Routes | read-only | `store_sites_read_only` | View external storefronts with non-BigCommerce URLs | [Sites V3, Routes, Certificates](/docs/rest-management/sites) <br /> [Channels V3 Sites](/docs/rest-management/channels/channel-site#get-a-channel-site) |
@@ -239,6 +239,9 @@ All OAuth scopes except `default` provide `read-only` permissions scopes so that
 | Account Users | write | `account_users_write` | Add a user to an account | [GraphQL Account API](/docs/graphql-users) |
 | Account Users | write | `account_users_write` | Create a user with a password for an account | [GraphQL Account API](/docs/graphql-users) |
 | Account Users | delete | `account_users_delete` | Remove a user from an account | [GraphQL Account API](/docs/graphql-users) |
+| Subscriptions | read-only| `subscriptions_read_only` | View or cancel subscriptions | [GraphQL Account API](/docs/graphql-users) |
+| Checkouts | modify | `account_checkouts` | View or cancel checkouts | [GraphQL Account API](/docs/graphql-users) |
+| Charges | modify | `account_charges` | Create or delete charges | [GraphQL Account API](/docs/graphql-users) |
 
 ## Resources
 

--- a/docs/api-docs/getting-started/rest-api-authentication.mdx
+++ b/docs/api-docs/getting-started/rest-api-authentication.mdx
@@ -236,8 +236,7 @@ All OAuth scopes except `default` provide `read-only` permissions scopes so that
 | Account Stores | read-only | `account_stores_read` | View the stores associated with an account | [GraphQL Account API](/docs/graphql-users) |
 | Account Apps | read-only | `account_apps_read` | View the apps associated with an account | [GraphQL Account API](/docs/graphql-users) |
 | Account Users | read-only | `account_users_read` | View the users associated with an account | [GraphQL Account API](/docs/graphql-users) |
-| Account Users | write | `account_users_write` | Add a user to an account | [GraphQL Account API](/docs/graphql-users) |
-| Account Users | write | `account_users_write` | Create a user with a password for an account | [GraphQL Account API](/docs/graphql-users) |
+| Account Users | write | `account_users_write` | Add and update users | [GraphQL Account API](/docs/graphql-users) |
 | Account Users | delete | `account_users_delete` | Remove a user from an account | [GraphQL Account API](/docs/graphql-users) |
 | Subscriptions | read-only| `subscriptions_read_only` | View or cancel subscriptions | [GraphQL Account API](/docs/graphql-users) |
 | Checkouts | modify | `account_checkouts` | View or cancel checkouts | [GraphQL Account API](/docs/graphql-users) |

--- a/docs/api-docs/users/overview.mdx
+++ b/docs/api-docs/users/overview.mdx
@@ -28,6 +28,8 @@ To learn more about making requests, see the next section on [Getting Started](#
 | Account Users | write | Create and update users |
 | Account Users | delete | Remove users |
 
+For more information on these OAuth scopes, see the [Guide to API Accounts](/api-docs/getting-started/api-accounts#account-resource-scopes).
+
 For more information on access token authentication, see [Authentication and Example Requests](/api-docs/getting-started/authentication#access-tokens).
 
 ## Getting started


### PR DESCRIPTION
# no ticket - OAuth scopes improvement

## What changed?
* Separate account scopes from store scopes
* Add link on Users Overview to the account level OAuth scopes
* Deduplicate a repeated scope

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-4868]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ