### PR TITLE
DEVDOCS-5561 [revise]: About Our APIs, headings

### DIFF
--- a/docs/api-docs/getting-started/about-our-api.mdx
+++ b/docs/api-docs/getting-started/about-our-api.mdx
@@ -198,18 +198,6 @@ The priorities with which you can process these methods are:
 * Accept header high-priority types (eg. `Accept: application/json`) extensions on the resource (e.g. `customers.json`).
 * Accept header low priority types (priorities less than 1, e.g. `Accept: application/json;q=0.9`)
 
-### Request Structure
-
-The body of a JSON request is an object containing a set of key-value pairs. A simple representation of a product object is:
-
-```http filename="Example JSON request body" showLineNumbers copy
-{
- "id": 5,
- "name": "iPod",
- "description": "A portable MP3 music player."
-}
-```
-
 ### Response structure
 
 Responses are structured similarly to requests. If a request returns a single object, then the response will contain a single object containing the fields for that resource.

--- a/docs/api-docs/getting-started/about-our-api.mdx
+++ b/docs/api-docs/getting-started/about-our-api.mdx
@@ -198,7 +198,7 @@ The priorities with which you can process these methods are:
 * Accept header high-priority types (eg. `Accept: application/json`) extensions on the resource (e.g. `customers.json`).
 * Accept header low priority types (priorities less than 1, e.g. `Accept: application/json;q=0.9`)
 
-### Response structure
+#### Response structure
 
 Responses are structured similarly to requests. If a request returns a single object, then the response will contain a single object containing the fields for that resource.
 


### PR DESCRIPTION
# [DEVDOCS-5561]

## What changed?
- Removed duplicate heading (Line 201 duplicates Line 147)
- Move "Response Structure" section to go under "Responses"

[DEVDOCS-5561]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ