### PR TITLE
[Stencil] Update handlebars reverse helper link

### DIFF
--- a/docs/stencil-docs/reference-docs/handlebars-helpers-reference.mdx
+++ b/docs/stencil-docs/reference-docs/handlebars-helpers-reference.mdx
@@ -1749,7 +1749,7 @@ The following table contains acceptlisted standard Handlebars helpers available 
 | [pascalcase](https://github.com/helpers/handlebars-helpers#pascalcase) | string | PascalCase the characters in a string. |
 | [pathcase](https://github.com/helpers/handlebars-helpers#pathcase) | string | `path/case` the characters in a string. |
 | [plusify](https://github.com/helpers/handlebars-helpers#plusify) | string | Replaces spaces in the given string with pluses. |
-| [reverse](https://github.com/helpers/handlebars-helpers#reverse) | string | Reverses a string. |
+| [reverse](https://github.com/bigcommerce/paper-handlebars/blob/master/helpers/3p/string.js#L280) | string | Reverses a string. |
 | [sentence](https://github.com/helpers/handlebars-helpers#sentence) | string | Sentence case the given string. |
 | [snakecase](https://github.com/helpers/handlebars-helpers#snakecase) | string | `snake_case` the characters in the given string. |
 | [split](https://github.com/helpers/handlebars-helpers#split) | string | Splits a string by the given character. |


### PR DESCRIPTION
# [DEVDOCS-]
{Ticket number or summary of work}
Reverse helper currently doesn't support array's type. Our documentation is correct, but the link goes to the old codebase, which is not fully correct (currently it says that supports string and arrays, but actually only strings are supported) and makes [confusion](https://github.com/bigcommerce/paper-handlebars/issues/292) 

## What changed?
Updated reverse helper link to our codebase


ping @bigcommerce/dev-docs @bigcommerce/team-storefront @bc-evan-johnson
