### PR TITLE
DEVDOCS-5645: [update] add webhook requirements

### DIFF
--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -88,7 +88,7 @@ BigCommerce has the following webhook requirements:
 **Limitations**
 * The header value should not exceed 8 kilobytes (10 by 1 kilobytes is OK). 
 * The header name should not exceed 64 characters (bytes). 
-* The number of headers should not be larger than 64. 
+* The total number of headers shouldn't exceed 64. 
 
 
 ## Callback retry mechanism

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -85,7 +85,7 @@ BigCommerce doesn't recommend sending bodies or headers in response to webhooks.
 
 BigCommerce has the following webhook response requirements:
 
-**Limitations**
+If you send response headers, they must conform to the following limitations for the webhook delivery to be successfully acknowledged:
 * The header value should not exceed 8 kilobytes (10 by 1 kilobytes is OK). 
 * The header name should not exceed 64 characters (bytes). 
 * The total number of headers shouldn't exceed 64. 

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -86,7 +86,7 @@ BigCommerce does not save or log any response information except response codes 
 BigCommerce has the following webhook requirements:
 
 **Limitations**
-* The header should not exceed 8 kilobytes (10 by 1 kilobytes is OK). 
+* The header value should not exceed 8 kilobytes (10 by 1 kilobytes is OK). 
 * The header name should not exceed 64 characters (bytes). 
 * The number of headers should not be larger than 64. 
 

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -79,6 +79,18 @@ To acknowledge a callback has been received without issue, the destination serve
 
 Need to set up a quick webhook destination URL for testing? See [Tools for Debugging and Testing Webhooks](#tools).
 
+### Response requirements
+
+BigCommerce does not save or log any response information except response codes and does not recommend sending request bodies or headers in response to webhooks. 
+
+BigCommerce has the following webhook requirements:
+
+**Limitations**
+* The header should not exceed 8 kilobytes (10 by 1 kilobytes is OK). 
+* The header name should not exceed 64 characters (bytes). 
+* The number of headers should not be larger than 64. 
+
+
 ## Callback retry mechanism
 
 The webhooks service will do its best to deliver events to the destination callback URI. It is best practice for the application to respond to the callback before taking any other action that would slow its response. Doing otherwise triggers BigCommerce's callback retry mechanism.

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -81,7 +81,7 @@ Need to set up a quick webhook destination URL for testing? See [Tools for Debug
 
 ### Response requirements
 
-BigCommerce doesn't save or log any response information except for response codes and doesn't recommend sending request bodies or headers in response to webhooks. 
+BigCommerce doesn't recommend sending bodies or headers in response to webhooks. 
 
 BigCommerce has the following webhook requirements:
 

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -81,7 +81,7 @@ Need to set up a quick webhook destination URL for testing? See [Tools for Debug
 
 ### Response requirements
 
-BigCommerce doesn't recommend sending bodies or headers in response to webhooks. 
+BigCommerce doesn't recommend sending bodies or headers in response to webhooks. It may interfere with the webhook delivery acknowledgment. 
 
 BigCommerce has the following webhook response requirements:
 

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -83,7 +83,7 @@ Need to set up a quick webhook destination URL for testing? See [Tools for Debug
 
 BigCommerce doesn't recommend sending bodies or headers in response to webhooks. 
 
-BigCommerce has the following webhook requirements:
+BigCommerce has the following webhook response requirements:
 
 **Limitations**
 * The header value should not exceed 8 kilobytes (10 by 1 kilobytes is OK). 

--- a/docs/api-docs/webhooks/about-webhooks.mdx
+++ b/docs/api-docs/webhooks/about-webhooks.mdx
@@ -81,7 +81,7 @@ Need to set up a quick webhook destination URL for testing? See [Tools for Debug
 
 ### Response requirements
 
-BigCommerce does not save or log any response information except response codes and does not recommend sending request bodies or headers in response to webhooks. 
+BigCommerce doesn't save or log any response information except for response codes and doesn't recommend sending request bodies or headers in response to webhooks. 
 
 BigCommerce has the following webhook requirements:
 


### PR DESCRIPTION
# [DEVDOCS-5645]
{Ticket number or summary of work}

## What changed?
Added webhook requirements to the overview doc.

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5645]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ