### PR TITLE
DEVDOCS-5578: [update] update node-sass date

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/installing-stencil.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/installing-stencil.mdx
@@ -1,7 +1,7 @@
 # Installing Stencil CLI
 
 <Callout type="warning">
-BigCommerce is currently targeting 11/1/2023 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/docs/storefront/stencil/cli/unexpected-behavior#incompatible-scss-directives), which can cause issues with the styling of your storefront.
+BigCommerce is currently targeting 01/31/2024 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/docs/storefront/stencil/cli/unexpected-behavior#incompatible-scss-directives), which can cause issues with the styling of your storefront.
 
 </Callout>
 

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.mdx
@@ -5,7 +5,7 @@
 This article is a comprehensive command reference for Stencil CLI, BigCommerce's powerful theme development and deployment tool. For installation instructions for your OS, see [Installing Stencil CLI](/docs/storefront/stencil/cli/install). For more information on BigCommerce's Stencil Theme Engine, see [About Stencil](/docs/storefront/stencil/start). Continue reading below for detailed information on each Stencil CLI command and option.
 
 <Callout type="warning">
-BigCommerce is currently targeting 11/1/2023 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/docs/storefront/stencil/cli/unexpected-behavior#incompatible-scss-directives), which can cause issues with the styling of your storefront.
+BigCommerce is currently targeting January 30, 2024 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/docs/storefront/stencil/cli/unexpected-behavior#incompatible-scss-directives), which can cause issues with the styling of your storefront.
 </Callout>
 
 ## Commands overview

--- a/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/stencil-cli-options-and-commands.mdx
@@ -5,7 +5,7 @@
 This article is a comprehensive command reference for Stencil CLI, BigCommerce's powerful theme development and deployment tool. For installation instructions for your OS, see [Installing Stencil CLI](/docs/storefront/stencil/cli/install). For more information on BigCommerce's Stencil Theme Engine, see [About Stencil](/docs/storefront/stencil/start). Continue reading below for detailed information on each Stencil CLI command and option.
 
 <Callout type="warning">
-BigCommerce is currently targeting January 30, 2024 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/docs/storefront/stencil/cli/unexpected-behavior#incompatible-scss-directives), which can cause issues with the styling of your storefront.
+BigCommerce is currently targeting January 31, 2024 to sunset its node-sass fork in favor of the latest [sass/node-sass](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the latest node version (Node 18) in Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](/docs/storefront/stencil/cli/unexpected-behavior#incompatible-scss-directives), which can cause issues with the styling of your storefront.
 </Callout>
 
 ## Commands overview

--- a/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/troubleshooting-your-setup.mdx
@@ -6,7 +6,7 @@ When you encounter unexpected behavior while developing your Stencil theme, star
 In some cases, the terminal provides verbose error messages specifying where to look for problems. These have the potential to provide insight into the root cause of errors. For error messages that may not be helpful in revealing the issue you're experiencing, diagnostic suggestions are listed in this article.
 
 <Callout type="warning">
-  BigCommerce is currently targeting November 2023 to sunset its node-sass fork in favor of the latest [sass/node-sass (GitHub)](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the [latest Node.js version with long-term support (Node 18 LTS)](https://nodejs.org/en) to run the Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](#incompatible-scss-directives), which can cause errors and consistency issues with your storefront's CSS.
+  BigCommerce is currently targeting January 31, 2024 to sunset its node-sass fork in favor of the latest [sass/node-sass (GitHub)](https://github.com/sass/node-sass). To ensure that your storefront is up to date, use the [latest Node.js version with long-term support (Node 18 LTS)](https://nodejs.org/en) to run the Stencil CLI and use the CLI command to resolve [incompatible SCSS directives](#incompatible-scss-directives), which can cause errors and consistency issues with your storefront's CSS.
 </Callout>
 
 ## Incompatible SCSS directives


### PR DESCRIPTION
# [DEVDOCS-5578]
{Ticket number or summary of work}

## What changed?
Changed the node-sass date to Jan 31, 2024

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5578]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ