### PR TITLE
DEVDOCS-5284 [new]: Shipping Provider API, add digital wallets

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -496,6 +496,8 @@ When you uninstall an app with an associated shipping carrier, you also automati
   The response payload will display shipping quotes from lowest to highest price.
 </Callout>
 
+Shipping provider integrations should plan to handle incomplete postcodes when handling shipping quotes. This occurs when stores use [digital wallets](https://support.bigcommerce.com/s/article/Online-Payment-Methods?language=en_US#digital-wallet) as a payment method. Digital wallets truncate postcodes for shipping addresses in UK and Canada. They only provide the first 3 characters to shipping provider integrations.
+
 ## Including product metadata in rate requests
 
 BigCommerce passes carrier-specific product metadata to a carrier service in a rate request via product and variant metafields. This product metadata can be useful if your service depends on specific fields that are not existent on BigCommerce products or variants by default.

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -496,7 +496,7 @@ When you uninstall an app with an associated shipping carrier, you also automati
   The response payload will display shipping quotes from lowest to highest price.
 </Callout>
 
-Shipping provider integrations should plan to handle incomplete postcodes when handling shipping quotes. This occurs when stores use [digital wallets](https://support.bigcommerce.com/s/article/Online-Payment-Methods?language=en_US#digital-wallet) as a payment method. Digital wallets truncate postcodes for shipping addresses in UK and Canada. They only provide the first 3 characters to shipping provider integrations.
+Shipping provider integrations should plan to handle incomplete postcodes when handling shipping quotes. Incomplete postcodes can occur when stores use [digital wallets](https://support.bigcommerce.com/s/article/Online-Payment-Methods?language=en_US#digital-wallet) as a payment method. Digital wallets truncate postcodes for shipping addresses in the UK and Canada as they only provide the first three characters to shipping provider integrations.
 
 ## Including product metadata in rate requests
 


### PR DESCRIPTION
# [DEVDOCS-5284]

## What changed?
* Add paragraph about how Shipping Provider APIs should handle incomplete postal codes (from digital wallets)

@bigcommerce/team-shipping 

[DEVDOCS-5284]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ