### PR TITLE
another update for DEVDOCS-5183

### DIFF
--- a/docs/api-docs/catalog/products-overview.mdx
+++ b/docs/api-docs/catalog/products-overview.mdx
@@ -473,7 +473,7 @@ To combine the variant option values into variants and build out SKUs use the fo
 `https://api.bigcommerce.com/stores/{{store_hash}}/v3/catalog/products/{{product_id}}/variants`
 
 <Callout type="info">
-  * If you want only some option combinations to have a variant, do not edit the variants in the control panel, as that will cause the store to autogenerate all missing variant SKUs.
+  * If you want only some option combinations to have a variant, do not edit the variant options in the control panel, as that will cause the store to autogenerate all missing variant SKUs.
   * You can create only one variant option at a time; individual variant options will contain an array of multiple values.
   * To use a variant array and create variants in the same call as the base product, use the [/catalog/product](/docs/rest-catalog/products#create-a-product) endpoint during product creation.
 </Callout>


### PR DESCRIPTION
# [DEVDOCS-5183]
{Ticket number or summary of work}

## What changed?
The SME saw the changes and realized that it should be "variant options", not "variants". 

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5183]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ