### PR TITLE
DEVDOCS-5442: [deprecate] pre-Handlebars Legacy Email Templates

### DIFF
--- a/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
+++ b/docs/api-docs/getting-started/deprecations-and-sunsets.mdx
@@ -9,21 +9,20 @@ This article provides a reference for deprecated APIs and exposes BigCommerce's 
 
 ## Deprecations
 
-The following APIs and tools are deprecated. We discourage using these listed items, as BigCommerce no longer supports them. Instead, consider using the suggested replacements.
+The following APIs, features, and tools are deprecated. We discourage using these listed items, as BigCommerce no longer supports them. Instead, consider using the suggested replacements.
 
-| Deprecated API | Replacement |
-|:---------------|:------------|
+| Deprecated API or feature | Replacement |
+|:--------------------------|:------------|
 | `/v2/brands` | [Catalog V3 Brands](/docs/rest-catalog/brands#get-all-brands) |
+| `/v3/content/widgets/search` | [Widgets V3, Get all widgets](/docs/rest-content/widgets/widget#get-all-widgets) |
 | `/v2/categories` | [Catalog V3 Categories](/docs/rest-catalog/categories#get-all-categories) |
 | `/v2/customers` | [Customers V3](/docs/rest-management/customers) |
 | `/v3/hooks/events`| [Get Events](/docs/webhooks/webhooks/webhook-events#get-events) |
-|`/v2/options`| [Catalog V3 Product Modifiers](/docs/rest-catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-catalog/product-variant-options#get-all-product-variant-options). See the [Accessing product options](#accessing-product-options-with-V3) callout.  |
-|`/v2/option_sets`| [Catalog V3 Product Modifiers](/docs/rest-catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-catalog/product-variant-options#get-all-product-variant-options). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/docs/store-operations/catalog/migration). |
-|`/v2/pages`| [Pages V3](/docs/rest-content/pages) |
-|`/v2/products `| [Catalog V3 Products](/docs/rest-catalog/products#get-all-products) |
-|`/v2/redirects`| [Redirects V3](/docs/rest-management/redirects) |
-|`/v3/content/widgets/search` | [Widgets V3, Get all widgets](/docs/rest-content/widgets/widget#get-all-widgets) |
-
+| `/v2/options` | [Catalog V3 Product Modifiers](/docs/rest-catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-catalog/product-variant-options#get-all-product-variant-options). See the [Accessing product options](#accessing-product-options-with-V3) callout. |
+| `/v2/option_sets` | [Catalog V3 Product Modifiers](/docs/rest-catalog/product-modifiers#get-all-product-modifiers), [Catalog V3 Product Variant Options](/docs/rest-catalog/product-variant-options#get-all-product-variant-options). The `option_sets` endpoint is intentionally not available in the V3 Catalog API. For more information, see [V2 vs V3 Catalog APIs](/docs/store-operations/catalog/migration). |
+| `/v2/pages` | [Pages V3](/docs/rest-content/pages) |
+| `/v2/products ` | [Catalog V3 Products](/docs/rest-catalog/products#get-all-products) |
+| `/v2/redirects` | [Redirects V3](/docs/rest-management/redirects) |
 
 <Callout type="info">
   #### Accessing product options with V3
@@ -34,17 +33,18 @@ The following APIs and tools are deprecated. We discourage using these listed it
 
 We no longer support the following general product tools.
 
-|Deprecated tool|Support end date|
-|:--|:--|
-|[Google AMP](https://amp.dev/)|January 18th 2023|
-|[Google's Universal Analytics](https://support.google.com/analytics/answer/11583528?hl=en)|July 1st 2023|
+| Deprecated tool | Support end date |
+|:----------------|:-----------------|
+| [Google AMP](https://amp.dev/) | January 18th 2023 |
+| [Google's Universal Analytics](https://support.google.com/analytics/answer/11583528?hl=en) | July 1st 2023 |
 
 ## Sunsets
 
-We have removed the following endpoints.
+We have removed the following features, APIs, and endpoints.
 
-| Sunset endpoint / API | Replacement endpoint / API |
-|:----------------------|:---------------------------|
+| Sunset feature, endpoint, or API | Replacement |
+|:---------------------------------|:------------|
+| Legacy email templates | Handlebars email templates; [Overview](/docs/store-operations/emails), [API reference](/docs/rest-content/email-templates) |
 | `DELETE Collection` [Customers V2](/docs/rest-management/customers-v2) | [Customers V3, Delete customers](/docs/rest-management/customers-v2#delete-customers) |
 | `DELETE Collection` [Option Sets V2](/archive/store-operations/v2-catalog-products/v2-option-sets) | None; can still be deleted individually by ID. |
 | `DELETE Collection` [Products V2](/archive/store-operations/v2-catalog-products/v2-products) | [Products V3, Delete products](/docs/rest-catalog/products#delete-products) or individually, [Products V2, Delete a product](/archive/store-operations/v2-catalog-products/v2-products#delete-a-product) |
@@ -53,9 +53,9 @@ We have removed the following properties.
 
 | API | Sunset property | Replacement property |
 |:----|:----------------|:---------------------|
-[Channels V3](/docs/rest-management/channels#get-all-channels) |`is_enabled` | `status` |
+| [Channels V3](/docs/rest-management/channels#get-all-channels) |`is_enabled` | `status` |
 
 ## Related resources 
 
-* [Developer Changelog](/release-notes)
-* [Difference between V2 and V3 Catalog REST APIs](/docs/store-operations/catalog/migration)
+* [Release Notes](/release-notes)
+* [Migrating from Catalog V2 to V3 REST API](/docs/store-operations/catalog/migration)


### PR DESCRIPTION
# [DEVDOCS-5442]

## What changed?
Provide a bulleted list in the present tense
* deprecate legacy email templates

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping @bc-traciporter


[DEVDOCS-5442]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ