### PR TITLE
DEVDOCS-5493: [update] add webhook cleanup policy

### DIFF
--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -48,6 +48,7 @@ Accept: application/json
 <Callout type="info">
   * The `destination` URL must be served on port **443**; custom ports are not currently supported.
   * It can take up to one minute for a newly created webhook to work.
+  *  Webhook subscriptions are deleted after 90 days of inactivity.
 </Callout>
 
 

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -48,7 +48,7 @@ Accept: application/json
 <Callout type="info">
   * The `destination` URL must be served on port **443**; custom ports are not currently supported.
   * It can take up to one minute for a newly created webhook to work.
-  *  Webhook subscriptions are deleted after 90 days of inactivity.
+  * A webhook subscription becomes deactivated after 90 days of inactivity.
 </Callout>
 
 


### PR DESCRIPTION
# [DEVDOCS-5493]
{Ticket number or summary of work}

## What changed?
Added the webhook cleanup policy

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5493]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ