### PR TITLE
DEVDOCS-5284 [new]: Shipping Provider API, clarify truncated postcodes 

### DIFF
--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -496,7 +496,11 @@ When you uninstall an app with an associated shipping carrier, you also automati
   The response payload will display shipping quotes from lowest to highest price.
 </Callout>
 
+### Incomplete postcodes
+
 Shipping provider integrations should plan to handle incomplete postcodes when handling shipping quotes. Incomplete postcodes can occur when stores use [digital wallets](https://support.bigcommerce.com/s/article/Online-Payment-Methods?language=en_US#digital-wallet) as a payment method. Digital wallets truncate postcodes for shipping addresses in the UK and Canada as they only provide the first three characters to shipping provider integrations.
+
+Digital wallets truncate postcodes only when they generate shipping quotes. Complete postcodes are available once a shopper places the order, and shipping providers can read and fetch order data after order placement.
 
 ## Including product metadata in rate requests
 

--- a/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
+++ b/docs/api-docs/store-management/shipping/shipping-provider-api.mdx
@@ -500,7 +500,7 @@ When you uninstall an app with an associated shipping carrier, you also automati
 
 Shipping provider integrations should plan to handle incomplete postcodes when handling shipping quotes. Incomplete postcodes can occur when stores use [digital wallets](https://support.bigcommerce.com/s/article/Online-Payment-Methods?language=en_US#digital-wallet) as a payment method. Digital wallets truncate postcodes for shipping addresses in the UK and Canada as they only provide the first three characters to shipping provider integrations.
 
-Digital wallets truncate postcodes only when they generate shipping quotes. Complete postcodes are available once a shopper places the order, and shipping providers can read and fetch order data after order placement.
+Digital wallets truncate postcodes only when they generate shipping quotes. Complete postcodes are available once a shopper places the order. Shipping providers can read and fetch order data after order placement.
 
 ## Including product metadata in rate requests
 


### PR DESCRIPTION
# [DEVDOCS-5284]

This PR incorporates the feedback made by @vborinsk in [PR 2073](https://github.com/bigcommerce/dev-docs/pull/2073).

## What changed?
- Make a heading for postcodes 
- Clarify that shipping providers can see complete postcodes after order placement 




[DEVDOCS-5284]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ